### PR TITLE
fix: mark portfolio domains page as dynamic and normalize API URL

### DIFF
--- a/app/portfolio-domains/page.tsx
+++ b/app/portfolio-domains/page.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { DomainList } from '@/components/portfolioDomains/DomainList';
 
+// This page always fetches fresh data from the API (no static optimization)
+export const dynamic = 'force-dynamic';
+
 interface PortfolioDomain {
   id: string;
   name: string;
@@ -9,7 +12,8 @@ interface PortfolioDomain {
 
 async function fetchDomains(): Promise<PortfolioDomain[]> {
   try {
-    const url = `${process.env.NEXT_PUBLIC_API_URL || ''}/portfolio-domains`;
+    const baseUrl = (process.env.NEXT_PUBLIC_API_URL || '').replace(/\/+$/, '');
+    const url = `${baseUrl}/portfolio-domains`;
     console.log('Fetching from:', url);
     const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Force dynamic rendering for the portfolio domains page and sanitize the API base URL to avoid double slashes.
> 
> - **App page `app/portfolio-domains/page.tsx`**:
>   - Set `export const dynamic = 'force-dynamic'` to always fetch fresh data.
>   - Normalize `NEXT_PUBLIC_API_URL` by trimming trailing slashes before constructing `'/portfolio-domains'`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 193202af6a288a0a53c604f41eeead37d56755e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->