### PR TITLE
feat: lessons learned integration  add minimal Lessons tab, API route, tests and dev seed

### DIFF
--- a/__tests__/components/LessonsTab.test.tsx
+++ b/__tests__/components/LessonsTab.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+
+jest.mock('@/lib/api', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}))
+
+import LessonsTab from '@/app/projects/[id]/components/LessonsTab'
+import { apiClient } from '@/lib/api'
+
+describe('LessonsTab', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('renders lessons returned by API and allows applying one', async () => {
+    const sample = [
+      {
+        knowledge_entry_id: 'k-1',
+        title: 'Lesson: involve legal earlier',
+        reasoning: 'Legal review delayed the project by several weeks',
+        entry_type: 'lesson_learned',
+        source_project_name: 'Alpha Project',
+      },
+    ]
+
+    ;(apiClient.get as jest.Mock).mockResolvedValue({ success: true, data: sample })
+    ;(apiClient.post as jest.Mock).mockResolvedValue({ success: true, data: {} })
+
+    render(<LessonsTab projectId="proj-1" />)
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalled())
+
+    expect(screen.getByText('Lessons learned')).toBeInTheDocument()
+    expect(screen.getByText('Lesson: involve legal earlier')).toBeInTheDocument()
+
+    const applyBtn = screen.getByRole('button', { name: /apply/i })
+    fireEvent.click(applyBtn)
+
+    await waitFor(() => expect(apiClient.post).toHaveBeenCalledWith('/knowledge-base/applications', { entry_id: 'k-1', project_id: 'proj-1' }))
+  })
+
+  it('handles 404 (no recommendations) gracefully', async () => {
+    ;(apiClient.get as jest.Mock).mockRejectedValueOnce({ status: 404, message: 'Not found' })
+
+    render(<LessonsTab projectId="proj-1" />)
+
+    await waitFor(() => expect(apiClient.get).toHaveBeenCalled())
+
+    // When 404, component should show the friendly 'no recommendations' message
+    expect(screen.getByText('No lessons learned recommendations available for this project.')).toBeInTheDocument()
+  })
+})

--- a/app/projects/[id]/components/LessonsTab.tsx
+++ b/app/projects/[id]/components/LessonsTab.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import React, { useEffect, useState, useCallback } from 'react'
+import { apiClient } from '@/lib/api'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { toast } from 'sonner'
+
+interface LessonsTabProps {
+  projectId: string
+}
+
+export default function LessonsTab({ projectId }: LessonsTabProps) {
+  const [items, setItems] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchLessons = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      // Knowledge-base recommendations are scoped to the project
+      // Suppress not-found logs for this call — if recommendations don't exist yet for a project
+      const resp = await apiClient.get<{ success: boolean; data: any[] }>(`/knowledge-base/recommendations/${projectId}`, { suppressNotFoundError: true })
+
+      if (!resp || !resp.success) {
+        setItems([])
+        return
+      }
+
+      // Filter for recommendations that look like lessons learned
+      const lessons = (resp.data || []).filter((e: any) => {
+        const type = String(e.entry_type || e.type || '')
+        const title = String(e.title || '')
+        return type.toLowerCase().includes('lesson') || title.toLowerCase().includes('lesson')
+      })
+
+      setItems(lessons)
+    } catch (err: unknown) {
+      // If the server returns 404 (no recommendations for this project yet), treat it as 'no items' (not an error)
+      const status = (err as any)?.status
+      if (status === 404) {
+        setItems([])
+        setError(null)
+        setLoading(false)
+        return
+      }
+      console.error('Failed to load lessons:', err)
+      setItems([])
+      setError(err instanceof Error ? err.message : 'Failed to load lessons')
+      toast.error('Failed to load lessons')
+    } finally {
+      setLoading(false)
+    }
+  }, [projectId])
+
+  useEffect(() => {
+    void fetchLessons()
+  }, [fetchLessons])
+
+  const handleApply = async (entryId: string) => {
+    try {
+      const response = await apiClient.post(`/knowledge-base/applications`, {
+        entry_id: entryId,
+        project_id: projectId,
+      })
+
+      if (response && response.success) {
+        toast.success('Applied lesson to project')
+      } else {
+        throw new Error('Failed to apply')
+      }
+    } catch (err: unknown) {
+      console.error('Apply failed', err)
+      toast.error('Failed to apply lesson')
+    }
+  }
+
+  if (loading) {
+    return <div className="py-8 text-center">Loading lessons…</div>
+  }
+
+  if (error) {
+    return (
+      <div className="py-8 text-center text-destructive">Unable to load lessons: {error}</div>
+    )
+  }
+
+  if (!items || items.length === 0) {
+    return <div className="py-8 text-center text-muted-foreground">No lessons learned recommendations available for this project.</div>
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold">Lessons learned</h2>
+          <p className="text-sm text-muted-foreground">Actionable recommendations extracted for this project</p>
+        </div>
+        <div>
+          <Button onClick={() => void fetchLessons()} size="sm" variant="outline">Refresh</Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3">
+        {items.map((entry) => (
+          <Card key={entry.knowledge_entry_id || entry.id} className="border">
+            <CardHeader>
+              <CardTitle>{entry.title}</CardTitle>
+              <CardDescription className="line-clamp-2 text-sm text-muted-foreground">{entry.reasoning || entry.description}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="flex items-center justify-between">
+                <div className="text-sm text-muted-foreground">
+                  {entry.source_project_name ? (<span>From: {entry.source_project_name}</span>) : null}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button size="sm" onClick={() => void handleApply(entry.knowledge_entry_id || entry.id)}>
+                    Apply
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/projects/[id]/components/LessonsTab.tsx
+++ b/app/projects/[id]/components/LessonsTab.tsx
@@ -10,8 +10,19 @@ interface LessonsTabProps {
   projectId: string
 }
 
+interface LessonItem {
+  knowledge_entry_id?: string
+  id?: string
+  title: string
+  reasoning?: string
+  description?: string
+  entry_type?: string
+  type?: string
+  source_project_name?: string
+}
+
 export default function LessonsTab({ projectId }: LessonsTabProps) {
-  const [items, setItems] = useState<any[]>([])
+  const [items, setItems] = useState<LessonItem[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -18,6 +18,7 @@ import { ProjectDataExtraction } from "./components/ProjectDataExtraction"
 import { PerformanceDashboard } from "@/components/project/PerformanceDashboard"
 import { StakeholdersTab } from "./components/StakeholdersTab"
 import { TeamAgreementsTab } from "./components/TeamAgreementsTab"
+import LessonsTab from "./components/LessonsTab"
 import { VariablesTab } from "./components/VariablesTab"
 import { TimelineTab } from "./components/TimelineTab"
 import { OverviewTab } from "./components/OverviewTab"
@@ -3001,6 +3002,10 @@ Generate the COMPLETE, DETAILED ${templateContent.title} now. This must be a pro
                   <Database className="h-4 w-4 mr-2" />
                   AI Extraction
                 </TabsTrigger>
+                <TabsTrigger value="lessons">
+                  <Lightbulb className="h-4 w-4 mr-2" />
+                  Lessons
+                </TabsTrigger>
                 <TabsTrigger value="performance">
                   <Activity className="h-4 w-4 mr-2" />
                   Performance
@@ -3064,6 +3069,10 @@ Generate the COMPLETE, DETAILED ${templateContent.title} now. This must be a pro
               <TabsContent value="extraction" className="space-y-4">
                 {/* AI Project Data Extraction - NEW RAG Integration */}
                 <ProjectDataExtraction projectId={projectId} documents={documents} />
+              </TabsContent>
+
+              <TabsContent value="lessons" className="space-y-4">
+                <LessonsTab projectId={projectId} />
               </TabsContent>
 
               <TabsContent value="performance" className="space-y-4">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -424,8 +424,18 @@ class ApiClient {
       try {
         data = await response.json()
       } catch (jsonError) {
-        // If response is not JSON, create a text error
-        const text = await response.text()
+        // If response is not JSON or JSON parsing failed, read the raw text.
+        // Use `response.clone()` because some environments may have already
+        // consumed the body (or `response.json()` attempted to read it and
+        // failed) — cloning provides a fresh stream to safely call `text()`.
+        let text: string
+        try {
+          text = await response.clone().text()
+        } catch (_err) {
+          // Fallback if clone/text also fail; provide a generic message
+          text = `HTTP error! status: ${response.status}`
+        }
+
         data = { error: text || `HTTP error! status: ${response.status}`, message: text || `HTTP error! status: ${response.status}` }
       }
 
@@ -506,10 +516,17 @@ class ApiClient {
   // WebSocket connection
   connectWebSocket(): Socket {
     if (!this.socket) {
+      // Configure socket with safe reconnection settings and prefer websocket transport
       this.socket = io(WS_URL, {
         auth: {
           token: this.token,
         },
+        transports: ['websocket', 'polling'],
+        reconnection: true,
+        reconnectionAttempts: 5,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 10000,
+        timeout: 20000,
       })
 
       this.socket.on("connect", () => {

--- a/server/migrations/999_dev_seed_knowledge_base_samples.sql
+++ b/server/migrations/999_dev_seed_knowledge_base_samples.sql
@@ -28,50 +28,157 @@ BEGIN
 END$$;
 
 -- 2) Insert a sample knowledge base entry (if not exists)
-INSERT INTO knowledge_base_entries (
-  id, entry_type, category, title, description, context, approach, results, source_project_id, business_value_score,
-  replicable, replication_difficulty, replicated_instructions, tags, keywords, ai_generated, ai_confidence, created_by, created_at, updated_at
-)
-VALUES (
-  '22222222-2222-2222-2222-222222222222',
-  'lesson_learned',
-  'best_practice',
-  'Keep meetings focused and time-boxed',
-  'A developer-friendly lesson to keep meetings short; used as a local sample record',
-  'Applies to team ceremonies and ad-hoc syncs',
-  'Limit meeting duration, set an agenda and action items',
-  'Reduced meeting time and clearer outcomes',
-  '11111111-1111-1111-1111-111111111111',
-  0.75,
-  TRUE,
-  'easy',
-  'Short checklist: agenda, owner, actions',
-  ARRAY['meetings','process'],
-  ARRAY['meeting','timebox','agile'],
-  TRUE,
-  0.8,
-  NULL,
-  NOW(),
-  NOW()
-)
-ON CONFLICT (id) DO NOTHING;
+-- This insertion is schema-aware. The knowledge_base_entries table evolved between migrations
+-- (some schemas use `context/approach/results` while newer ones use JSONB fields such as
+-- `baseline_approach` / `improved_approach` / `replication_guide` and require a non-null `created_by`).
+-- To keep this migration safe across environments we check available columns and adapt.
+DO $$
+DECLARE
+  has_context_col BOOLEAN := FALSE;
+  has_baseline_approach_col BOOLEAN := FALSE;
+  has_created_by_col BOOLEAN := FALSE;
+  users_exist BOOLEAN := FALSE;
+BEGIN
+  SELECT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'knowledge_base_entries' AND column_name = 'context'
+  ) INTO has_context_col;
+
+  SELECT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'knowledge_base_entries' AND column_name = 'baseline_approach'
+  ) INTO has_baseline_approach_col;
+
+  SELECT EXISTS(
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'knowledge_base_entries' AND column_name = 'created_by'
+  ) INTO has_created_by_col;
+
+  -- Check if there's at least one user to use for the created_by field when required
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE tablename = 'users') THEN
+    SELECT EXISTS(SELECT 1 FROM users) INTO users_exist;
+  END IF;
+
+  IF has_context_col THEN
+    -- Old/legacy schema path (uses plain text columns)
+    INSERT INTO knowledge_base_entries (
+      id, entry_type, category, title, description, context, approach, results, source_project_id, business_value_score,
+      replicable, replication_difficulty, replication_instructions, tags, keywords, ai_generated, ai_confidence, created_by, created_at, updated_at
+    )
+    VALUES (
+      '22222222-2222-2222-2222-222222222222',
+      'lesson_learned',
+      'best_practice',
+      'Keep meetings focused and time-boxed',
+      'A developer-friendly lesson to keep meetings short; used as a local sample record',
+      'Applies to team ceremonies and ad-hoc syncs',
+      'Limit meeting duration, set an agenda and action items',
+      'Reduced meeting time and clearer outcomes',
+      '11111111-1111-1111-1111-111111111111',
+      0.75,
+      TRUE,
+      'easy',
+      'Short checklist: agenda, owner, actions',
+      ARRAY['meetings','process'],
+      ARRAY['meeting','timebox','agile'],
+      TRUE,
+      0.8,
+      NULL,
+      NOW(),
+      NOW()
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+  ELSIF has_baseline_approach_col THEN
+    -- Newer schema path (313-style) where content and replication guides are JSONB and
+    -- 'project_id' + 'created_by' constraints may be enforced. We'll only insert when
+    -- the environment contains at least one user to reference for created_by (a dev env typically does).
+    IF NOT users_exist THEN
+      RAISE NOTICE 'Skipping 999 KB entry seed: no users present to satisfy created_by NOT NULL constraint';
+    ELSE
+      INSERT INTO knowledge_base_entries (
+        id, project_id, entry_type, category, title, description, baseline_approach, improved_approach,
+        value_metrics, replication_guide, applicable_contexts, tags, keywords, ai_confidence, created_by, created_at, updated_at
+      )
+      VALUES (
+        '22222222-2222-2222-2222-222222222222',
+        '11111111-1111-1111-1111-111111111111',
+        'lessons_learned',
+        'other',
+        'Keep meetings focused and time-boxed',
+        'A developer-friendly lesson to keep meetings short; used as a local sample record',
+        jsonb_build_object('description', 'Limit meeting duration, set an agenda and action items'),
+        jsonb_build_object('description', 'Limit meeting duration, set an agenda and action items'),
+        jsonb_build_object('time_saved', 0.25),
+        jsonb_build_object('steps', ARRAY['Set agenda','Assign an owner','Capture actions']),
+        jsonb_build_array('team','ceremony'),
+        ARRAY['meetings','process'],
+        ARRAY['meeting','timebox','agile'],
+        0.8,
+        (SELECT id FROM users LIMIT 1),
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (id) DO NOTHING;
+    END IF;
+
+  ELSE
+    -- If we don't recognize the schema shape, insert a minimal, safe record using only
+    -- common columns (id, entry_type, title, description, tags, keywords) if those exist.
+    IF EXISTS(SELECT 1 FROM information_schema.columns WHERE table_name='knowledge_base_entries' AND column_name='title') THEN
+      INSERT INTO knowledge_base_entries (
+        id, entry_type, category, title, description, tags, keywords, created_at, updated_at
+      ) VALUES (
+        '22222222-2222-2222-2222-222222222222',
+        'lesson_learned',
+        'best_practice',
+        'Keep meetings focused and time-boxed',
+        'A developer-friendly lesson to keep meetings short; used as a local sample record',
+        ARRAY['meetings','process'],
+        ARRAY['meeting','timebox','agile'],
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (id) DO NOTHING;
+    ELSE
+      RAISE NOTICE 'Skipping 999 KB entry seed: knowledge_base_entries table does not contain expected columns for safe insert';
+    END IF;
+  END IF;
+END$$;
 
 -- 3) Insert a sample recommendation record for the dev project (if not exists)
-INSERT INTO knowledge_base_recommendations (
-  id, knowledge_entry_id, project_id, relevance_score, reasoning, expected_impact, ai_model, ai_confidence, created_at
-)
-VALUES (
-  '33333333-3333-3333-3333-333333333333',
-  '22222222-2222-2222-2222-222222222222',
-  '11111111-1111-1111-1111-111111111111',
-  0.9,
-  'Dev sample - created to demonstrate Lessons UI locally',
-  'Expected to save developer time spent in meetings',
-  'dev-seed',
-  0.8,
-  NOW()
-)
-ON CONFLICT (knowledge_entry_id, project_id) DO NOTHING;
+-- 3) Insert a sample recommendation record for the dev project (if not exists)
+-- Only insert a recommendation if the recommendations table exists and the referenced KB entry was inserted.
+DO $$
+DECLARE
+  recs_table_exists BOOLEAN := FALSE;
+  kb_entry_exists BOOLEAN := FALSE;
+BEGIN
+  SELECT EXISTS(SELECT 1 FROM pg_tables WHERE tablename = 'knowledge_base_recommendations') INTO recs_table_exists;
+  IF recs_table_exists THEN
+    SELECT EXISTS(SELECT 1 FROM knowledge_base_entries WHERE id = '22222222-2222-2222-2222-222222222222') INTO kb_entry_exists;
+    IF kb_entry_exists THEN
+      -- Use dynamic SQL here so this DO block parses even when the table is absent
+      EXECUTE 'INSERT INTO knowledge_base_recommendations (
+        id, knowledge_entry_id, project_id, relevance_score, reasoning, expected_impact, ai_model, ai_confidence, created_at
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9) ON CONFLICT (knowledge_entry_id, project_id) DO NOTHING'
+      USING
+        '33333333-3333-3333-3333-333333333333',
+        '22222222-2222-2222-2222-222222222222',
+        '11111111-1111-1111-1111-111111111111',
+        0.9,
+        'Dev sample - created to demonstrate Lessons UI locally',
+        'Expected to save developer time spent in meetings',
+        'dev-seed',
+        0.8,
+        NOW();
+    ELSE
+      RAISE NOTICE 'Skipping recommendation: knowledge base entry not present (seed likely skipped)';
+    END IF;
+  ELSE
+    RAISE NOTICE 'Skipping recommendation: knowledge_base_recommendations table not present in this schema';
+  END IF;
+END$$;
 
 COMMIT;
 
@@ -82,10 +189,22 @@ COMMIT;
 
 BEGIN;
 
-DELETE FROM knowledge_base_recommendations WHERE id = '33333333-3333-3333-3333-333333333333' OR (knowledge_entry_id = '22222222-2222-2222-2222-222222222222' AND project_id = '11111111-1111-1111-1111-111111111111');
+-- Only run DELETEs where the target tables exist in the current schema. This keeps DOWN safe
+-- to run across multiple schema variants.
+DO $$
+BEGIN
+  IF EXISTS(SELECT 1 FROM pg_tables WHERE tablename = 'knowledge_base_recommendations') THEN
+    EXECUTE 'DELETE FROM knowledge_base_recommendations WHERE id = $1 OR (knowledge_entry_id = $2 AND project_id = $3)'
+    USING '33333333-3333-3333-3333-333333333333', '22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111';
+  END IF;
+END$$;
 
-DELETE FROM knowledge_base_entries WHERE id = '22222222-2222-2222-2222-222222222222';
+IF EXISTS(SELECT 1 FROM pg_tables WHERE tablename = 'knowledge_base_entries') THEN
+  DELETE FROM knowledge_base_entries WHERE id = '22222222-2222-2222-2222-222222222222';
+END IF;
 
-DELETE FROM projects WHERE id = '11111111-1111-1111-1111-111111111111';
+IF EXISTS(SELECT 1 FROM pg_tables WHERE tablename = 'projects') THEN
+  DELETE FROM projects WHERE id = '11111111-1111-1111-1111-111111111111';
+END IF;
 
 COMMIT;

--- a/server/migrations/999_dev_seed_knowledge_base_samples.sql
+++ b/server/migrations/999_dev_seed_knowledge_base_samples.sql
@@ -1,0 +1,91 @@
+-- Migration: 999_dev_seed_knowledge_base_samples.sql
+-- Purpose: Insert developer-friendly sample project + KB entries + recommendations for local development
+-- Notes: This migration is safe to re-run (uses INSERT ... ON CONFLICT DO NOTHING)
+
+BEGIN;
+
+-- Create pgcrypto for gen_random_uuid when not present (safe/ idempotent)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- 1) Create a stable, recognizable dev project (id is deterministic so DOWN can cleanup)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM projects WHERE id = '11111111-1111-1111-1111-111111111111') THEN
+    INSERT INTO projects (id, name, description, framework, status, priority, owner_id, created_by, created_at, updated_at)
+    VALUES (
+      '11111111-1111-1111-1111-111111111111',
+      'Dev Sample Project',
+      'Local developer sample project created by migration 999_dev_seed_knowledge_base_samples.sql',
+      'agile',
+      'green',
+      'low',
+      NULL,
+      NULL,
+      NOW(),
+      NOW()
+    );
+  END IF;
+END$$;
+
+-- 2) Insert a sample knowledge base entry (if not exists)
+INSERT INTO knowledge_base_entries (
+  id, entry_type, category, title, description, context, approach, results, source_project_id, business_value_score,
+  replicable, replication_difficulty, replicated_instructions, tags, keywords, ai_generated, ai_confidence, created_by, created_at, updated_at
+)
+VALUES (
+  '22222222-2222-2222-2222-222222222222',
+  'lesson_learned',
+  'best_practice',
+  'Keep meetings focused and time-boxed',
+  'A developer-friendly lesson to keep meetings short; used as a local sample record',
+  'Applies to team ceremonies and ad-hoc syncs',
+  'Limit meeting duration, set an agenda and action items',
+  'Reduced meeting time and clearer outcomes',
+  '11111111-1111-1111-1111-111111111111',
+  0.75,
+  TRUE,
+  'easy',
+  'Short checklist: agenda, owner, actions',
+  ARRAY['meetings','process'],
+  ARRAY['meeting','timebox','agile'],
+  TRUE,
+  0.8,
+  NULL,
+  NOW(),
+  NOW()
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- 3) Insert a sample recommendation record for the dev project (if not exists)
+INSERT INTO knowledge_base_recommendations (
+  id, knowledge_entry_id, project_id, relevance_score, reasoning, expected_impact, ai_model, ai_confidence, created_at
+)
+VALUES (
+  '33333333-3333-3333-3333-333333333333',
+  '22222222-2222-2222-2222-222222222222',
+  '11111111-1111-1111-1111-111111111111',
+  0.9,
+  'Dev sample - created to demonstrate Lessons UI locally',
+  'Expected to save developer time spent in meetings',
+  'dev-seed',
+  0.8,
+  NOW()
+)
+ON CONFLICT (knowledge_entry_id, project_id) DO NOTHING;
+
+COMMIT;
+
+-- DOWN (cleanup) -- reverse the seed (delete only the deterministic IDs created by this migration)
+-- Note: run the DOWN section only when reverting this migration
+
+-- DOWN
+
+BEGIN;
+
+DELETE FROM knowledge_base_recommendations WHERE id = '33333333-3333-3333-3333-333333333333' OR (knowledge_entry_id = '22222222-2222-2222-2222-222222222222' AND project_id = '11111111-1111-1111-1111-111111111111');
+
+DELETE FROM knowledge_base_entries WHERE id = '22222222-2222-2222-2222-222222222222';
+
+DELETE FROM projects WHERE id = '11111111-1111-1111-1111-111111111111';
+
+COMMIT;

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "migrate:300:rollback": "tsx scripts/rollback-migration-300.ts",
     "migrate:325:ccb": "tsx scripts/run-migration-325-ccb.ts",
     "migrate:326": "tsx scripts/run-migration-326.ts",
+    "migrate:999": "tsx scripts/run-migration-999.ts",
     "migrate:327": "tsx scripts/run-migration-327.ts",
     "migrate:328": "tsx scripts/run-migration-328.ts",
     "migrate:329": "tsx scripts/run-migration-329.ts",

--- a/server/scripts/run-migration-999.ts
+++ b/server/scripts/run-migration-999.ts
@@ -1,0 +1,73 @@
+/**
+ * Migration Runner: Seed development-friendly KB samples (migration 999)
+ * Purpose: Run migration 999 to insert deterministic dev sample project + KB entry + recommendation
+ * Usage: npm run migrate:999  (from server/ folder) or npx tsx server/scripts/run-migration-999.ts
+ */
+
+import { pool, connectDatabase } from '../src/database/connection'
+import { logger } from '../src/utils/logger'
+import * as fs from 'fs'
+import * as path from 'path'
+
+async function runMigration() {
+  const migrationFile = path.join(__dirname, '../migrations/999_dev_seed_knowledge_base_samples.sql')
+
+  try {
+    logger.info('Starting migration 999: Dev seed knowledge base samples')
+
+    // Connect to database first
+    logger.info('Connecting to database...')
+    await connectDatabase()
+
+    if (!pool) {
+      throw new Error('Database connection failed - pool is null')
+    }
+
+    logger.info('Database connected successfully')
+
+    // Read migration SQL and only run the UP portion. Migration files include a DOWN section
+    // after the UP which may reference tables that don't exist in all schemas. To be
+    // tolerant we only apply the UP portion when running a dev-only seeding migration.
+    const migrationSQL = fs.readFileSync(migrationFile, 'utf-8')
+    const upSql = migrationSQL.split(/\n--\s*DOWN\b/)[0]
+
+    logger.info('Applying migration SQL (UP section only)...')
+    await pool.query(upSql)
+
+    // Quick verification: report which of the deterministic dev records exist now
+    const [projectRes, kbRes, recRes] = await Promise.all([
+      pool.query("SELECT id FROM projects WHERE id = '11111111-1111-1111-1111-111111111111' LIMIT 1"),
+      pool.query("SELECT id FROM knowledge_base_entries WHERE id = '22222222-2222-2222-2222-222222222222' LIMIT 1"),
+      pool.query("SELECT id FROM knowledge_base_recommendations WHERE id = '33333333-3333-3333-3333-333333333333' LIMIT 1")
+        .catch(() => ({ rowCount: 0 }))
+    ])
+
+    logger.info('✅ Migration 999 applied successfully! (dev seed inserted if not present)', {
+      project_present: !!(projectRes?.rowCount),
+      knowledge_entry_present: !!(kbRes?.rowCount),
+      recommendation_present: !!(recRes?.rowCount)
+    })
+
+    process.exit(0)
+  } catch (error) {
+    logger.error('❌ Migration 999 failed:', error)
+    logger.error('Error details:', error)
+
+    process.exit(1)
+  }
+}
+
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+  logger.info('Migration interrupted by user')
+  await pool.end()
+  process.exit(1)
+})
+
+process.on('SIGTERM', async () => {
+  logger.info('Migration terminated')
+  await pool.end()
+  process.exit(1)
+})
+
+runMigration()

--- a/server/src/modules/knowledgeBase/__tests__/routes.test.ts
+++ b/server/src/modules/knowledgeBase/__tests__/routes.test.ts
@@ -60,21 +60,23 @@ describe('Knowledge Base recommendations route (modules)', () => {
   })
 
   test('GET /api/knowledge-base/recommendations/:projectId returns dev sample when project missing in development', async () => {
-    // Temporarily set NODE_ENV to development
-    const originalEnv = process.env.NODE_ENV
-    process.env.NODE_ENV = 'development'
+      // Temporarily set NODE_ENV to development and ensure cleanup in a finally block
+      const originalEnv = process.env.NODE_ENV
+      try {
+        process.env.NODE_ENV = 'development'
 
-    ;(coreService.getRecommendationsForProject as jest.Mock).mockRejectedValueOnce(new Error('Project not found: anything'))
+        ;(coreService.getRecommendationsForProject as jest.Mock).mockRejectedValueOnce(new Error('Project not found: anything'))
 
-    const res = await request(app)
-      .get('/api/knowledge-base/recommendations/missing-proj')
-      .set('Authorization', 'Bearer test-token')
+        const res = await request(app)
+          .get('/api/knowledge-base/recommendations/missing-proj')
+          .set('Authorization', 'Bearer test-token')
 
-    expect(res.status).toBe(200)
-    expect(res.body.success).toBe(true)
-    expect(Array.isArray(res.body.data)).toBe(true)
-
-    // Restore NODE_ENV
-    process.env.NODE_ENV = originalEnv
+        expect(res.status).toBe(200)
+        expect(res.body.success).toBe(true)
+        expect(Array.isArray(res.body.data)).toBe(true)
+      } finally {
+        // Restore NODE_ENV even if the test throws
+        process.env.NODE_ENV = originalEnv
+      }
   })
 })

--- a/server/src/modules/knowledgeBase/__tests__/routes.test.ts
+++ b/server/src/modules/knowledgeBase/__tests__/routes.test.ts
@@ -1,0 +1,80 @@
+import express from 'express'
+import request from 'supertest'
+
+// We will stub authentication to allow the tests through
+jest.mock('../../../middleware/auth', () => ({
+  authenticateToken: (req: any, res: any, next: any) => {
+    req.user = { id: 'test-user', email: 'tester@example.com', role: 'user', permissions: [] }
+    next()
+  }
+}))
+
+// Mock core service that provides recommendations logic
+jest.mock('../../../services/knowledgeBaseService', () => ({
+  knowledgeBaseService: {
+    getRecommendationsForProject: jest.fn()
+  }
+}))
+
+import knowledgeBaseRoutes from '../routes'
+import { knowledgeBaseService as coreService } from '../../../services/knowledgeBaseService'
+
+describe('Knowledge Base recommendations route (modules)', () => {
+  let app: express.Application
+
+  beforeAll(() => {
+    app = express()
+    app.use(express.json())
+    app.use('/api/knowledge-base', knowledgeBaseRoutes)
+  })
+
+  beforeEach(() => {
+    ;(coreService.getRecommendationsForProject as jest.Mock).mockReset()
+  })
+
+  test('GET /api/knowledge-base/recommendations/:projectId returns recommendations', async () => {
+    const fakeRecs = [{ knowledge_entry_id: 'kb-1', relevance_score: 0.9 }]
+    ;(coreService.getRecommendationsForProject as jest.Mock).mockResolvedValueOnce(fakeRecs)
+
+    const res = await request(app)
+      .get('/api/knowledge-base/recommendations/proj-123')
+      .set('Authorization', 'Bearer test-token')
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(Array.isArray(res.body.data)).toBe(true)
+    expect(res.body.data.length).toBe(1)
+    expect(coreService.getRecommendationsForProject).toHaveBeenCalledWith('proj-123', 10)
+  })
+
+  test('GET /api/knowledge-base/recommendations/:projectId returns 404 for missing project', async () => {
+    ;(coreService.getRecommendationsForProject as jest.Mock).mockRejectedValueOnce(new Error('Project not found: proj-no'))
+
+    const res = await request(app)
+      .get('/api/knowledge-base/recommendations/proj-no')
+      .set('Authorization', 'Bearer test-token')
+
+    expect(res.status).toBe(404)
+    expect(res.body.error).toBe('Project not found')
+    expect(coreService.getRecommendationsForProject).toHaveBeenCalledWith('proj-no', 10)
+  })
+
+  test('GET /api/knowledge-base/recommendations/:projectId returns dev sample when project missing in development', async () => {
+    // Temporarily set NODE_ENV to development
+    const originalEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    ;(coreService.getRecommendationsForProject as jest.Mock).mockRejectedValueOnce(new Error('Project not found: anything'))
+
+    const res = await request(app)
+      .get('/api/knowledge-base/recommendations/missing-proj')
+      .set('Authorization', 'Bearer test-token')
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(Array.isArray(res.body.data)).toBe(true)
+
+    // Restore NODE_ENV
+    process.env.NODE_ENV = originalEnv
+  })
+})

--- a/server/src/modules/knowledgeBase/controller.ts
+++ b/server/src/modules/knowledgeBase/controller.ts
@@ -5,6 +5,8 @@
 
 import { Request, Response } from 'express'
 import { knowledgeBaseService } from './service'
+// The global service contains AI-driven recommendations helper used by some endpoints
+import { knowledgeBaseService as coreKnowledgeBaseService } from '../../services/knowledgeBaseService'
 import { logger } from '../../utils/logger'
 import type {
   CreateKnowledgeBaseEntryRequest,
@@ -238,6 +240,50 @@ export class KnowledgeBaseController {
     } catch (error) {
       logger.error('Error in getStats controller:', error)
       res.status(500).json({ error: 'Failed to fetch statistics' })
+    }
+  }
+
+  /**
+   * Get generated recommendations for a project
+   * GET /api/knowledge-base/recommendations/:projectId
+   */
+  async getRecommendationsForProject(req: Request, res: Response): Promise<void> {
+    try {
+      const { projectId } = req.params
+      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 10
+
+      const recommendations = await coreKnowledgeBaseService.getRecommendationsForProject(projectId, limit)
+
+      res.json({ success: true, data: recommendations })
+    } catch (error: any) {
+      logger.error('Error in getRecommendationsForProject controller:', error, { projectId: req.params?.projectId })
+
+      // When running in local development it's handy to return a friendly
+      // sample payload instead of 404 so the front-end can render a dev preview
+      // without requiring a populated database.
+      if ((process.env.NODE_ENV === 'development') && error.message && error.message.includes('Project not found')) {
+        const sample = [
+          {
+            knowledge_entry_id: 'dev-kb-1',
+            entry: { id: 'dev-kb-1', title: 'Dev sample: Keep meetings short', description: 'A simple lesson for local testing', entry_type: 'lesson_learned' },
+            relevance_score: 0.9,
+            reasoning: 'High-level practice that helps avoid long meetings',
+            expected_impact: 'Saves time',
+            ai_model: 'dev-fallback',
+            ai_confidence: 0.8
+          }
+        ]
+
+        res.json({ success: true, data: sample })
+        return
+      }
+
+      if (error.message && error.message.includes('Project not found')) {
+        res.status(404).json({ error: 'Project not found' })
+        return
+      }
+
+      res.status(500).json({ error: 'Failed to fetch recommendations' })
     }
   }
 }

--- a/server/src/modules/knowledgeBase/controller.ts
+++ b/server/src/modules/knowledgeBase/controller.ts
@@ -261,7 +261,7 @@ export class KnowledgeBaseController {
       // When running in local development it's handy to return a friendly
       // sample payload instead of 404 so the front-end can render a dev preview
       // without requiring a populated database.
-      if ((process.env.NODE_ENV === 'development') && error.message && error.message.includes('Project not found')) {
+      if ((process.env.NODE_ENV === 'development') && typeof error?.message === 'string' && error.message.includes('Project not found')) {
         const sample = [
           {
             knowledge_entry_id: 'dev-kb-1',
@@ -278,7 +278,7 @@ export class KnowledgeBaseController {
         return
       }
 
-      if (error.message && error.message.includes('Project not found')) {
+      if (typeof error?.message === 'string' && error.message.includes('Project not found')) {
         res.status(404).json({ error: 'Project not found' })
         return
       }

--- a/server/src/modules/knowledgeBase/routes.ts
+++ b/server/src/modules/knowledgeBase/routes.ts
@@ -31,4 +31,7 @@ router.get('/entries/:id/reviews', (req, res) => knowledgeBaseController.getRevi
 // Statistics
 router.get('/stats', (req, res) => knowledgeBaseController.getStats(req, res))
 
+// Recommendations (generated AI recommendations for a project)
+router.get('/recommendations/:projectId', (req, res) => knowledgeBaseController.getRecommendationsForProject(req, res))
+
 export default router


### PR DESCRIPTION
This PR adds a minimal Lessons learned UI tab for project pages, a server route to surface AI-generated recommendations, tests for client and server, fixes to the API client (prevents double-reading response body), safer WebSocket options, and a development DB seed migration so local environments show sample recommendations.\n\nFiles changed: LessonsTab UI, lib/api.ts, knowledge base module controller/routes/tests, and server/migrations/999_dev_seed_knowledge_base_samples.sql (dev seed).\n\nAll tests pass locally. Please review; I did not push to main  target is adpa-project-charter as requested.