### PR TITLE
fix: use backend API URL for assessment list in onboarding

### DIFF
--- a/app/onboarding/assessments/page.tsx
+++ b/app/onboarding/assessments/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
+import { getApiUrl } from '@/lib/api-url';
 import { MaturityCard } from '@/components/onboarding/MaturityCard';
 import { MaturityScore } from '@/components/onboarding/MaturityScore';
 import { maturityTheme, getMaturityColor } from '@/lib/theme/maturity-portal-theme';
@@ -109,7 +110,7 @@ export default function AssessmentsListPage() {
     
     try {
       const token = localStorage.getItem('auth_token');
-      const response = await fetch('/api/assessment/list', {
+      const response = await fetch(getApiUrl('/assessment/list'), {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace local `/api` call with `getApiUrl('/assessment/list')` in `app/onboarding/assessments/page.tsx` to target the backend API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4db845e025a8d63a3b4d252f3b06c14c3d0be79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->