### PR TITLE
fix: Fix document conversion worker initialization and MaxListeners w…

### DIFF
--- a/server/src/database/connection.ts
+++ b/server/src/database/connection.ts
@@ -155,6 +155,10 @@ export async function connectDatabase() {
     
     const testPool = new Pool(poolConfig)
     
+    // Increase max listeners to prevent MaxListenersExceededWarning
+    // This can happen when multiple connection attempts are made
+    testPool.setMaxListeners(20)
+    
     try {
       const client = await Promise.race([
         testPool.connect(),
@@ -187,6 +191,9 @@ export async function connectDatabase() {
     
     // Create a new pool for this connection method
     const testPool = createPool(method.host)
+    
+    // Increase max listeners to prevent MaxListenersExceededWarning
+    testPool.setMaxListeners(20)
     
     for (let attempt = 1; attempt <= maxRetriesPerMethod; attempt++) {
       try {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -469,11 +469,11 @@ async function startServer() {
     }
 
     // Initialize document conversion queue worker
+    // Note: The worker is automatically initialized when the module is imported
     try {
       console.log("📄 Initializing document conversion worker...")
-      const { setupDocumentConversionWorker } = require('./jobs/documentConversionJob')
-      setupDocumentConversionWorker(pool)
-      console.log("✅ Document conversion worker initialized (5 concurrent workers)")
+      require('./jobs/documentConversionJob') // Import to trigger worker initialization
+      console.log("✅ Document conversion worker initialized")
     } catch (workerError) {
       console.warn(
         "⚠️  Document conversion worker initialization failed:",


### PR DESCRIPTION
…arning

- Fix setupDocumentConversionWorker error: Worker auto-initializes on import
- Remove non-existent function call, just require the module
- Increase max listeners on database pool to prevent MaxListenersExceededWarning
- Fixes: 'setupDocumentConversionWorker is not a function' error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize document conversion worker by importing its module and raise Postgres pool max listeners to avoid MaxListenersExceededWarning.
> 
> - **Server**:
>   - Initialize document conversion worker by importing `server/src/jobs/documentConversionJob` (remove `setupDocumentConversionWorker` call).
>   - Update logs to reflect auto-initialization.
> - **Database**:
>   - After creating test pools (`DATABASE_URL` path and fallback `createPool`), call `setMaxListeners(20)` to prevent `MaxListenersExceededWarning`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68882d49738ba660f8324ec35dd39757188d381c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->