### PR TITLE
Development

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -119,19 +119,29 @@ export default function AnalyticsPage() {
   const fetchAnalytics = async () => {
     try {
       setLoading(true)
+      
+      // Only attempt to fetch system analytics if user is admin
+      if (!hasPermission('analytics.system')) {
+        console.log('User does not have analytics.system permission, using mock data')
+        setAnalyticsData(null) // Will fall back to mock data
+        return
+      }
+      
       const data = await apiClient.getSystemAnalytics(timeRange)
       setAnalyticsData(data)
     } catch (error) {
       console.error("Failed to fetch analytics:", error)
-      toast.error("Failed to load analytics data")
+      // Gracefully fall back to mock data instead of showing error
+      console.log('Falling back to mock analytics data')
+      setAnalyticsData(null)
     } finally {
       setLoading(false)
     }
   }
 
   useEffect(() => {
-    fetchAnalytics()
-  }, [timeRange])
+    void fetchAnalytics()
+  }, [timeRange, hasPermission])
 
   // Mock stats with real-time capability
   const stats = {

--- a/server/migrations/create_document_chunks.sql
+++ b/server/migrations/create_document_chunks.sql
@@ -1,0 +1,42 @@
+-- Migration: Create document_chunks table for RAG context
+-- Purpose: Store markdown-aware chunks, embeddings (JSONB), and metadata
+
+CREATE TABLE IF NOT EXISTS document_chunks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  project_id UUID REFERENCES projects(id),
+  template_id UUID,
+  chunk_index INTEGER NOT NULL,
+  title TEXT,
+  content TEXT NOT NULL,
+  content_tokens INTEGER DEFAULT 0,
+  embeddings JSONB,
+  keywords TEXT[] DEFAULT '{}',
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_chunks_document ON document_chunks(document_id);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_project ON document_chunks(project_id);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_template ON document_chunks(template_id);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_created_at ON document_chunks(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_keywords ON document_chunks USING GIN (keywords);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_metadata ON document_chunks USING GIN (metadata);
+CREATE INDEX IF NOT EXISTS idx_document_chunks_tsv ON document_chunks USING GIN (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,'')));
+
+-- Trigger to maintain updated_at
+CREATE OR REPLACE FUNCTION set_document_chunks_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_document_chunks_updated_at ON document_chunks;
+CREATE TRIGGER trg_document_chunks_updated_at
+BEFORE UPDATE ON document_chunks
+FOR EACH ROW EXECUTE FUNCTION set_document_chunks_updated_at();
+
+

--- a/server/package.json
+++ b/server/package.json
@@ -12,11 +12,13 @@
     "lint": "eslint src --ext .ts",
     "migrate": "node -r dotenv/config scripts/run-migrations.js",
     "create-admin": "tsx scripts/create-admin-user.ts",
-    "fix-encryption": "tsx scripts/fix-encryption-migration.ts"
+    "fix-encryption": "tsx scripts/fix-encryption-migration.ts",
+    "seed:baselines": "tsx scripts/seed-baseline-data.ts",
+    "drift:recompute": "tsx scripts/recompute-drift.ts"
   },
   "dependencies": {
     "@adobe/pdfservices-node-sdk": "^4.1.0",
-    "@ai-sdk/mistral": "^2.0.19",
+    "@ai-sdk/mistral": "^2.0.20",
     "@ai-sdk/openai": "^2.0.56",
     "@google/generative-ai": "^0.24.1",
     "@types/jsdom": "^27.0.0",

--- a/server/scripts/recompute-drift.ts
+++ b/server/scripts/recompute-drift.ts
@@ -1,0 +1,64 @@
+/*
+ * Recompute Drift
+ * Compares latest project state to last baseline and inserts drift findings/root causes (simplified).
+ */
+import { pool } from '../src/database/connection'
+import { logger } from '../src/utils/logger'
+
+async function main(): Promise<void> {
+  const client = await pool.connect()
+  try {
+    logger.info('Recomputing baseline drift...')
+
+    const projects = await client.query(`SELECT id FROM projects`)
+    let inserted = 0
+    for (const p of projects.rows) {
+      const projectId: string = p.id
+      const baseline = await client.query(
+        `SELECT * FROM baselines WHERE project_id = $1 ORDER BY created_at DESC LIMIT 1`,
+        [projectId]
+      )
+      if (baseline.rows.length === 0) continue
+      const b = baseline.rows[0]
+
+      // Example: detect schedule variance via milestones
+      const ms = await client.query(
+        `SELECT COALESCE(AVG(variance_days),0) AS avg_var FROM milestones WHERE project_id = $1`,
+        [projectId]
+      )
+      const avgVar = Number(ms.rows[0]?.avg_var ?? 0)
+
+      if (Math.abs(avgVar) >= 1) {
+        await client.query(
+          `INSERT INTO baseline_drift_findings (
+             project_id, category, severity, status, detected_at, impact_area, variance_value, variance_units, description
+           ) VALUES ($1, $2, $3, $4, NOW(), $5, $6, $7, $8)`,
+          [
+            projectId,
+            'schedule',
+            avgVar > 5 ? 'high' : avgVar > 2 ? 'medium' : 'low',
+            'open',
+            'timeline',
+            Math.round(avgVar),
+            'days',
+            'Average milestone variance differs from baseline expectations.'
+          ]
+        )
+        inserted++
+      }
+    }
+
+    logger.info('Drift recompute completed', { inserted })
+  } catch (err: any) {
+    logger.error('Drift recompute failed', { error: err.message })
+    process.exitCode = 1
+  } finally {
+    client.release()
+  }
+}
+
+if (require.main === module) {
+  main().then(() => process.exit()).catch(() => process.exit(1))
+}
+
+

--- a/server/scripts/seed-baseline-data.ts
+++ b/server/scripts/seed-baseline-data.ts
@@ -1,3 +1,106 @@
+/*
+ * Seed Baseline Data
+ * Creates initial baseline snapshots per project if none exist yet.
+ */
+import { pool } from '../src/database/connection'
+import { logger } from '../src/utils/logger'
+
+async function main(): Promise<void> {
+  const client = await pool.connect()
+  try {
+    logger.info('Seeding baseline data...')
+
+    const projectsRes = await client.query(`
+      SELECT id, name
+      FROM projects
+      WHERE deleted_at IS NULL OR deleted_at IS NULL
+    `)
+
+    let created = 0
+    for (const p of projectsRes.rows) {
+      const projectId: string = p.id
+
+      // Skip if baseline already exists
+      const existing = await client.query(
+        'SELECT 1 FROM baselines WHERE project_id = $1 LIMIT 1',
+        [projectId]
+      )
+      if (existing.rows.length > 0) continue
+
+      // Derive simple snapshots from available data
+      const scopeSnapshot = await deriveScopeSnapshot(client, projectId)
+      const scheduleSnapshot = await deriveScheduleSnapshot(client, projectId)
+      const costSnapshot = await deriveCostSnapshot(client, projectId)
+
+      await client.query(
+        `
+        INSERT INTO baselines (
+          project_id,
+          baseline_type,
+          scope_snapshot,
+          schedule_snapshot,
+          cost_snapshot,
+          created_at
+        ) VALUES ($1, $2, $3::jsonb, $4::jsonb, $5::jsonb, NOW())
+        `,
+        [projectId, 'initial', JSON.stringify(scopeSnapshot), JSON.stringify(scheduleSnapshot), JSON.stringify(costSnapshot)]
+      )
+      created++
+    }
+
+    logger.info('Baseline seeding completed', { projects: projectsRes.rowCount, created })
+  } catch (err: any) {
+    logger.error('Baseline seeding failed', { error: err.message })
+    process.exitCode = 1
+  } finally {
+    client.release()
+  }
+}
+
+async function deriveScopeSnapshot(client: any, projectId: string): Promise<Record<string, unknown>> {
+  const requirements = await client.query(
+    `SELECT COUNT(*)::int AS total FROM requirements WHERE project_id = $1`,
+    [projectId]
+  )
+  const risks = await client.query(
+    `SELECT COUNT(*)::int AS total FROM risks WHERE project_id = $1`,
+    [projectId]
+  )
+  return {
+    requirement_count: requirements.rows[0]?.total ?? 0,
+    risk_count: risks.rows[0]?.total ?? 0
+  }
+}
+
+async function deriveScheduleSnapshot(client: any, projectId: string): Promise<Record<string, unknown>> {
+  const milestones = await client.query(
+    `SELECT COUNT(*)::int AS total, AVG(variance_days)::float AS avg_variance FROM milestones WHERE project_id = $1`,
+    [projectId]
+  )
+  return {
+    milestone_count: milestones.rows[0]?.total ?? 0,
+    avg_variance_days: milestones.rows[0]?.avg_variance ?? 0
+  }
+}
+
+async function deriveCostSnapshot(client: any, projectId: string): Promise<Record<string, unknown>> {
+  // If a proper cost table exists, prefer it; else derive simple proxies from documents metadata
+  const docs = await client.query(
+    `SELECT AVG(NULLIF(output_tokens,0))::float AS avg_tokens, COUNT(*)::int AS doc_count
+     FROM documents WHERE project_id = $1`,
+    [projectId]
+  )
+  return {
+    avg_output_tokens: docs.rows[0]?.avg_tokens ?? 0,
+    document_count: docs.rows[0]?.doc_count ?? 0
+  }
+}
+
+// Execute if invoked directly
+if (require.main === module) {
+  main().then(() => process.exit()).catch(() => process.exit(1))
+}
+
 /**
  * Seed Baseline Tables with Realistic Data
  * Tests that baseline_components, baseline_drift_detection, and baseline_compliance_reviews work

--- a/server/src/modules/contextGathering/analyzers/documentHistoryAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/documentHistoryAnalyzer.ts
@@ -558,6 +558,55 @@ export class DocumentHistoryAnalyzer {
     }
   }
 
+  // Baseline-aware gathers
+  private async gatherBaselineAlignmentChecks(templateId: string, projectId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT c.id, c.check_name, c.check_type, c.last_run_at, c.last_result
+        FROM document_consistency_checks c
+        WHERE c.target_document_id IN (
+          SELECT id FROM documents WHERE project_id = $1 AND title ILIKE '%' || $2 || '%'
+        )
+        ORDER BY c.last_run_at DESC NULLS LAST
+      `, [projectId, templateId])
+      return res.rows.map(r => ({
+        check_id: r.id,
+        check_name: r.check_name,
+        check_type: r.check_type,
+        last_run_at: r.last_run_at,
+        last_result: r.last_result || {},
+        metadata: {}
+      }))
+    } catch (e: any) {
+      logger.warn('gatherBaselineAlignmentChecks failed', { projectId, templateId, error: e.message })
+      return []
+    }
+  }
+
+  private async gatherDocumentDriftImpacts(templateId: string, projectId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT d.id, d.title, d.updated_at, dv.version_number, dv.status
+        FROM documents d
+        LEFT JOIN document_versions dv ON dv.document_id = d.id AND dv.status = 'published'
+        WHERE d.project_id = $1 AND d.title ILIKE '%' || $2 || '%'
+        ORDER BY d.updated_at DESC
+      `, [projectId, templateId])
+      return res.rows.map(r => ({
+        document_id: r.id,
+        title: r.title,
+        version: r.version_number || null,
+        status: r.status || 'unknown',
+        last_updated: r.updated_at,
+        impact_summary: 'Potential drift impact — requires validation',
+        metadata: {}
+      }))
+    } catch (e: any) {
+      logger.warn('gatherDocumentDriftImpacts failed', { projectId, templateId, error: e.message })
+      return []
+    }
+  }
+
   // Additional helper methods
   private calculateUsageFrequency(usageCount: number): string {
     if (usageCount >= 100) return 'high'

--- a/server/src/modules/contextGathering/analyzers/documentHistoryAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/documentHistoryAnalyzer.ts
@@ -5,9 +5,15 @@
 
 import { logger } from '@/utils/logger'
 import { pool } from '@/database/connection'
+import { ContextRetrievalService } from '@/modules/contextRetrieval/contextRetrievalService'
 import type { DocumentHistoryContextData } from '../types'
 
 export class DocumentHistoryAnalyzer {
+  private retrieval?: ContextRetrievalService
+
+  constructor(retrieval?: ContextRetrievalService) {
+    this.retrieval = retrieval
+  }
   async analyzeDocumentHistory(templateId: string, projectId: string, userId: string): Promise<DocumentHistoryContextData> {
     try {
       logger.debug('Analyzing document history context', {
@@ -61,6 +67,26 @@ export class DocumentHistoryAnalyzer {
           data_sources: ['document_history', 'usage_patterns', 'quality_metrics'],
           data_freshness: new Date(),
           analysis_confidence: 0.9
+        }
+      }
+
+      // Optional: enrich with RAG chunks when feature flag is enabled
+      if (process.env.ENABLE_RAG_CONTEXT_RETRIEVAL === 'true' && this.retrieval) {
+        try {
+          const query = 'recent risks issues milestones scope changes';
+          const topChunks = await this.retrieval.searchChunks({ projectId, query, topK: 10, templateId })
+          if (topChunks.length > 0) {
+            ;(documentHistoryContext as any).rag_context = topChunks.map(c => ({
+              chunk_id: c.id,
+              document_id: c.document_id,
+              title: c.title,
+              content_preview: c.content.substring(0, 400),
+              score: c.score
+            }))
+            documentHistoryContext.metadata.data_sources.push('rag_chunks')
+          }
+        } catch (e: any) {
+          logger.warn('RAG enrichment skipped', { error: e.message })
         }
       }
 

--- a/server/src/modules/contextGathering/analyzers/externalContextAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/externalContextAnalyzer.ts
@@ -5,8 +5,15 @@
 
 import { logger } from '@/utils/logger'
 import type { ExternalContextData, ContextSource } from '../types'
+import { ContextRetrievalService } from '@/modules/contextRetrieval/contextRetrievalService'
 
 export class ExternalContextAnalyzer {
+  private retrieval?: ContextRetrievalService
+
+  constructor(retrieval?: ContextRetrievalService) {
+    this.retrieval = retrieval
+  }
+
   async analyzeExternalContext(projectId: string, contextSources: ContextSource[]): Promise<ExternalContextData> {
     try {
       logger.debug('Analyzing external context', {
@@ -67,6 +74,36 @@ export class ExternalContextAnalyzer {
           sources_analyzed: enabledSources.length,
           data_freshness: new Date(),
           analysis_confidence: 0.8
+        }
+      }
+
+      // Optional RAG enrichment: fetch top external policy/standard chunks
+      if (process.env.ENABLE_RAG_CONTEXT_RETRIEVAL === 'true' && this.retrieval) {
+        try {
+          const queries = [
+            'regulatory requirements relevant to current project',
+            'industry standards and controls mapping',
+            'external policy constraints and guidance'
+          ]
+          const ragChunks = [] as Array<{ chunk_id: string; document_id: string; title: string | null; score: number; content_preview: string }>
+          for (const q of queries) {
+            const found = await this.retrieval.searchChunks({ projectId, query: q, topK: 10 })
+            for (const c of found) {
+              ragChunks.push({
+                chunk_id: c.id,
+                document_id: c.document_id,
+                title: c.title,
+                score: c.score,
+                content_preview: c.content.substring(0, 400)
+              })
+            }
+          }
+          if (ragChunks.length > 0) {
+            ;(externalContext as any).rag_external_context = ragChunks
+            externalContext.metadata.analysis_confidence = Math.min(1, externalContext.metadata.analysis_confidence + 0.05)
+          }
+        } catch (e: any) {
+          logger.warn('RAG external context enrichment skipped', { error: e.message })
         }
       }
 

--- a/server/src/modules/contextGathering/analyzers/projectContextAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/projectContextAnalyzer.ts
@@ -5,9 +5,16 @@
 
 import { logger } from '@/utils/logger'
 import { pool } from '@/database/connection'
+import { ContextRetrievalService } from '@/modules/contextRetrieval/contextRetrievalService'
 import type { ProjectContextData } from '../types'
 
 export class ProjectContextAnalyzer {
+  private retrieval?: ContextRetrievalService
+
+  constructor(retrieval?: ContextRetrievalService) {
+    this.retrieval = retrieval
+  }
+
   async analyzeProjectContext(projectId: string): Promise<ProjectContextData> {
     try {
       logger.debug('Analyzing project context', { projectId })
@@ -26,6 +33,11 @@ export class ProjectContextAnalyzer {
 
       // Analyze project performance
       const performanceMetrics = await this.analyzeProjectPerformance(projectId)
+
+      // Baseline & drift detection
+      const baselineSnapshots = await this.gatherBaselineSnapshots(projectId)
+      const baselineDriftFindings = await this.gatherBaselineDriftFindings(projectId)
+      const driftRootCauses = await this.gatherDriftRootCauses(projectId)
 
       // Gather lessons learned and best practices
       const lessonsLearned = await this.gatherLessonsLearned(projectId)
@@ -61,12 +73,46 @@ export class ProjectContextAnalyzer {
         lessons_learned: lessonsLearned,
         best_practices: bestPractices,
         performance_metrics: performanceMetrics,
+        baseline_snapshots: baselineSnapshots,
+        baseline_drift_findings: baselineDriftFindings,
+        drift_root_causes: driftRootCauses,
         metadata: {
           analysis_timestamp: new Date(),
           analysis_duration: Date.now() - startTime,
-          data_sources: ['project_database', 'stakeholder_database', 'requirement_database'],
+          data_sources: ['project_database', 'stakeholder_database', 'requirement_database', 'baseline', 'drift_detection'],
           data_freshness: new Date(),
           analysis_confidence: 0.9
+        }
+      }
+
+      // Optional RAG enrichment for baseline/drift context
+      if (process.env.ENABLE_RAG_CONTEXT_RETRIEVAL === 'true' && this.retrieval) {
+        try {
+          const queries = [
+            'baseline variance causes and mitigations',
+            'schedule slippage justifications and impacts',
+            'scope change rationales and decisions',
+            'budget overrun corrective actions'
+          ]
+          const ragChunks = [] as Array<{ chunk_id: string; document_id: string; title: string | null; score: number; content_preview: string }>
+          for (const q of queries) {
+            const found = await this.retrieval.searchChunks({ projectId, query: q, topK: 10 })
+            for (const c of found) {
+              ragChunks.push({
+                chunk_id: c.id,
+                document_id: c.document_id,
+                title: c.title,
+                score: c.score,
+                content_preview: c.content.substring(0, 400)
+              })
+            }
+          }
+          if (ragChunks.length > 0) {
+            ;(projectContext as any).rag_baseline_context = ragChunks
+            projectContext.metadata.data_sources.push('rag_baseline_chunks')
+          }
+        } catch (e: any) {
+          logger.warn('RAG baseline context enrichment skipped', { error: e.message })
         }
       }
 
@@ -86,6 +132,87 @@ export class ProjectContextAnalyzer {
         error: error.message
       })
       throw error
+    }
+  }
+
+  private async gatherBaselineSnapshots(projectId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT b.id, b.project_id, b.baseline_type, b.created_at, b.created_by,
+               b.scope_snapshot, b.schedule_snapshot, b.cost_snapshot
+        FROM baselines b
+        WHERE b.project_id = $1
+        ORDER BY b.created_at DESC
+        LIMIT 10
+      `, [projectId])
+      return res.rows.map(r => ({
+        baseline_id: r.id,
+        baseline_type: r.baseline_type || 'initial',
+        created_at: r.created_at,
+        created_by: r.created_by,
+        scope_snapshot: r.scope_snapshot || {},
+        schedule_snapshot: r.schedule_snapshot || {},
+        cost_snapshot: r.cost_snapshot || {},
+        metadata: {}
+      }))
+    } catch (e: any) {
+      logger.warn('gatherBaselineSnapshots failed', { projectId, error: e.message })
+      return []
+    }
+  }
+
+  private async gatherBaselineDriftFindings(projectId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT d.id, d.project_id, d.category, d.severity, d.status, d.detected_at, d.resolved_at,
+               d.impact_area, d.variance_value, d.variance_units, d.description
+        FROM baseline_drift_findings d
+        WHERE d.project_id = $1
+        ORDER BY d.detected_at DESC
+        LIMIT 50
+      `, [projectId])
+      return res.rows.map(r => ({
+        drift_id: r.id,
+        category: r.category || 'schedule',
+        severity: r.severity || 'medium',
+        status: r.status || 'open',
+        detected_at: r.detected_at,
+        resolved_at: r.resolved_at,
+        impact_area: r.impact_area || 'unknown',
+        variance_value: r.variance_value,
+        variance_units: r.variance_units || '%',
+        description: r.description || '',
+        metadata: {}
+      }))
+    } catch (e: any) {
+      logger.warn('gatherBaselineDriftFindings failed', { projectId, error: e.message })
+      return []
+    }
+  }
+
+  private async gatherDriftRootCauses(projectId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT r.id, r.project_id, r.cause_category, r.cause_detail, r.recurring,
+               r.proposed_actions, r.owner, r.last_updated
+        FROM drift_root_causes r
+        WHERE r.project_id = $1
+        ORDER BY r.last_updated DESC
+        LIMIT 50
+      `, [projectId])
+      return res.rows.map(r => ({
+        root_cause_id: r.id,
+        cause_category: r.cause_category || 'unknown',
+        cause_detail: r.cause_detail || '',
+        recurring: !!r.recurring,
+        proposed_actions: r.proposed_actions || [],
+        owner: r.owner || 'unassigned',
+        last_updated: r.last_updated,
+        metadata: {}
+      }))
+    } catch (e: any) {
+      logger.warn('gatherDriftRootCauses failed', { projectId, error: e.message })
+      return []
     }
   }
 

--- a/server/src/modules/contextGathering/analyzers/templateContextAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/templateContextAnalyzer.ts
@@ -5,9 +5,16 @@
 
 import { logger } from '@/utils/logger'
 import { pool } from '@/database/connection'
+import { ContextRetrievalService } from '@/modules/contextRetrieval/contextRetrievalService'
 import type { TemplateContextData } from '../types'
 
 export class TemplateContextAnalyzer {
+  private retrieval?: ContextRetrievalService
+
+  constructor(retrieval?: ContextRetrievalService) {
+    this.retrieval = retrieval
+  }
+
   async analyzeTemplateContext(templateId: string): Promise<TemplateContextData> {
     try {
       logger.debug('Analyzing template context', { templateId })
@@ -70,6 +77,38 @@ export class TemplateContextAnalyzer {
           data_sources: ['template_database', 'usage_metrics', 'feedback_data'],
           data_freshness: new Date(),
           analysis_confidence: 0.9
+        }
+      }
+
+      // Optional RAG enrichment for template-targeted context
+      if (process.env.ENABLE_RAG_CONTEXT_RETRIEVAL === 'true' && this.retrieval) {
+        try {
+          const framework = templateData.framework || ''
+          const queries = [
+            `validation rules for ${framework} sections`,
+            'examples of high-quality outputs for this template',
+            'common pitfalls and corrections for this template type',
+            'variable resolution examples and guidance'
+          ]
+          const ragChunks = [] as Array<{ chunk_id: string; document_id: string; title: string | null; score: number; content_preview: string }>
+          for (const q of queries) {
+            const found = await this.retrieval.searchChunks({ projectId: templateMetadata?.project_id || '', query: q, topK: 8 })
+            for (const c of found) {
+              ragChunks.push({
+                chunk_id: c.id,
+                document_id: c.document_id,
+                title: c.title,
+                score: c.score,
+                content_preview: c.content.substring(0, 400)
+              })
+            }
+          }
+          if (ragChunks.length > 0) {
+            ;(templateContext as any).rag_template_context = ragChunks
+            templateContext.metadata.data_sources.push('rag_template_chunks')
+          }
+        } catch (e: any) {
+          logger.warn('RAG template context enrichment skipped', { error: e.message })
         }
       }
 

--- a/server/src/modules/contextGathering/analyzers/userProfileAnalyzer.ts
+++ b/server/src/modules/contextGathering/analyzers/userProfileAnalyzer.ts
@@ -5,9 +5,15 @@
 
 import { logger } from '@/utils/logger'
 import { pool } from '@/database/connection'
+import { ContextRetrievalService } from '@/modules/contextRetrieval/contextRetrievalService'
 import type { UserProfileContextData } from '../types'
 
 export class UserProfileAnalyzer {
+  private retrieval?: ContextRetrievalService
+
+  constructor(retrieval?: ContextRetrievalService) {
+    this.retrieval = retrieval
+  }
   async analyzeUserProfile(userId: string): Promise<UserProfileContextData> {
     try {
       logger.debug('Analyzing user profile context', { userId })
@@ -35,6 +41,15 @@ export class UserProfileAnalyzer {
         user_writing_style: userWritingStyle,
         user_domain_knowledge: userDomainKnowledge,
         user_collaboration_preferences: userCollaborationPreferences,
+        user_locale_preferences: await this.gatherUserLocalePreferences(userId),
+        user_notification_preferences: await this.gatherUserNotificationPreferences(userId),
+        user_accessibility_preferences: await this.gatherUserAccessibilityPreferences(userId),
+        user_device_profile: await this.gatherUserDeviceProfile(userId),
+        user_security_posture: await this.gatherUserSecurityPosture(userId),
+        user_time_preferences: await this.gatherUserTimePreferences(userId),
+        user_project_affiliations: await this.gatherUserProjectAffiliations(userId),
+        user_recent_successes: await this.gatherUserRecentSuccesses(userId),
+        user_known_gaps: await this.gatherUserKnownGaps(userId),
         user_performance_history: performanceHistory,
         user_learning_preferences: await this.gatherUserLearningPreferences(userId),
         user_access_patterns: accessPatterns,
@@ -50,9 +65,40 @@ export class UserProfileAnalyzer {
         metadata: {
           analysis_timestamp: new Date(),
           analysis_duration: Date.now() - startTime,
-          data_sources: ['user_profile', 'user_preferences', 'user_expertise'],
+          data_sources: ['user_profile', 'user_preferences', 'user_expertise', 'user_locale', 'user_notifications', 'user_accessibility', 'user_devices', 'user_security', 'user_time', 'user_projects'],
           data_freshness: new Date(),
           analysis_confidence: 0.9
+        }
+      }
+
+      // Optional RAG enrichment of user-authored semantic context (notes, prior docs)
+      if (process.env.ENABLE_RAG_CONTEXT_RETRIEVAL === 'true' && this.retrieval) {
+        try {
+          const queries = [
+            'writing tone and style preferences',
+            'recent successful documents and reasons',
+            'domain-specific playbooks and checklists',
+            'common pitfalls and lessons learned'
+          ]
+          const ragChunks = [] as Array<{ chunk_id: string; document_id: string; title: string | null; score: number; content_preview: string }>
+          for (const q of queries) {
+            const found = await this.retrieval.searchChunks({ projectId: userProfile?.project_id || '', query: `${q} by user:${userId}`, topK: 5 })
+            for (const c of found) {
+              ragChunks.push({
+                chunk_id: c.id,
+                document_id: c.document_id,
+                title: c.title,
+                score: c.score,
+                content_preview: c.content.substring(0, 400)
+              })
+            }
+          }
+          if (ragChunks.length > 0) {
+            ;(userProfileContext as any).rag_user_context = ragChunks
+            userProfileContext.metadata.data_sources.push('rag_user_chunks')
+          }
+        } catch (e: any) {
+          logger.warn('RAG user context enrichment skipped', { error: e.message })
         }
       }
 
@@ -374,6 +420,137 @@ export class UserProfileAnalyzer {
       preferred_examples: true,
       preferred_exercises: true,
       metadata: {}
+    }
+  }
+
+  private async gatherUserLocalePreferences(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_locale_preferences WHERE user_id = $1', [userId])
+      if (res.rows.length === 0) return { locale: 'en-US', timezone: 'UTC', date_format: 'YYYY-MM-DD', number_format: '1,234.56', metadata: {} }
+      const r = res.rows[0]
+      return {
+        locale: r.locale || 'en-US',
+        timezone: r.timezone || 'UTC',
+        date_format: r.date_format || 'YYYY-MM-DD',
+        number_format: r.number_format || '1,234.56',
+        metadata: {}
+      }
+    } catch (e: any) {
+      logger.warn('gatherUserLocalePreferences failed', { userId, error: e.message })
+      return { locale: 'en-US', timezone: 'UTC', date_format: 'YYYY-MM-DD', number_format: '1,234.56', metadata: {} }
+    }
+  }
+
+  private async gatherUserNotificationPreferences(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_notification_preferences WHERE user_id = $1', [userId])
+      if (res.rows.length === 0) return { channels: ['email'], frequency: 'daily', quiet_hours: { start: '21:00', end: '07:00' }, metadata: {} }
+      const r = res.rows[0]
+      return {
+        channels: r.channels || ['email'],
+        frequency: r.frequency || 'daily',
+        quiet_hours: r.quiet_hours || { start: '21:00', end: '07:00' },
+        metadata: {}
+      }
+    } catch (e: any) {
+      logger.warn('gatherUserNotificationPreferences failed', { userId, error: e.message })
+      return { channels: ['email'], frequency: 'daily', quiet_hours: { start: '21:00', end: '07:00' }, metadata: {} }
+    }
+  }
+
+  private async gatherUserAccessibilityPreferences(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_accessibility_preferences WHERE user_id = $1', [userId])
+      if (res.rows.length === 0) return { font_size: 'medium', contrast: 'standard', reduce_motion: false, metadata: {} }
+      const r = res.rows[0]
+      return {
+        font_size: r.font_size || 'medium',
+        contrast: r.contrast || 'standard',
+        reduce_motion: !!r.reduce_motion,
+        metadata: {}
+      }
+    } catch (e: any) {
+      logger.warn('gatherUserAccessibilityPreferences failed', { userId, error: e.message })
+      return { font_size: 'medium', contrast: 'standard', reduce_motion: false, metadata: {} }
+    }
+  }
+
+  private async gatherUserDeviceProfile(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_devices WHERE user_id = $1 ORDER BY last_seen DESC LIMIT 1', [userId])
+      if (res.rows.length === 0) return { device_type: 'web', os: 'unknown', browser: 'unknown', last_seen: null, metadata: {} }
+      const r = res.rows[0]
+      return { device_type: r.device_type || 'web', os: r.os || 'unknown', browser: r.browser || 'unknown', last_seen: r.last_seen, metadata: {} }
+    } catch (e: any) {
+      logger.warn('gatherUserDeviceProfile failed', { userId, error: e.message })
+      return { device_type: 'web', os: 'unknown', browser: 'unknown', last_seen: null, metadata: {} }
+    }
+  }
+
+  private async gatherUserSecurityPosture(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_security_settings WHERE user_id = $1', [userId])
+      if (res.rows.length === 0) return { mfa_enabled: false, last_password_change_days: null, allowed_ip_ranges: [], metadata: {} }
+      const r = res.rows[0]
+      return { mfa_enabled: !!r.mfa_enabled, last_password_change_days: r.last_password_change_days, allowed_ip_ranges: r.allowed_ip_ranges || [], metadata: {} }
+    } catch (e: any) {
+      logger.warn('gatherUserSecurityPosture failed', { userId, error: e.message })
+      return { mfa_enabled: false, last_password_change_days: null, allowed_ip_ranges: [], metadata: {} }
+    }
+  }
+
+  private async gatherUserTimePreferences(userId: string): Promise<any> {
+    try {
+      const res = await pool.query('SELECT * FROM user_time_preferences WHERE user_id = $1', [userId])
+      if (res.rows.length === 0) return { working_hours: { start: '09:00', end: '17:00' }, meeting_preferences: ['morning'], metadata: {} }
+      const r = res.rows[0]
+      return { working_hours: r.working_hours || { start: '09:00', end: '17:00' }, meeting_preferences: r.meeting_preferences || ['morning'], metadata: {} }
+    } catch (e: any) {
+      logger.warn('gatherUserTimePreferences failed', { userId, error: e.message })
+      return { working_hours: { start: '09:00', end: '17:00' }, meeting_preferences: ['morning'], metadata: {} }
+    }
+  }
+
+  private async gatherUserProjectAffiliations(userId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT p.id, p.name, up.role
+        FROM user_projects up
+        JOIN projects p ON p.id = up.project_id
+        WHERE up.user_id = $1
+        ORDER BY p.created_at DESC
+      `, [userId])
+      return res.rows.map(r => ({ project_id: r.id, project_name: r.name, role: r.role || 'member' }))
+    } catch (e: any) {
+      logger.warn('gatherUserProjectAffiliations failed', { userId, error: e.message })
+      return []
+    }
+  }
+
+  private async gatherUserRecentSuccesses(userId: string): Promise<any[]> {
+    try {
+      const res = await pool.query(`
+        SELECT id, title, quality_score, created_at
+        FROM document_history
+        WHERE created_by = $1 AND quality_score >= 0.85
+        ORDER BY created_at DESC
+        LIMIT 10
+      `, [userId])
+    
+      return res.rows.map(r => ({ document_id: r.id, title: r.title, quality_score: r.quality_score, created_at: r.created_at }))
+    } catch (e: any) {
+      logger.warn('gatherUserRecentSuccesses failed', { userId, error: e.message })
+      return []
+    }
+  }
+
+  private async gatherUserKnownGaps(userId: string): Promise<any[]> {
+    try {
+      const res = await pool.query('SELECT * FROM user_known_gaps WHERE user_id = $1 ORDER BY created_at DESC LIMIT 20', [userId])
+      return res.rows.map(r => ({ gap_id: r.id, domain: r.domain, description: r.description, priority: r.priority || 'medium', created_at: r.created_at }))
+    } catch (e: any) {
+      logger.warn('gatherUserKnownGaps failed', { userId, error: e.message })
+      return []
     }
   }
 

--- a/server/src/modules/contextRetrieval/contextRetrievalService.ts
+++ b/server/src/modules/contextRetrieval/contextRetrievalService.ts
@@ -40,6 +40,56 @@ export class ContextRetrievalService implements IContextRetrievalService {
     this.relevanceScoringEngine = new RelevanceScoringEngine(relevanceScoringConfig)
   }
 
+  /**
+   * Search precomputed document chunks (RAG) using hybrid strategy
+   */
+  async searchChunks(params: {
+    projectId: string
+    query: string
+    topK?: number
+    templateId?: string
+  }): Promise<Array<{ id: string; document_id: string; title: string | null; content: string; score: number }>> {
+    const { projectId, query, topK = 20, templateId } = params
+    try {
+      // Keyword pre-filter using full text search
+      const keywordRes = await pool.query(
+        `
+        SELECT id, document_id, title, content,
+               ts_rank(to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,'')), plainto_tsquery('english', $1)) AS kw_rank
+        FROM document_chunks
+        WHERE project_id = $2
+          AND to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,'')) @@ plainto_tsquery('english', $1)
+          ${templateId ? 'AND template_id = $3' : ''}
+        ORDER BY kw_rank DESC
+        LIMIT $${templateId ? 4 : 3}
+        `,
+        templateId ? [query, projectId, templateId, Math.max(topK * 3, 50)] : [query, projectId, Math.max(topK * 3, 50)]
+      )
+
+      const preCandidates = keywordRes.rows as Array<{ id: string; document_id: string; title: string | null; content: string; kw_rank: number }>
+
+      // If no candidates, return empty
+      if (preCandidates.length === 0) return []
+
+      // Semantic rerank: compute similarity between query and candidate content
+      const semanticScored: Array<{ id: string; document_id: string; title: string | null; content: string; score: number }> = []
+      for (const c of preCandidates) {
+        const similarity = await this.relevanceScoringEngine.calculateSemanticRelevance(query, c.content)
+        // Simple hybrid score: 0.6 semantic + 0.4 normalized kw
+        const kw = Number(c.kw_rank) || 0
+        const kwNorm = isFinite(kw) ? Math.min(1, kw / (preCandidates[0]?.kw_rank || 1)) : 0
+        const score = 0.6 * similarity + 0.4 * kwNorm
+        semanticScored.push({ id: c.id, document_id: c.document_id, title: c.title, content: c.content, score })
+      }
+
+      // Sort and topK
+      return semanticScored.sort((a, b) => b.score - a.score).slice(0, topK)
+    } catch (error: any) {
+      logger.error('searchChunks failed', { error: error.message })
+      return []
+    }
+  }
+
   async retrieveContext(request: ContextRetrievalRequest): Promise<ContextRetrievalResponse> {
     const startTime = Date.now()
     

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -45,10 +45,19 @@ router.post("/generate",
 
       // Check if provider exists and is active
       log.info('🔍 [BACKEND-3/10] Checking if provider exists and is active...')
-      const providerCheck = await pool.query(
-        "SELECT id, name, provider_type FROM ai_providers WHERE name = $1 AND is_active = true",
-        [provider]
-      )
+      let providerCheck
+      try {
+        providerCheck = await pool.query(
+          "SELECT id, name, provider_type FROM ai_providers WHERE name = $1 AND is_active = true",
+          [provider]
+        )
+      } catch (dbError: unknown) {
+        log.error('❌ [DATABASE] Failed to query providers:', dbError)
+        return res.status(500).json({ 
+          error: "Database connection error",
+          details: dbError instanceof Error ? dbError.message : 'Unknown database error'
+        })
+      }
 
       if (providerCheck.rows.length === 0) {
         log.error('❌ [BACKEND] Provider not found or inactive:', provider)
@@ -65,7 +74,13 @@ router.post("/generate",
       
       // CRITICAL FIX: Prevent duplicate submissions within 10 seconds
       const dedupeKey = `ai-gen:${req.user?.id}:${template_id}:${req.body.project_id}`
-      const recentJobId = await cache.get(dedupeKey)
+      let recentJobId
+      try {
+        recentJobId = await cache.get(dedupeKey)
+      } catch (cacheError: unknown) {
+        log.warn('⚠️ [CACHE] Redis unavailable for deduplication, continuing:', cacheError)
+        // Continue without deduplication if Redis is down
+      }
       
       if (recentJobId) {
         log.warn('⚠️ [DEDUPE] Duplicate request detected, returning existing job ID:', recentJobId)
@@ -82,7 +97,12 @@ router.post("/generate",
       log.info('🆔 [BACKEND-7/10] Created job ID:', jobId)
       
       // Store job ID for deduplication (10 second window)
-      await cache.set(dedupeKey, jobId, 10)
+      try {
+        await cache.set(dedupeKey, jobId, 10)
+      } catch (cacheError: unknown) {
+        log.warn('⚠️ [CACHE] Failed to set deduplication key, continuing:', cacheError)
+        // Continue without caching if Redis is down
+      }
       
       // Add job to queue
       const jobData = {
@@ -103,8 +123,16 @@ router.post("/generate",
         custom_context: req.body.custom_context,
       }
       
-      await queueService.addJob('ai-generate', jobData)
-      log.info('✅ [BACKEND-8/10] Job added to queue')
+      try {
+        await queueService.addJob('ai-generate', jobData)
+        log.info('✅ [BACKEND-8/10] Job added to queue')
+      } catch (queueError: unknown) {
+        log.error('❌ [QUEUE] Failed to add job to queue:', queueError)
+        return res.status(500).json({ 
+          error: "Failed to queue document generation",
+          details: queueError instanceof Error ? queueError.message : 'Queue service unavailable'
+        })
+      }
       
       // Return immediately with job ID
       log.info('🎉 [BACKEND-9/10] Returning job ID to client')
@@ -296,15 +324,25 @@ router.post("/generate",
       })
       
       log.info('✅ [BACKEND] AI generation COMPLETE! Document ready.')
-    } catch (error) {
+    } catch (error: unknown) {
       log.error("❌ [BACKEND-ERROR] AI generation failed:", error)
       log.error("❌ [BACKEND-ERROR] Error details:", {
         message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined
+        stack: error instanceof Error ? error.stack : undefined,
+        type: error instanceof Error ? error.constructor.name : typeof error
       })
+      
+      // Provide detailed error information for debugging
+      const errorMessage = error instanceof Error ? error.message : String(error)
+      const isRedisError = errorMessage.includes('Redis') || errorMessage.includes('ECONNREFUSED')
+      const isDatabaseError = errorMessage.includes('database') || errorMessage.includes('postgres')
+      
       res.status(500).json({ 
         error: "AI generation failed",
-        details: error instanceof Error ? error.message : "Unknown error"
+        details: errorMessage,
+        hint: isRedisError ? 'Redis connection unavailable - check REDIS_URL environment variable' 
+              : isDatabaseError ? 'Database connection error - check DATABASE_URL' 
+              : 'Check backend logs for details'
       })
     }
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -46,7 +46,15 @@ import contextAiRoutes from "./routes/context-ai"
 // import quantumStabilityRoutes from "./routes/quantum-stability"
 // import speedOfLightRoutes from "./routes/speed-of-light"
 // import monteCarloProofRoutes from "./routes/monte-carlo-proof"
-import aiProviderTestingRoutes from "./routes/ai-provider-testing"
+// Optional: AI Provider Testing routes (skip if module absent)
+let aiProviderTestingRoutes: any | null = null
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const m = require("./routes/ai-provider-testing")
+  aiProviderTestingRoutes = m?.default || m
+} catch (e) {
+  console.warn("⚠️  Skipping ai-provider-testing routes:", (e as any)?.message || e)
+}
 // import azureAIFoundryRoutes from "./routes/azure-ai-foundry"
 import processFlowRoutes from "./routes/process-flow"
 import aiModelsRoutes from "./routes/ai-models"
@@ -200,7 +208,9 @@ app.use("/api/context-ai", contextAiRoutes)
 // app.use("/api/quantum-stability", quantumStabilityRoutes)
 // app.use("/api/speed-of-light", speedOfLightRoutes)
 // app.use("/api/monte-carlo-proof", monteCarloProofRoutes)
-app.use("/api/ai-provider-testing", aiProviderTestingRoutes)
+if (aiProviderTestingRoutes) {
+  app.use("/api/ai-provider-testing", aiProviderTestingRoutes)
+}
 // app.use("/api/azure-ai-foundry", azureAIFoundryRoutes)
 app.use("/api/process-flow", processFlowRoutes)
 app.use("/api/ai-models", aiModelsRoutes)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce RAG chunk storage and hybrid search, enrich context analyzers with RAG, harden AI generation API with dedupe/error handling, add baseline drift/seed scripts, and make analytics page permission-aware with mock fallback.
> 
> - **Backend**
>   - **RAG Infrastructure**:
>     - Add `server/migrations/create_document_chunks.sql` with `document_chunks` table, GIN/tsvector indexes, and `updated_at` trigger.
>     - Implement hybrid chunk search `searchChunks` in `ContextRetrievalService` (keyword prefilter + semantic rerank).
>   - **Context Gathering**:
>     - Inject optional `ContextRetrievalService` into analyzers and append RAG results (`rag_context`, `rag_external_context`, `rag_baseline_context`, `rag_template_context`, `rag_user_context`).
>     - Project analyzer: add baseline snapshots, drift findings, and root causes retrieval.
>   - **AI API Robustness (`server/src/routes/ai.ts`)**:
>     - Wrap provider lookup, Redis dedupe, and queue enqueue in try/catch with clear error responses and hints.
>     - Prevent duplicate `/generate` submissions via Redis; improve logging and response typing.
>     - Add models/provider endpoints enhancements and toggle response messaging.
>   - **Scripts & Config**:
>     - Add `scripts/seed-baseline-data.ts` and `scripts/recompute-drift.ts`; expose via `package.json` (`seed:baselines`, `drift:recompute`).
>     - Bump `@ai-sdk/mistral` to `^2.0.20`.
>   - **Server**:
>     - Conditionally load `ai-provider-testing` routes; enable analytics middleware; minor WebSocket join auth handling.
> - **Frontend**
>   - **Analytics Page (`app/analytics/page.tsx`)**:
>     - Gate system analytics behind `hasPermission('analytics.system')`; on failure or no permission, fall back to mock data without toasts.
>     - Adjust effect deps and call pattern (`void fetchAnalytics()`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d23fcdaa4584f7b5cf83f7483c58c370a3178855. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->