### PR TITLE
Continue pmbok 8th edition entity alignment

### DIFF
--- a/components/project/PMBOK8DomainDashboard.tsx
+++ b/components/project/PMBOK8DomainDashboard.tsx
@@ -305,6 +305,58 @@ export function PMBOK8DomainDashboard({ projectId }: PMBOK8DomainDashboardProps)
       })
     }
     
+    const measurementActuals = analytics.domains.measurement.actuals
+    if (measurementActuals?.total_actuals > 0) {
+      const scheduleVariance = measurementActuals.avg_schedule_variance_days ?? null
+      if (scheduleVariance !== null && scheduleVariance < -1) {
+        insights.push({
+          type: 'warning',
+          domain: 'Measurement',
+          message: `Average schedule variance is ${scheduleVariance.toFixed(1)} days behind. Investigate delays in actual execution.`,
+          icon: AlertTriangle,
+          priority: 'high'
+        })
+      } else if (scheduleVariance !== null && scheduleVariance > 1) {
+        insights.push({
+          type: 'success',
+          domain: 'Measurement',
+          message: `Projects are ahead of schedule by ${scheduleVariance.toFixed(1)} days on average.`,
+          icon: CheckCircle2,
+          priority: 'low'
+        })
+      }
+
+      if (measurementActuals.avg_cost_variance !== null && measurementActuals.avg_cost_variance < 0) {
+        insights.push({
+          type: 'warning',
+          domain: 'Measurement',
+          message: `Average cost variance is ${measurementActuals.avg_cost_variance.toFixed(0)} (over budget). Review spend controls.`,
+          icon: AlertTriangle,
+          priority: 'high'
+        })
+      }
+
+      if (measurementActuals.avg_quality_score !== null) {
+        if (measurementActuals.avg_quality_score < 7) {
+          insights.push({
+            type: 'warning',
+            domain: 'Measurement',
+            message: `Quality score averages ${measurementActuals.avg_quality_score.toFixed(1)}/10. Address defect and rework drivers.`,
+            icon: AlertTriangle,
+            priority: 'medium'
+          })
+        } else if (measurementActuals.avg_quality_score >= 8.5) {
+          insights.push({
+            type: 'success',
+            domain: 'Measurement',
+            message: `Quality holding strong at ${(measurementActuals.avg_quality_score).toFixed(1)}/10.`,
+            icon: CheckCircle2,
+            priority: 'low'
+          })
+        }
+      }
+    }
+
     // Uncertainty insights
     if (analytics.domains.uncertainty.realized_opportunities > 0) {
       insights.push({
@@ -691,6 +743,46 @@ export function PMBOK8DomainDashboard({ projectId }: PMBOK8DomainDashboardProps)
                           <div className="flex justify-between text-xs">
                             <span className="text-muted-foreground">Off Track:</span>
                             <span className="font-medium text-red-600">{domain.performance.off_track_count}</span>
+                          </div>
+                        )}
+                        {domain.actuals?.total_actuals ? (
+                          <>
+                            <div className="flex justify-between text-xs pt-1 border-t">
+                              <span className="text-muted-foreground">Performance Actuals:</span>
+                              <span className="font-medium">{domain.actuals.total_actuals}</span>
+                            </div>
+                            <div className="flex justify-between text-xs">
+                              <span className="text-muted-foreground">Avg Schedule Var:</span>
+                              <span className={`font-medium ${domain.actuals.avg_schedule_variance_days != null && domain.actuals.avg_schedule_variance_days < 0 ? 'text-red-600' : 'text-green-600'}`}>
+                                {domain.actuals.avg_schedule_variance_days != null
+                                  ? `${domain.actuals.avg_schedule_variance_days >= 0 ? '+' : ''}${domain.actuals.avg_schedule_variance_days.toFixed(1)}d`
+                                  : 'N/A'}
+                              </span>
+                            </div>
+                            <div className="flex justify-between text-xs">
+                              <span className="text-muted-foreground">Avg Cost Var:</span>
+                              <span className={`font-medium ${domain.actuals.avg_cost_variance != null && domain.actuals.avg_cost_variance < 0 ? 'text-red-600' : 'text-green-600'}`}>
+                                {domain.actuals.avg_cost_variance != null
+                                  ? `${domain.actuals.avg_cost_variance >= 0 ? '+' : ''}${domain.actuals.avg_cost_variance.toFixed(0)}`
+                                  : 'N/A'}
+                              </span>
+                            </div>
+                            <div className="flex justify-between text-xs">
+                              <span className="text-muted-foreground">Avg Quality:</span>
+                              <span className="font-medium">
+                                {domain.actuals.avg_quality_score != null
+                                  ? `${domain.actuals.avg_quality_score.toFixed(1)}/10`
+                                  : 'N/A'}
+                              </span>
+                            </div>
+                            <div className="flex justify-between text-xs">
+                              <span className="text-muted-foreground">Defects (total):</span>
+                              <span className="font-medium text-red-600">{domain.actuals.total_defects ?? 0}</span>
+                            </div>
+                          </>
+                        ) : (
+                          <div className="text-xs text-muted-foreground pt-1 border-t">
+                            No performance actuals recorded
                           </div>
                         )}
                       </>

--- a/components/project/ProjectDashboardV0.tsx
+++ b/components/project/ProjectDashboardV0.tsx
@@ -66,11 +66,21 @@ const ENTITY_TYPE_MAP: Record<string, { label: string; icon: string }> = {
   phases: { label: "Phases", icon: "📅" },
   resources: { label: "Resources", icon: "💰" },
   qualityStandards: { label: "Quality", icon: "✅" },
+  complianceSecurity: { label: "Compliance & Security", icon: "🛡️" },
   deliverables: { label: "Deliverables", icon: "📦" },
   scopeItems: { label: "Scope Items", icon: "📋" },
   activities: { label: "Activities", icon: "📊" },
   technologies: { label: "Technologies", icon: "🔧" },
-  developmentApproaches: { label: "Development Approach", icon: "🔨" }
+  teamAgreements: { label: "Team Agreements", icon: "🤝" },
+  developmentApproaches: { label: "Development Approach", icon: "🧭" },
+  projectIterations: { label: "Project Iterations", icon: "🔁" },
+  workItems: { label: "Work Items", icon: "📌" },
+  capacityPlans: { label: "Capacity Plans", icon: "🗂️" },
+  performanceMeasurements: { label: "Performance Measurements", icon: "📈" },
+  earnedValueMetrics: { label: "EVM Metrics", icon: "💹" },
+  opportunities: { label: "Opportunities", icon: "🚀" },
+  riskResponses: { label: "Risk Responses", icon: "🛠️" },
+  performanceActuals: { label: "Performance Actuals", icon: "⚙️" }
 }
 
 export default function ProjectDashboardV0({ projectId }: ProjectDashboardV0Props) {
@@ -787,7 +797,7 @@ export default function ProjectDashboardV0({ projectId }: ProjectDashboardV0Prop
                 <div className="flex items-center justify-between">
                   <div>
                     <CardTitle>AI Extraction Dashboard</CardTitle>
-                    <CardDescription>23 entity types extracted from PMBOK 8 standards (14 legacy + 9 Performance Domain entities)</CardDescription>
+                    <CardDescription>24 entity types extracted from PMBOK 8 standards (14 legacy + 10 Performance Domain entities)</CardDescription>
                   </div>
                   <div className="flex gap-2">
                     <Button 

--- a/docs/features/pmbok8-domain-dashboard.md
+++ b/docs/features/pmbok8-domain-dashboard.md
@@ -19,7 +19,7 @@ Each domain card displays:
   - **Team**: Agreements count, adherence scores, violations
   - **Development Approach**: Iterations, velocity, story points
   - **Project Work**: Work items, blocked items, progress
-  - **Measurement**: CPI, SPI, variance tracking
+  - **Measurement**: CPI, SPI, variance tracking, performance actuals (schedule/cost variance, quality trends)
   - **Uncertainty**: Opportunities, risk responses, effectiveness
 
 ### 3. **Actionable Insights Engine**
@@ -85,6 +85,10 @@ PMBOK8DomainDashboard
 - Average variance percentage
 - Measured success criteria
 - EVM metrics (CPI, SPI, SV, CV)
+- Performance actuals coverage (counts, ahead/behind split)
+- Average schedule variance (days) and cost variance
+- Average progress variance and quality score
+- Total recorded defects and rework hours
 
 #### Uncertainty Performance Domain
 - Total opportunities

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -239,6 +239,7 @@ export interface PMBOK8EntityCounts {
   resources: number
   technologies: number
   qualityStandards: number
+  complianceSecurity: number
   deliverables: number
   scopeItems: number
   activities: number
@@ -252,6 +253,7 @@ export interface PMBOK8EntityCounts {
   earnedValueMetrics: number
   opportunities: number
   riskResponses: number
+  performanceActuals: number
 }
 
 export interface PMBOK8DomainCounts {
@@ -341,6 +343,17 @@ export interface PMBOK8DomainAnalytics {
         avg_sv: number | null
         avg_cv: number | null
         latest_measurement_date: string | null
+      }
+      actuals: {
+        total_actuals: number
+        ahead_of_schedule: number
+        behind_schedule: number
+        avg_schedule_variance_days: number | null
+        avg_cost_variance: number | null
+        avg_progress_variance: number | null
+        avg_quality_score: number | null
+        total_defects: number
+        total_rework_hours: number | null
       }
       health: DomainHealth
     }

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -563,6 +563,21 @@ router.get(
         WHERE project_id = $1
       `, [projectId])
 
+      const actualsMetrics = await pool.query(`
+        SELECT 
+          COUNT(*)::int as total_actuals,
+          COUNT(*) FILTER (WHERE schedule_variance_days >= 0)::int as ahead_of_schedule,
+          COUNT(*) FILTER (WHERE schedule_variance_days < 0)::int as behind_schedule,
+          AVG(schedule_variance_days) as avg_schedule_variance_days,
+          AVG(cost_variance) as avg_cost_variance,
+          AVG(progress_variance) as avg_progress_variance,
+          AVG(quality_score) as avg_quality_score,
+          COALESCE(SUM(defects_found), 0)::int as total_defects,
+          SUM(rework_hours) as total_rework_hours
+        FROM performance_actuals
+        WHERE project_id = $1
+      `, [projectId])
+
       // Uncertainty Performance Domain metrics
       // Note: Using separate subqueries to avoid Cartesian product from JOINing opportunities and risk_responses
       const uncertaintyMetrics = await pool.query(`
@@ -578,6 +593,61 @@ router.get(
       `, [projectId])
 
       // Aggregate domain health scores
+      const measurementTotals = parseInt(measurementMetrics.rows[0]?.total_measurements || '0', 10)
+      const onTrackCount = parseInt(measurementMetrics.rows[0]?.on_track_count || '0', 10)
+      const offTrackCount = parseInt(measurementMetrics.rows[0]?.off_track_count || '0', 10)
+
+      const actualsRaw = actualsMetrics.rows[0] || {}
+      const actualsData = {
+        total_actuals: parseInt(actualsRaw.total_actuals || '0', 10),
+        ahead_of_schedule: parseInt(actualsRaw.ahead_of_schedule || '0', 10),
+        behind_schedule: parseInt(actualsRaw.behind_schedule || '0', 10),
+        avg_schedule_variance_days: actualsRaw.avg_schedule_variance_days !== null && actualsRaw.avg_schedule_variance_days !== undefined
+          ? parseFloat(actualsRaw.avg_schedule_variance_days)
+          : null,
+        avg_cost_variance: actualsRaw.avg_cost_variance !== null && actualsRaw.avg_cost_variance !== undefined
+          ? parseFloat(actualsRaw.avg_cost_variance)
+          : null,
+        avg_progress_variance: actualsRaw.avg_progress_variance !== null && actualsRaw.avg_progress_variance !== undefined
+          ? parseFloat(actualsRaw.avg_progress_variance)
+          : null,
+        avg_quality_score: actualsRaw.avg_quality_score !== null && actualsRaw.avg_quality_score !== undefined
+          ? parseFloat(actualsRaw.avg_quality_score)
+          : null,
+        total_defects: parseInt(actualsRaw.total_defects || '0', 10),
+        total_rework_hours: actualsRaw.total_rework_hours !== null && actualsRaw.total_rework_hours !== undefined
+          ? parseFloat(actualsRaw.total_rework_hours)
+          : null
+      }
+
+      const measurementScoreFromMeasurements = measurementTotals > 0
+        ? (onTrackCount / measurementTotals) * 100
+        : null
+      const measurementScoreFromActuals = actualsData.total_actuals > 0
+        ? (actualsData.ahead_of_schedule / actualsData.total_actuals) * 100
+        : null
+      let measurementScore: number | null = null
+      if (measurementScoreFromMeasurements !== null && measurementScoreFromActuals !== null) {
+        measurementScore = (measurementScoreFromMeasurements + measurementScoreFromActuals) / 2
+      } else {
+        measurementScore = measurementScoreFromMeasurements ?? measurementScoreFromActuals
+      }
+
+      let measurementStatus: 'healthy' | 'needs_attention' | 'active' | 'inactive' | 'blocked' | 'at_risk' | 'on_track' | 'managed'
+        = (measurementTotals === 0 && actualsData.total_actuals === 0) ? 'inactive' : 'on_track'
+      if (offTrackCount > 0) {
+        measurementStatus = 'at_risk'
+      }
+      const avgScheduleVariance = actualsData.avg_schedule_variance_days ?? 0
+      const avgCostVariance = actualsData.avg_cost_variance ?? 0
+      if (actualsData.total_actuals > 0) {
+        if (avgScheduleVariance < -1 || avgCostVariance < 0) {
+          measurementStatus = 'at_risk'
+        } else if (measurementStatus !== 'at_risk' && avgScheduleVariance > 1 && avgCostVariance >= 0) {
+          measurementStatus = 'healthy'
+        }
+      }
+
       const domainHealth = {
         team: {
           score: teamMetrics.rows[0]?.avg_adherence_score 
@@ -600,10 +670,8 @@ router.get(
             : 'inactive'
         },
         measurement: {
-          score: measurementMetrics.rows[0]?.on_track_count 
-            ? (measurementMetrics.rows[0].on_track_count / measurementMetrics.rows[0].total_measurements) * 100
-            : null,
-          status: measurementMetrics.rows[0]?.off_track_count > 0 ? 'at_risk' : 'on_track'
+          score: measurementScore,
+          status: measurementStatus
         },
         uncertainty: {
           score: uncertaintyMetrics.rows[0]?.effective_responses 
@@ -635,6 +703,7 @@ router.get(
           measurement: {
             performance: measurementMetrics.rows[0],
             evm: evmMetrics.rows[0],
+            actuals: actualsData,
             health: domainHealth.measurement
           },
           uncertainty: {


### PR DESCRIPTION
Enhance PMBOK 8 analytics by integrating performance actuals for end-to-end execution variance visibility.

This PR adds the `performanceActuals` entity, updates the API to aggregate and blend this data into the measurement score, and renders new insights (schedule/cost variance, quality, defects) on the PMBOK 8 dashboard. The AI Extraction tab now advertises 24 entity types with a richer icon map.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5774053-e1cf-424d-a8a8-3765bdbbd0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5774053-e1cf-424d-a8a8-3765bdbbd0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds performance actuals to PMBOK 8 measurement analytics, blends them into health scoring, exposes via API/types, and surfaces in dashboards with new insights; AI Extraction now lists 24 entity types.
> 
> - **Backend/API**:
>   - Add `performance_actuals` aggregation to `/analytics/pmbok8-domains/:projectId` (schedule/cost/progress variance, quality, defects, rework).
>   - Blend measurements and actuals into `measurement.health.score` and refine `measurement.health.status`.
>   - Extend `PMBOK8DomainAnalytics.measurement.actuals` schema and `PMBOK8EntityCounts` with `complianceSecurity` and `performanceActuals`.
> - **Frontend**:
>   - `components/project/PMBOK8DomainDashboard.tsx`: render actuals (counts, schedule/cost variance, quality, defects) and generate new insights based on these metrics.
>   - `components/project/ProjectDashboardV0.tsx`: update entity map/icons, add `performanceActuals`, and change AI Extraction copy to “24 entity types (14 legacy + 10 PD)”.
> - **Docs**:
>   - Update measurement domain documentation to include performance actuals coverage and KPIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5ecc70765d5d75585e56ed874aefe9e3c9f4a13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->