### PR TITLE
Baselines page definitions

### DIFF
--- a/server/src/services/extraction/ExtractionOrchestrator.ts
+++ b/server/src/services/extraction/ExtractionOrchestrator.ts
@@ -1,4 +1,5 @@
 ;(async function(){ try{ await (require('../../lib/db')).initDb() } catch(e){} })();
+const db = require('../../lib/db')
 /**
  * Extraction Orchestrator
  * 

--- a/server/src/services/extraction/ExtractionOrchestrator.ts
+++ b/server/src/services/extraction/ExtractionOrchestrator.ts
@@ -1,5 +1,4 @@
 ;(async function(){ try{ await (require('../../lib/db')).initDb() } catch(e){} })();
-const db = require('../../lib/db')
 /**
  * Extraction Orchestrator
  * 
@@ -56,7 +55,7 @@ async function getProjectDocuments(
     if (!pool) {
       throw new Error('Database pool not initialized after connection attempt')
     }
-    const result = await db.query(query, params)
+    const result = await pool.query(query, params)
     return result.rows
   } catch (error: unknown) {
     logger.error('[EXTRACTION] Failed to fetch project documents', {

--- a/server/src/services/extraction/ExtractionRegistry.ts
+++ b/server/src/services/extraction/ExtractionRegistry.ts
@@ -435,6 +435,13 @@ export async function initializeRegistry(): Promise<void> {
     save: saveBudgetBaseline
   })
 
+  // Register cost_actuals module (Phase 2 - Finance)
+  const { extractCostActuals, saveCostActuals } = await import('./entities/cost_actuals')
+  extractionRegistry.register('cost_actuals', {
+    extract: extractCostActuals,
+    save: saveCostActuals
+  })
+
   // Register cost_estimates module (Phase 2 - Finance)
   const { extractCostEstimates, saveCostEstimates } = await import('./entities/cost_estimates')
   extractionRegistry.register('cost_estimates', {
@@ -498,6 +505,48 @@ export async function initializeRegistry(): Promise<void> {
     save: saveProjectOrgChart
   })
 
+  // Register resource_assignments module (Phase 3 - Resources)
+  const { extractResourceAssignments, saveResourceAssignments } = await import('./entities/resource_assignments')
+  extractionRegistry.register('resource_assignments', {
+    extract: extractResourceAssignments,
+    save: saveResourceAssignments
+  })
+
+  // Register resource_pool module (Phase 3 - Resources)
+  const { extractResourcePool, saveResourcePool } = await import('./entities/resource_pool')
+  extractionRegistry.register('resource_pool', {
+    extract: extractResourcePool,
+    save: saveResourcePool
+  })
+
+  // Register capacity_forecasts module (Phase 3 - Resources)
+  const { extractCapacityForecasts, saveCapacityForecasts } = await import('./entities/capacity_forecasts')
+  extractionRegistry.register('capacity_forecasts', {
+    extract: extractCapacityForecasts,
+    save: saveCapacityForecasts
+  })
+
+  // Register utilization_records module (Phase 3 - Resources)
+  const { extractUtilizationRecords, saveUtilizationRecords } = await import('./entities/utilization_records')
+  extractionRegistry.register('utilization_records', {
+    extract: extractUtilizationRecords,
+    save: saveUtilizationRecords
+  })
+
+  // Register resource_conflicts module (Phase 3 - Resources)
+  const { extractResourceConflicts, saveResourceConflicts } = await import('./entities/resource_conflicts')
+  extractionRegistry.register('resource_conflicts', {
+    extract: extractResourceConflicts,
+    save: saveResourceConflicts
+  })
+
+  // Register onboarding_offboarding module (Phase 3 - Resources)
+  const { extractOnboardingOffboarding, saveOnboardingOffboarding } = await import('./entities/onboarding_offboarding')
+  extractionRegistry.register('onboarding_offboarding', {
+    extract: extractOnboardingOffboarding,
+    save: saveOnboardingOffboarding
+  })
+
   // Register risk_appetite module (Phase 3 - Risk Extensions)
   const { extractRiskAppetite, saveRiskAppetite } = await import('./entities/risk_appetite')
   extractionRegistry.register('risk_appetite', {
@@ -517,6 +566,48 @@ export async function initializeRegistry(): Promise<void> {
   extractionRegistry.register('probability_impact_matrix', {
     extract: extractProbabilityImpactMatrix,
     save: saveProbabilityImpactMatrix
+  })
+
+  // Register risk_assessments module (Phase 3 - Risk Extensions)
+  const { extractRiskAssessments, saveRiskAssessments } = await import('./entities/risk_assessments')
+  extractionRegistry.register('risk_assessments', {
+    extract: extractRiskAssessments,
+    save: saveRiskAssessments
+  })
+
+  // Register risk_response_plans module (Phase 3 - Risk Extensions)
+  const { extractRiskResponsePlans, saveRiskResponsePlans } = await import('./entities/risk_response_plans')
+  extractionRegistry.register('risk_response_plans', {
+    extract: extractRiskResponsePlans,
+    save: saveRiskResponsePlans
+  })
+
+  // Register risk_triggers module (Phase 3 - Risk Extensions)
+  const { extractRiskTriggers, saveRiskTriggers } = await import('./entities/risk_triggers')
+  extractionRegistry.register('risk_triggers', {
+    extract: extractRiskTriggers,
+    save: saveRiskTriggers
+  })
+
+  // Register risk_reviews module (Phase 3 - Risk Extensions)
+  const { extractRiskReviews, saveRiskReviews } = await import('./entities/risk_reviews')
+  extractionRegistry.register('risk_reviews', {
+    extract: extractRiskReviews,
+    save: saveRiskReviews
+  })
+
+  // Register contingency_reserves module (Phase 3 - Risk Extensions)
+  const { extractContingencyReserves, saveContingencyReserves } = await import('./entities/contingency_reserves')
+  extractionRegistry.register('contingency_reserves', {
+    extract: extractContingencyReserves,
+    save: saveContingencyReserves
+  })
+
+  // Register risk_metrics module (Phase 3 - Risk Extensions)
+  const { extractRiskMetrics, saveRiskMetrics } = await import('./entities/risk_metrics')
+  extractionRegistry.register('risk_metrics', {
+    extract: extractRiskMetrics,
+    save: saveRiskMetrics
   })
 
   // Register issue_log module (Phase 3 - Issues)
@@ -545,6 +636,34 @@ export async function initializeRegistry(): Promise<void> {
   extractionRegistry.register('communication_logs', {
     extract: extractCommunicationLogs,
     save: saveCommunicationLogs
+  })
+
+  // Register engagement_actions module (Phase 4 - Stakeholder Ops)
+  const { extractEngagementActions, saveEngagementActions } = await import('./entities/engagement_actions')
+  extractionRegistry.register('engagement_actions', {
+    extract: extractEngagementActions,
+    save: saveEngagementActions
+  })
+
+  // Register satisfaction_surveys module (Phase 4 - Stakeholder Ops)
+  const { extractSatisfactionSurveys, saveSatisfactionSurveys } = await import('./entities/satisfaction_surveys')
+  extractionRegistry.register('satisfaction_surveys', {
+    extract: extractSatisfactionSurveys,
+    save: saveSatisfactionSurveys
+  })
+
+  // Register stakeholder_issues module (Phase 4 - Stakeholder Ops)
+  const { extractStakeholderIssues, saveStakeholderIssues } = await import('./entities/stakeholder_issues')
+  extractionRegistry.register('stakeholder_issues', {
+    extract: extractStakeholderIssues,
+    save: saveStakeholderIssues
+  })
+
+  // Register relationship_health module (Phase 4 - Stakeholder Ops)
+  const { extractRelationshipHealth, saveRelationshipHealth } = await import('./entities/relationship_health')
+  extractionRegistry.register('relationship_health', {
+    extract: extractRelationshipHealth,
+    save: saveRelationshipHealth
   })
 
   // Register action_items module (Phase 4 - Stakeholder Ops)
@@ -637,11 +756,18 @@ export async function initializeRegistry(): Promise<void> {
   extractionRegistry.setFeatureFlagFromEnv('schedule_variances')
   extractionRegistry.setFeatureFlagFromEnv('schedule_forecasts')
   extractionRegistry.setFeatureFlagFromEnv('budget_baseline')
+  extractionRegistry.setFeatureFlagFromEnv('cost_actuals')
   extractionRegistry.setFeatureFlagFromEnv('cost_estimates')
   extractionRegistry.setFeatureFlagFromEnv('funding_tranches')
   extractionRegistry.setFeatureFlagFromEnv('financial_variances')
   extractionRegistry.setFeatureFlagFromEnv('procurement_costs')
   extractionRegistry.setFeatureFlagFromEnv('resource_plans')
+  extractionRegistry.setFeatureFlagFromEnv('resource_assignments')
+  extractionRegistry.setFeatureFlagFromEnv('resource_pool')
+  extractionRegistry.setFeatureFlagFromEnv('capacity_forecasts')
+  extractionRegistry.setFeatureFlagFromEnv('utilization_records')
+  extractionRegistry.setFeatureFlagFromEnv('resource_conflicts')
+  extractionRegistry.setFeatureFlagFromEnv('onboarding_offboarding')
   extractionRegistry.setFeatureFlagFromEnv('roles_and_responsibilities')
   extractionRegistry.setFeatureFlagFromEnv('team_availability')
   extractionRegistry.setFeatureFlagFromEnv('labor_rates')
@@ -649,10 +775,20 @@ export async function initializeRegistry(): Promise<void> {
   extractionRegistry.setFeatureFlagFromEnv('risk_appetite')
   extractionRegistry.setFeatureFlagFromEnv('risk_checklists')
   extractionRegistry.setFeatureFlagFromEnv('probability_impact_matrix')
+  extractionRegistry.setFeatureFlagFromEnv('risk_assessments')
+  extractionRegistry.setFeatureFlagFromEnv('risk_response_plans')
+  extractionRegistry.setFeatureFlagFromEnv('risk_triggers')
+  extractionRegistry.setFeatureFlagFromEnv('risk_reviews')
+  extractionRegistry.setFeatureFlagFromEnv('contingency_reserves')
+  extractionRegistry.setFeatureFlagFromEnv('risk_metrics')
   extractionRegistry.setFeatureFlagFromEnv('issue_log')
   extractionRegistry.setFeatureFlagFromEnv('lessons_learned')
   extractionRegistry.setFeatureFlagFromEnv('stakeholder_engagements')
   extractionRegistry.setFeatureFlagFromEnv('communication_logs')
+  extractionRegistry.setFeatureFlagFromEnv('engagement_actions')
+  extractionRegistry.setFeatureFlagFromEnv('satisfaction_surveys')
+  extractionRegistry.setFeatureFlagFromEnv('stakeholder_issues')
+  extractionRegistry.setFeatureFlagFromEnv('relationship_health')
   extractionRegistry.setFeatureFlagFromEnv('action_items')
   extractionRegistry.setFeatureFlagFromEnv('meeting_minutes')
   extractionRegistry.setFeatureFlagFromEnv('project_charter_details')

--- a/server/src/services/extraction/entities/capacity_forecasts/index.ts
+++ b/server/src/services/extraction/entities/capacity_forecasts/index.ts
@@ -1,0 +1,224 @@
+/**
+ * Capacity Forecasts Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface CapacityForecast {
+  period?: string
+  role?: string
+  available_hours?: number | null
+  demand_hours?: number | null
+  gap_hours?: number | null
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractCapacityForecasts(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<CapacityForecast>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-CAPACITY-FORECASTS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'capacity_forecasts',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-CAPACITY-FORECASTS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "capacity_forecasts": [
+    {
+      "period": "YYYY-MM",
+      "role": "Role or skill group",
+      "available_hours": 320,
+      "demand_hours": 360,
+      "gap_hours": 40,
+      "notes": "Any capacity constraints or mitigation notes",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Include capacity forecasts by period and role',
+      'Provide available and demand hours as numbers',
+      'Include gap_hours when possible'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'capacity_forecasts',
+      'capacity forecasts by period and role',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.capacity_forecasts || []
+
+    const normalized: CapacityForecast[] = rawEntities.map((entity: CapacityForecast) => ({
+      ...entity,
+      available_hours: coerceNumber(entity?.available_hours),
+      demand_hours: coerceNumber(entity?.demand_hours),
+      gap_hours: coerceNumber(entity?.gap_hours)
+    }))
+
+    const validEntities: CapacityForecast[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'CAPACITY-FORECASTS',
+        entity.role || entity.period || 'Capacity Forecast'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'capacity_forecasts',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-CAPACITY-FORECASTS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveCapacityForecasts(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: CapacityForecast[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM capacity_forecasts WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 9
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9})`
+      )
+
+      values.push(
+        projectId,
+        e.period || null,
+        e.role || null,
+        e.available_hours ?? null,
+        e.demand_hours ?? null,
+        e.gap_hours ?? null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO capacity_forecasts (
+        project_id, period, role, available_hours, demand_hours, gap_hours,
+        notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-CAPACITY-FORECASTS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/contingency_reserves/index.ts
+++ b/server/src/services/extraction/entities/contingency_reserves/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Contingency Reserves Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface ContingencyReserve {
+  category?: string
+  reserve_type?: string
+  allocated_to?: string
+  amount?: number | null
+  remaining_amount?: number | null
+  utilization?: number | null
+  approval_date?: string
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractContingencyReserves(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<ContingencyReserve>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-CONTINGENCY-RESERVES] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'contingency_reserves',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-CONTINGENCY-RESERVES] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "contingency_reserves": [
+    {
+      "category": "Cost|Schedule|Technical",
+      "reserve_type": "contingency|management",
+      "allocated_to": "Risk category or WBS element",
+      "amount": 25000,
+      "remaining_amount": 18000,
+      "utilization": 70,
+      "approval_date": "YYYY-MM-DD",
+      "notes": "Usage conditions or constraints",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture reserve amount and remaining amount when available',
+      'Include allocation target and reserve type',
+      'Include approval date if specified'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'contingency_reserves',
+      'contingency reserves with allocation details',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.contingency_reserves || []
+
+    const normalized: ContingencyReserve[] = rawEntities.map((entity: ContingencyReserve) => ({
+      ...entity,
+      amount: coerceNumber(entity?.amount),
+      remaining_amount: coerceNumber(entity?.remaining_amount),
+      utilization: coerceNumber(entity?.utilization)
+    }))
+
+    const validEntities: ContingencyReserve[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'CONTINGENCY-RESERVES',
+        entity.category || 'Contingency Reserve'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'contingency_reserves',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-CONTINGENCY-RESERVES] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveContingencyReserves(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: ContingencyReserve[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM contingency_reserves WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.category || null,
+        e.reserve_type || null,
+        e.allocated_to || null,
+        e.amount ?? null,
+        e.remaining_amount ?? null,
+        e.utilization ?? null,
+        e.approval_date || null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO contingency_reserves (
+        project_id, category, reserve_type, allocated_to, amount, remaining_amount,
+        utilization, approval_date, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-CONTINGENCY-RESERVES] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/cost_actuals/index.ts
+++ b/server/src/services/extraction/entities/cost_actuals/index.ts
@@ -1,0 +1,234 @@
+/**
+ * Cost Actuals Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface CostActual {
+  period?: string
+  category?: string
+  wbs_code?: string
+  planned_amount?: number | null
+  actual_amount?: number | null
+  variance?: number | null
+  variance_pct?: number | null
+  cumulative_actual?: number | null
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractCostActuals(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<CostActual>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-COST-ACTUALS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'cost_actuals',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-COST-ACTUALS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "cost_actuals": [
+    {
+      "period": "YYYY-MM or YYYY-MM-DD",
+      "category": "Labor|Materials|Software|Equipment|Overhead",
+      "wbs_code": "1.2.3",
+      "planned_amount": 10000,
+      "actual_amount": 12000,
+      "variance": 2000,
+      "variance_pct": 20,
+      "cumulative_actual": 45000,
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Extract actual costs by period and category',
+      'Include WBS codes when provided',
+      'Compute variance and variance_pct if both planned and actual are present',
+      'Use numbers for all amounts'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'cost_actuals',
+      'cost actuals by period and category',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.1,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.cost_actuals || []
+
+    const normalized: CostActual[] = rawEntities.map((entity: CostActual) => ({
+      ...entity,
+      planned_amount: coerceNumber(entity?.planned_amount),
+      actual_amount: coerceNumber(entity?.actual_amount),
+      variance: coerceNumber(entity?.variance),
+      variance_pct: coerceNumber(entity?.variance_pct),
+      cumulative_actual: coerceNumber(entity?.cumulative_actual)
+    }))
+
+    const validEntities: CostActual[] = []
+
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'COST-ACTUALS',
+        entity.category || 'Cost Actual'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'cost_actuals',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-COST-ACTUALS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveCostActuals(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: CostActual[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM cost_actuals WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.period || null,
+        e.category || null,
+        e.wbs_code || null,
+        e.planned_amount ?? null,
+        e.actual_amount ?? null,
+        e.variance ?? null,
+        e.variance_pct ?? null,
+        e.cumulative_actual ?? null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO cost_actuals (
+        project_id, period, category, wbs_code, planned_amount, actual_amount,
+        variance, variance_pct, cumulative_actual, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-COST-ACTUALS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/engagement_actions/index.ts
+++ b/server/src/services/extraction/entities/engagement_actions/index.ts
@@ -1,0 +1,241 @@
+/**
+ * Engagement Actions Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface EngagementAction {
+  action_id?: string
+  stakeholder_id?: string
+  stakeholder_name?: string
+  action_type?: string
+  description?: string
+  planned_date?: string
+  actual_date?: string
+  outcome?: string
+  follow_up_required?: boolean
+  status?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+function normalizeBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value
+  if (value === null || value === undefined) return false
+  const normalized = String(value).trim().toLowerCase()
+  return ['true', 'yes', 'y', '1'].includes(normalized)
+}
+
+export async function extractEngagementActions(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<EngagementAction>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-ENGAGEMENT-ACTIONS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'engagement_actions',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-ENGAGEMENT-ACTIONS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "engagement_actions": [
+    {
+      "action_id": "Action identifier",
+      "stakeholder_id": "Stakeholder ID",
+      "stakeholder_name": "Stakeholder name",
+      "action_type": "Workshop|Interview|Status Update|Survey",
+      "description": "Action description",
+      "planned_date": "YYYY-MM-DD",
+      "actual_date": "YYYY-MM-DD",
+      "outcome": "Outcome summary",
+      "follow_up_required": true,
+      "status": "planned|completed|blocked",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture engagement actions with outcomes',
+      'Include planned and actual dates when available',
+      'Specify whether follow-up is required'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'engagement_actions',
+      'stakeholder engagement actions with outcomes',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.engagement_actions || []
+
+    const normalized: EngagementAction[] = rawEntities.map((entity: EngagementAction) => ({
+      ...entity,
+      follow_up_required: normalizeBoolean(entity?.follow_up_required)
+    }))
+
+    const validEntities: EngagementAction[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'ENGAGEMENT-ACTIONS',
+        entity.action_type || entity.action_id || 'Engagement Action'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'engagement_actions',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-ENGAGEMENT-ACTIONS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveEngagementActions(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: EngagementAction[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM engagement_actions WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 13
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13})`
+      )
+
+      values.push(
+        projectId,
+        e.action_id || null,
+        e.stakeholder_id || null,
+        e.stakeholder_name || null,
+        e.action_type || null,
+        e.description || null,
+        e.planned_date || null,
+        e.actual_date || null,
+        e.outcome || null,
+        e.follow_up_required ?? false,
+        e.status || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO engagement_actions (
+        project_id, action_id, stakeholder_id, stakeholder_name, action_type, description,
+        planned_date, actual_date, outcome, follow_up_required, status, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-ENGAGEMENT-ACTIONS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/onboarding_offboarding/index.ts
+++ b/server/src/services/extraction/entities/onboarding_offboarding/index.ts
@@ -1,0 +1,223 @@
+/**
+ * Onboarding/Offboarding Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface OnboardingOffboarding {
+  resource_id?: string
+  resource_name?: string
+  action_type?: 'onboarding' | 'offboarding'
+  start_date?: string
+  end_date?: string
+  status?: string
+  checklist_status?: string
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractOnboardingOffboarding(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<OnboardingOffboarding>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-ONBOARDING-OFFBOARDING] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'onboarding_offboarding',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-ONBOARDING-OFFBOARDING] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "onboarding_offboarding": [
+    {
+      "resource_id": "Resource ID",
+      "resource_name": "Resource name",
+      "action_type": "onboarding|offboarding",
+      "start_date": "YYYY-MM-DD",
+      "end_date": "YYYY-MM-DD",
+      "status": "planned|in_progress|completed",
+      "checklist_status": "complete|partial|not_started",
+      "notes": "Additional context",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture onboarding and offboarding plans with dates',
+      'Include checklist status or completion notes when available',
+      'Use action_type = onboarding or offboarding'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'onboarding_offboarding',
+      'onboarding and offboarding plans',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.onboarding_offboarding || []
+
+    const validEntities: OnboardingOffboarding[] = []
+    rawEntities.forEach((entity: OnboardingOffboarding) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'ONBOARDING-OFFBOARDING',
+        entity.resource_name || 'Onboarding/Offboarding'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'onboarding_offboarding',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: rawEntities.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-ONBOARDING-OFFBOARDING] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveOnboardingOffboarding(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: OnboardingOffboarding[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM onboarding_offboarding WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.resource_id || null,
+        e.resource_name || null,
+        e.action_type || null,
+        e.start_date || null,
+        e.end_date || null,
+        e.status || null,
+        e.checklist_status || null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO onboarding_offboarding (
+        project_id, resource_id, resource_name, action_type, start_date, end_date,
+        status, checklist_status, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-ONBOARDING-OFFBOARDING] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/relationship_health/index.ts
+++ b/server/src/services/extraction/entities/relationship_health/index.ts
@@ -1,0 +1,229 @@
+/**
+ * Relationship Health Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RelationshipHealth {
+  stakeholder_id?: string
+  stakeholder_name?: string
+  assessment_date?: string
+  health_score?: number | null
+  health_status?: string
+  indicators?: string[]
+  trend?: string
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRelationshipHealth(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RelationshipHealth>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RELATIONSHIP-HEALTH] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'relationship_health',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RELATIONSHIP-HEALTH] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "relationship_health": [
+    {
+      "stakeholder_id": "Stakeholder ID",
+      "stakeholder_name": "Stakeholder name",
+      "assessment_date": "YYYY-MM-DD",
+      "health_score": 78,
+      "health_status": "good|fair|poor",
+      "indicators": ["Trust", "Responsiveness"],
+      "trend": "improving|stable|declining",
+      "notes": "Assessment notes",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Provide relationship health score or status when available',
+      'Include indicators or reasons for the health assessment',
+      'Include assessment date if provided'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'relationship_health',
+      'relationship health assessments',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.relationship_health || []
+
+    const normalized: RelationshipHealth[] = rawEntities.map((entity: RelationshipHealth) => ({
+      ...entity,
+      health_score: coerceNumber(entity?.health_score),
+      indicators: coerceArray<string>(entity?.indicators)
+    }))
+
+    const validEntities: RelationshipHealth[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RELATIONSHIP-HEALTH',
+        entity.stakeholder_name || entity.stakeholder_id || 'Relationship Health'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'relationship_health',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RELATIONSHIP-HEALTH] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRelationshipHealth(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RelationshipHealth[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM relationship_health WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.stakeholder_id || null,
+        e.stakeholder_name || null,
+        e.assessment_date || null,
+        e.health_score ?? null,
+        e.health_status || null,
+        e.indicators || [],
+        e.trend || null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO relationship_health (
+        project_id, stakeholder_id, stakeholder_name, assessment_date, health_score,
+        health_status, indicators, trend, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RELATIONSHIP-HEALTH] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/resource_assignments/index.ts
+++ b/server/src/services/extraction/entities/resource_assignments/index.ts
@@ -1,0 +1,232 @@
+/**
+ * Resource Assignments Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface ResourceAssignment {
+  resource_id?: string
+  resource_name?: string
+  activity_id?: string
+  activity_name?: string
+  allocation_pct?: number | null
+  start_date?: string
+  end_date?: string
+  skill_required?: string
+  skill_level?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractResourceAssignments(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<ResourceAssignment>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RESOURCE-ASSIGNMENTS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'resource_assignments',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RESOURCE-ASSIGNMENTS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "resource_assignments": [
+    {
+      "resource_id": "Resource ID or name",
+      "resource_name": "Resource name",
+      "activity_id": "Activity ID",
+      "activity_name": "Activity name",
+      "allocation_pct": 50,
+      "start_date": "YYYY-MM-DD",
+      "end_date": "YYYY-MM-DD",
+      "skill_required": "Skill required",
+      "skill_level": "Junior|Intermediate|Senior|Expert",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Map resources to activities with allocation percentages',
+      'Include skill requirements or levels when mentioned',
+      'Provide start and end dates when available'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'resource_assignments',
+      'resource assignments to activities',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.resource_assignments || []
+
+    const normalized: ResourceAssignment[] = rawEntities.map((entity: ResourceAssignment) => ({
+      ...entity,
+      allocation_pct: coerceNumber(entity?.allocation_pct)
+    }))
+
+    const validEntities: ResourceAssignment[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RESOURCE-ASSIGNMENTS',
+        entity.activity_name || entity.resource_name || 'Resource Assignment'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'resource_assignments',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-ASSIGNMENTS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveResourceAssignments(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: ResourceAssignment[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM resource_assignments WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 12
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
+      )
+
+      values.push(
+        projectId,
+        e.resource_id || null,
+        e.resource_name || null,
+        e.activity_id || null,
+        e.activity_name || null,
+        e.allocation_pct ?? null,
+        e.start_date || null,
+        e.end_date || null,
+        e.skill_required || null,
+        e.skill_level || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO resource_assignments (
+        project_id, resource_id, resource_name, activity_id, activity_name,
+        allocation_pct, start_date, end_date, skill_required, skill_level,
+        source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-ASSIGNMENTS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/resource_conflicts/index.ts
+++ b/server/src/services/extraction/entities/resource_conflicts/index.ts
@@ -1,0 +1,228 @@
+/**
+ * Resource Conflicts Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface ResourceConflict {
+  resource_id?: string
+  resource_name?: string
+  conflict_type?: string
+  conflict_description?: string
+  impacted_activities?: string[]
+  severity?: string
+  resolution?: string
+  resolution_date?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractResourceConflicts(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<ResourceConflict>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RESOURCE-CONFLICTS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'resource_conflicts',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RESOURCE-CONFLICTS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "resource_conflicts": [
+    {
+      "resource_id": "Resource ID",
+      "resource_name": "Resource name",
+      "conflict_type": "Overallocated|Schedule Clash|Skill Gap",
+      "conflict_description": "Description of the conflict",
+      "impacted_activities": ["Activity A", "Activity B"],
+      "severity": "Low|Medium|High",
+      "resolution": "Resolution or mitigation plan",
+      "resolution_date": "YYYY-MM-DD",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'List resource conflicts and overallocation issues',
+      'Include impacted activities when available',
+      'Capture severity and resolution details'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'resource_conflicts',
+      'resource conflicts and overallocation issues',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.resource_conflicts || []
+
+    const normalized: ResourceConflict[] = rawEntities.map((entity: ResourceConflict) => ({
+      ...entity,
+      impacted_activities: coerceArray<string>(entity?.impacted_activities)
+    }))
+
+    const validEntities: ResourceConflict[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RESOURCE-CONFLICTS',
+        entity.resource_name || entity.conflict_type || 'Resource Conflict'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'resource_conflicts',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-CONFLICTS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveResourceConflicts(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: ResourceConflict[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM resource_conflicts WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.resource_id || null,
+        e.resource_name || null,
+        e.conflict_type || null,
+        e.conflict_description || null,
+        e.impacted_activities || [],
+        e.severity || null,
+        e.resolution || null,
+        e.resolution_date || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO resource_conflicts (
+        project_id, resource_id, resource_name, conflict_type, conflict_description,
+        impacted_activities, severity, resolution, resolution_date, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-CONFLICTS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/resource_pool/index.ts
+++ b/server/src/services/extraction/entities/resource_pool/index.ts
@@ -1,0 +1,231 @@
+/**
+ * Resource Pool Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber, coerceArray } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface ResourcePoolEntry {
+  resource_name?: string
+  role?: string
+  resource_type?: string
+  skills?: string[]
+  availability_pct?: number | null
+  cost_rate?: number | null
+  capacity_hours?: number | null
+  location?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractResourcePool(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<ResourcePoolEntry>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RESOURCE-POOL] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'resource_pool',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RESOURCE-POOL] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "resource_pool": [
+    {
+      "resource_name": "Resource name",
+      "role": "Role or title",
+      "resource_type": "Human|Equipment|Contractor",
+      "skills": ["Skill 1", "Skill 2"],
+      "availability_pct": 75,
+      "cost_rate": 120,
+      "capacity_hours": 160,
+      "location": "Location or timezone",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'List available resources with roles and skills',
+      'Include availability percentages or capacity hours when provided',
+      'Capture cost rates if available'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'resource_pool',
+      'resource pool entries with skills and availability',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.resource_pool || []
+
+    const normalized: ResourcePoolEntry[] = rawEntities.map((entity: ResourcePoolEntry) => ({
+      ...entity,
+      skills: coerceArray<string>(entity?.skills),
+      availability_pct: coerceNumber(entity?.availability_pct),
+      cost_rate: coerceNumber(entity?.cost_rate),
+      capacity_hours: coerceNumber(entity?.capacity_hours)
+    }))
+
+    const validEntities: ResourcePoolEntry[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RESOURCE-POOL',
+        entity.resource_name || 'Resource'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'resource_pool',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-POOL] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveResourcePool(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: ResourcePoolEntry[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM resource_pool WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.resource_name || null,
+        e.role || null,
+        e.resource_type || null,
+        e.skills || [],
+        e.availability_pct ?? null,
+        e.cost_rate ?? null,
+        e.capacity_hours ?? null,
+        e.location || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO resource_pool (
+        project_id, resource_name, role, resource_type, skills,
+        availability_pct, cost_rate, capacity_hours, location, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RESOURCE-POOL] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/risk_assessments/index.ts
+++ b/server/src/services/extraction/entities/risk_assessments/index.ts
@@ -180,38 +180,93 @@ export async function saveRiskAssessments(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_assessments'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pickColumn = (options: string[]): string | null => {
+      for (const option of options) {
+        if (columnSet.has(option)) {
+          return option
+        }
+      }
+      return null
+    }
+
+    const riskIdColumn = pickColumn(['risk_id', 'risk_identifier'])
+    const riskTitleColumn = pickColumn(['risk_title', 'risk_name', 'title'])
+    const assessmentDateColumn = pickColumn(['assessment_date', 'assessed_at', 'review_date'])
+    const probabilityColumn = pickColumn(['probability', 'likelihood'])
+    const impactColumn = pickColumn(['impact'])
+    const detectabilityColumn = pickColumn(['detectability', 'detection_score'])
+    const rpnColumn = pickColumn(['rpn', 'risk_priority_number'])
+    const assessorColumn = pickColumn(['assessor', 'assessed_by'])
+    const notesColumn = pickColumn(['notes', 'assessment_notes'])
+    const sourceDocumentColumn = pickColumn(['source_document_id'])
+    const createdByColumn = pickColumn(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (entity: RiskAssessment) => any }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+
+    if (riskIdColumn) {
+      columnOrder.push({ name: riskIdColumn, value: (e) => e.risk_id || null })
+    }
+    if (riskTitleColumn) {
+      columnOrder.push({ name: riskTitleColumn, value: (e) => e.risk_title || null })
+    }
+    if (assessmentDateColumn) {
+      columnOrder.push({ name: assessmentDateColumn, value: (e) => e.assessment_date || null })
+    }
+    if (probabilityColumn) {
+      columnOrder.push({ name: probabilityColumn, value: (e) => e.probability || null })
+    }
+    if (impactColumn) {
+      columnOrder.push({ name: impactColumn, value: (e) => e.impact || null })
+    }
+    if (detectabilityColumn) {
+      columnOrder.push({ name: detectabilityColumn, value: (e) => e.detectability ?? null })
+    }
+    if (rpnColumn) {
+      columnOrder.push({ name: rpnColumn, value: (e) => e.rpn ?? null })
+    }
+    if (assessorColumn) {
+      columnOrder.push({ name: assessorColumn, value: (e) => e.assessor || null })
+    }
+    if (notesColumn) {
+      columnOrder.push({ name: notesColumn, value: (e) => e.notes || null })
+    }
+    if (sourceDocumentColumn) {
+      columnOrder.push({ name: sourceDocumentColumn, value: (e) => e.source_document_id || null })
+    }
+    if (createdByColumn) {
+      columnOrder.push({ name: createdByColumn, value: () => userId })
+    }
+
+    if (columnOrder.length === 0) {
+      throw new Error('risk_assessments table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_assessments WHERE project_id = $1', [projectId])
 
     const values: any[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 12
-      placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
-      )
-
-      values.push(
-        projectId,
-        e.risk_id || null,
-        e.risk_title || null,
-        e.assessment_date || null,
-        e.probability || null,
-        e.impact || null,
-        e.detectability ?? null,
-        e.rpn ?? null,
-        e.assessor || null,
-        e.notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      const offset = index * columnOrder.length
+      const rowPlaceholders = columnOrder.map((_, columnIndex) => `$${offset + columnIndex + 1}`)
+      placeholders.push(`(${rowPlaceholders.join(', ')})`)
+      columnOrder.forEach(column => {
+        values.push(column.value(e))
+      })
     })
 
     await client.query(
-      `INSERT INTO risk_assessments (
-        project_id, risk_id, risk_title, assessment_date, probability,
-        impact, detectability, rpn, assessor, notes, source_document_id, created_by
-      )
+      `INSERT INTO risk_assessments (${columnOrder.map(col => col.name).join(', ')})
       VALUES ${placeholders.join(', ')}`,
       values
     )

--- a/server/src/services/extraction/entities/risk_assessments/index.ts
+++ b/server/src/services/extraction/entities/risk_assessments/index.ts
@@ -169,6 +169,18 @@ export async function extractRiskAssessments(
   }
 }
 
+const PROB_IMPACT = new Set(['very_high', 'high', 'medium', 'low', 'very_low'])
+
+function normalizeProbImpact(v: unknown): string | null {
+  if (!v) return null
+  const s = String(v).toLowerCase().trim().replace(/\s+/g, '_')
+  if (PROB_IMPACT.has(s)) return s
+  const map: Record<string, string> = {
+    veryhigh: 'very_high', verylow: 'very_low'
+  }
+  return map[s] ?? null
+}
+
 export async function saveRiskAssessments(
   client: PoolClient,
   projectId: string,
@@ -180,39 +192,100 @@ export async function saveRiskAssessments(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_assessments'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pick = (opts: string[]) => opts.find(c => columnSet.has(c)) ?? null
+
+    const assessmentDateCol = pick(['assessment_date', 'assessed_at'])
+    const probabilityCol = pick(['probability'])
+    const impactCol = pick(['impact'])
+    const assessorCol = pick(['assessor'])
+    const riskIdCol = pick(['risk_id'])
+    const riskScoreCol = pick(['risk_score'])
+    const detectabilityCol = pick(['detectability'])
+    const rpnCol = pick(['rpn'])
+    const riskLevelCol = pick(['risk_level'])
+    const methodologyCol = pick(['assessment_methodology', 'methodology', 'notes'])
+    const assumptionsCol = pick(['assumptions'])
+    const sourceDocCol = pick(['source_document_id'])
+    const createdByCol = pick(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (e: RiskAssessment) => unknown }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+    if (assessmentDateCol) {
+      columnOrder.push({
+        name: assessmentDateCol,
+        value: (e) => e.assessment_date || new Date().toISOString().split('T')[0]
+      })
+    }
+    if (probabilityCol) {
+      columnOrder.push({
+        name: probabilityCol,
+        value: (e) => normalizeProbImpact(e.probability) ?? 'medium'
+      })
+    }
+    if (impactCol) {
+      columnOrder.push({
+        name: impactCol,
+        value: (e) => normalizeProbImpact(e.impact) ?? 'medium'
+      })
+    }
+    if (assessorCol) columnOrder.push({ name: assessorCol, value: (e) => e.assessor || null })
+    if (riskIdCol) {
+      columnOrder.push({
+        name: riskIdCol,
+        value: (e) => {
+          const v = e.risk_id
+          if (!v) return null
+          const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+          return typeof v === 'string' && uuid.test(v) ? v : null
+        }
+      })
+    }
+    if (riskScoreCol) columnOrder.push({ name: riskScoreCol, value: (e) => e.rpn ?? null })
+    if (detectabilityCol) {
+      columnOrder.push({
+        name: detectabilityCol,
+        value: (e) => {
+          if (typeof e.detectability === 'number') return null
+          return normalizeProbImpact(e.detectability as string) ?? null
+        }
+      })
+    }
+    if (rpnCol) columnOrder.push({ name: rpnCol, value: (e) => (typeof e.rpn === 'number' ? e.rpn : null) })
+    if (riskLevelCol) columnOrder.push({ name: riskLevelCol, value: () => null })
+    if (methodologyCol) columnOrder.push({ name: methodologyCol, value: (e) => e.notes || null })
+    if (assumptionsCol) columnOrder.push({ name: assumptionsCol, value: () => [] })
+    if (sourceDocCol) columnOrder.push({ name: sourceDocCol, value: (e) => e.source_document_id || null })
+    if (createdByCol) columnOrder.push({ name: createdByCol, value: () => userId })
+
+    if (columnOrder.length <= 1) {
+      throw new Error('risk_assessments table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_assessments WHERE project_id = $1', [projectId])
 
-    const values: any[] = []
+    const values: unknown[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 12
+      const offset = index * columnOrder.length
       placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
+        columnOrder.map((_, i) => `$${offset + i + 1}`).join(', ')
       )
-
-      values.push(
-        projectId,
-        e.risk_id || null,
-        e.risk_title || null,
-        e.assessment_date || null,
-        e.probability || null,
-        e.impact || null,
-        e.detectability ?? null,
-        e.rpn ?? null,
-        e.assessor || null,
-        e.notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      columnOrder.forEach(col => values.push(col.value(e)))
     })
 
     await client.query(
-      `INSERT INTO risk_assessments (
-        project_id, risk_id, risk_title, assessment_date, probability,
-        impact, detectability, rpn, assessor, notes, source_document_id, created_by
-      )
-      VALUES ${placeholders.join(', ')}`,
+      `INSERT INTO risk_assessments (${columnOrder.map(c => c.name).join(', ')})
+       VALUES ${placeholders.map(p => `(${p})`).join(', ')}`,
       values
     )
 

--- a/server/src/services/extraction/entities/risk_assessments/index.ts
+++ b/server/src/services/extraction/entities/risk_assessments/index.ts
@@ -1,0 +1,232 @@
+/**
+ * Risk Assessments Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RiskAssessment {
+  risk_id?: string
+  risk_title?: string
+  assessment_date?: string
+  probability?: string
+  impact?: string
+  detectability?: number | null
+  rpn?: number | null
+  assessor?: string
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRiskAssessments(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RiskAssessment>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RISK-ASSESSMENTS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'risk_assessments',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RISK-ASSESSMENTS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "risk_assessments": [
+    {
+      "risk_id": "Risk identifier",
+      "risk_title": "Risk title",
+      "assessment_date": "YYYY-MM-DD",
+      "probability": "Low|Medium|High",
+      "impact": "Low|Medium|High",
+      "detectability": 5,
+      "rpn": 120,
+      "assessor": "Name or role",
+      "notes": "Assessment notes",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture probability, impact, and detectability for each assessed risk',
+      'Provide a risk priority number (RPN) when possible',
+      'Include assessment date if provided'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'risk_assessments',
+      'risk assessments with probability, impact, and RPN',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.risk_assessments || []
+
+    const normalized: RiskAssessment[] = rawEntities.map((entity: RiskAssessment) => ({
+      ...entity,
+      detectability: coerceNumber(entity?.detectability),
+      rpn: coerceNumber(entity?.rpn)
+    }))
+
+    const validEntities: RiskAssessment[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RISK-ASSESSMENTS',
+        entity.risk_title || entity.risk_id || 'Risk Assessment'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'risk_assessments',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-ASSESSMENTS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRiskAssessments(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RiskAssessment[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM risk_assessments WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 12
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
+      )
+
+      values.push(
+        projectId,
+        e.risk_id || null,
+        e.risk_title || null,
+        e.assessment_date || null,
+        e.probability || null,
+        e.impact || null,
+        e.detectability ?? null,
+        e.rpn ?? null,
+        e.assessor || null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO risk_assessments (
+        project_id, risk_id, risk_title, assessment_date, probability,
+        impact, detectability, rpn, assessor, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-ASSESSMENTS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/risk_metrics/index.ts
+++ b/server/src/services/extraction/entities/risk_metrics/index.ts
@@ -1,0 +1,228 @@
+/**
+ * Risk Metrics Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RiskMetric {
+  measurement_date?: string
+  exposure_index?: number | null
+  new_risks?: number | null
+  closed_risks?: number | null
+  trend?: string
+  top_categories?: string[]
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRiskMetrics(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RiskMetric>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RISK-METRICS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'risk_metrics',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RISK-METRICS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "risk_metrics": [
+    {
+      "measurement_date": "YYYY-MM-DD",
+      "exposure_index": 0.42,
+      "new_risks": 3,
+      "closed_risks": 1,
+      "trend": "improving|stable|declining",
+      "top_categories": ["Schedule", "Technical"],
+      "notes": "Context for risk metrics",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Include exposure index and trend when provided',
+      'Capture new and closed risk counts',
+      'List top risk categories if mentioned'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'risk_metrics',
+      'risk metrics and trend indicators',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.risk_metrics || []
+
+    const normalized: RiskMetric[] = rawEntities.map((entity: RiskMetric) => ({
+      ...entity,
+      exposure_index: coerceNumber(entity?.exposure_index),
+      new_risks: coerceNumber(entity?.new_risks),
+      closed_risks: coerceNumber(entity?.closed_risks),
+      top_categories: coerceArray<string>(entity?.top_categories)
+    }))
+
+    const validEntities: RiskMetric[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RISK-METRICS',
+        entity.measurement_date || 'Risk Metrics'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'risk_metrics',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-METRICS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRiskMetrics(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RiskMetric[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM risk_metrics WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 10
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10})`
+      )
+
+      values.push(
+        projectId,
+        e.measurement_date || null,
+        e.exposure_index ?? null,
+        e.new_risks ?? null,
+        e.closed_risks ?? null,
+        e.trend || null,
+        e.top_categories || [],
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO risk_metrics (
+        project_id, measurement_date, exposure_index, new_risks, closed_risks,
+        trend, top_categories, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-METRICS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/risk_metrics/index.ts
+++ b/server/src/services/extraction/entities/risk_metrics/index.ts
@@ -178,36 +178,95 @@ export async function saveRiskMetrics(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_metrics'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pickColumn = (options: string[]): string | null => {
+      for (const option of options) {
+        if (columnSet.has(option)) {
+          return option
+        }
+      }
+      return null
+    }
+
+    const measurementDateColumn = pickColumn([
+      'measurement_date',
+      'report_date',
+      'as_of_date',
+      'recorded_at',
+      'metric_date'
+    ])
+    const exposureIndexColumn = pickColumn([
+      'exposure_index',
+      'risk_exposure_index',
+      'exposure_score'
+    ])
+    const newRisksColumn = pickColumn(['new_risks', 'new_risk_count'])
+    const closedRisksColumn = pickColumn(['closed_risks', 'closed_risk_count'])
+    const trendColumn = pickColumn(['trend', 'trend_direction'])
+    const topCategoriesColumn = pickColumn(['top_categories', 'categories', 'risk_categories'])
+    const notesColumn = pickColumn(['notes', 'commentary', 'details'])
+    const sourceDocumentColumn = pickColumn(['source_document_id'])
+    const createdByColumn = pickColumn(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (entity: RiskMetric) => any }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+
+    if (measurementDateColumn) {
+      columnOrder.push({ name: measurementDateColumn, value: (e) => e.measurement_date || null })
+    }
+    if (exposureIndexColumn) {
+      columnOrder.push({ name: exposureIndexColumn, value: (e) => e.exposure_index ?? null })
+    }
+    if (newRisksColumn) {
+      columnOrder.push({ name: newRisksColumn, value: (e) => e.new_risks ?? null })
+    }
+    if (closedRisksColumn) {
+      columnOrder.push({ name: closedRisksColumn, value: (e) => e.closed_risks ?? null })
+    }
+    if (trendColumn) {
+      columnOrder.push({ name: trendColumn, value: (e) => e.trend || null })
+    }
+    if (topCategoriesColumn) {
+      columnOrder.push({ name: topCategoriesColumn, value: (e) => e.top_categories || [] })
+    }
+    if (notesColumn) {
+      columnOrder.push({ name: notesColumn, value: (e) => e.notes || null })
+    }
+    if (sourceDocumentColumn) {
+      columnOrder.push({ name: sourceDocumentColumn, value: (e) => e.source_document_id || null })
+    }
+    if (createdByColumn) {
+      columnOrder.push({ name: createdByColumn, value: () => userId })
+    }
+
+    if (columnOrder.length === 0) {
+      throw new Error('risk_metrics table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_metrics WHERE project_id = $1', [projectId])
 
     const values: any[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 10
-      placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10})`
-      )
-
-      values.push(
-        projectId,
-        e.measurement_date || null,
-        e.exposure_index ?? null,
-        e.new_risks ?? null,
-        e.closed_risks ?? null,
-        e.trend || null,
-        e.top_categories || [],
-        e.notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      const offset = index * columnOrder.length
+      const rowPlaceholders = columnOrder.map((_, columnIndex) => `$${offset + columnIndex + 1}`)
+      placeholders.push(`(${rowPlaceholders.join(', ')})`)
+      columnOrder.forEach(column => {
+        values.push(column.value(e))
+      })
     })
 
     await client.query(
-      `INSERT INTO risk_metrics (
-        project_id, measurement_date, exposure_index, new_risks, closed_risks,
-        trend, top_categories, notes, source_document_id, created_by
-      )
+      `INSERT INTO risk_metrics (${columnOrder.map(col => col.name).join(', ')})
       VALUES ${placeholders.join(', ')}`,
       values
     )

--- a/server/src/services/extraction/entities/risk_metrics/index.ts
+++ b/server/src/services/extraction/entities/risk_metrics/index.ts
@@ -220,7 +220,10 @@ export async function saveRiskMetrics(
     ]
 
     if (measurementDateColumn) {
-      columnOrder.push({ name: measurementDateColumn, value: (e) => e.measurement_date || null })
+      columnOrder.push({
+        name: measurementDateColumn,
+        value: (e) => e.measurement_date || new Date().toISOString().split('T')[0]
+      })
     }
     if (exposureIndexColumn) {
       columnOrder.push({ name: exposureIndexColumn, value: (e) => e.exposure_index ?? null })

--- a/server/src/services/extraction/entities/risk_response_plans/index.ts
+++ b/server/src/services/extraction/entities/risk_response_plans/index.ts
@@ -1,0 +1,232 @@
+/**
+ * Risk Response Plans Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RiskResponsePlan {
+  risk_id?: string
+  risk_title?: string
+  strategy?: string
+  actions?: string[]
+  owner?: string
+  due_date?: string
+  status?: string
+  cost_estimate?: number | null
+  residual_risk?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRiskResponsePlans(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RiskResponsePlan>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RISK-RESPONSE-PLANS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'risk_response_plans',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RISK-RESPONSE-PLANS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "risk_response_plans": [
+    {
+      "risk_id": "Risk identifier",
+      "risk_title": "Risk title",
+      "strategy": "Avoid|Mitigate|Transfer|Accept",
+      "actions": ["Action 1", "Action 2"],
+      "owner": "Owner name or role",
+      "due_date": "YYYY-MM-DD",
+      "status": "planned|in_progress|completed",
+      "cost_estimate": 5000,
+      "residual_risk": "Residual risk summary",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Include response strategy and concrete actions',
+      'Identify owners and due dates when available',
+      'Provide cost estimates when mentioned'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'risk_response_plans',
+      'risk response plans with actions and owners',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.risk_response_plans || []
+
+    const normalized: RiskResponsePlan[] = rawEntities.map((entity: RiskResponsePlan) => ({
+      ...entity,
+      actions: coerceArray<string>(entity?.actions),
+      cost_estimate: coerceNumber(entity?.cost_estimate)
+    }))
+
+    const validEntities: RiskResponsePlan[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RISK-RESPONSE-PLANS',
+        entity.risk_title || entity.risk_id || 'Risk Response Plan'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'risk_response_plans',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-RESPONSE-PLANS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRiskResponsePlans(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RiskResponsePlan[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM risk_response_plans WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 12
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
+      )
+
+      values.push(
+        projectId,
+        e.risk_id || null,
+        e.risk_title || null,
+        e.strategy || null,
+        e.actions || [],
+        e.owner || null,
+        e.due_date || null,
+        e.status || null,
+        e.cost_estimate ?? null,
+        e.residual_risk || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO risk_response_plans (
+        project_id, risk_id, risk_title, strategy, actions, owner, due_date,
+        status, cost_estimate, residual_risk, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-RESPONSE-PLANS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/risk_response_plans/index.ts
+++ b/server/src/services/extraction/entities/risk_response_plans/index.ts
@@ -169,6 +169,22 @@ export async function extractRiskResponsePlans(
   }
 }
 
+const RESPONSE_STRATEGY = new Set([
+  'avoid', 'mitigate', 'transfer', 'accept', 'exploit', 'enhance', 'share'
+])
+
+function normalizeStrategy(v: unknown): string {
+  if (!v) return 'accept'
+  const s = String(v).toLowerCase().trim()
+  if (RESPONSE_STRATEGY.has(s)) return s
+  const map: Record<string, string> = {
+    avoid: 'avoid', mitigate: 'mitigate', mitigation: 'mitigate',
+    transfer: 'transfer', accept: 'accept', exploit: 'exploit',
+    enhance: 'enhance', share: 'share'
+  }
+  return map[s] ?? 'accept'
+}
+
 export async function saveRiskResponsePlans(
   client: PoolClient,
   projectId: string,
@@ -180,39 +196,99 @@ export async function saveRiskResponsePlans(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_response_plans'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pick = (opts: string[]) => opts.find(c => columnSet.has(c)) ?? null
+
+    const strategyCol = pick(['response_strategy', 'strategy'])
+    const actionsCol = pick(['response_actions', 'actions'])
+    const ownerCol = pick(['responsible_party', 'owner'])
+    const deadlineCol = pick(['deadline', 'due_date'])
+    const costCol = pick(['cost_estimate'])
+    const statusCol = pick(['status'])
+    const residualCol = pick(['residual_risk_level', 'residual_risk'])
+    const riskIdCol = pick(['risk_id'])
+    const sourceDocCol = pick(['source_document_id'])
+    const createdByCol = pick(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (e: RiskResponsePlan) => unknown }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+    if (strategyCol) {
+      columnOrder.push({
+        name: strategyCol,
+        value: (e) => normalizeStrategy(e.strategy)
+      })
+    }
+    if (actionsCol) {
+      columnOrder.push({
+        name: actionsCol,
+        value: (e) => {
+          const a = e.actions
+          if (Array.isArray(a) && a.length > 0) return a
+          return ['(none)']
+        }
+      })
+    }
+    if (ownerCol) columnOrder.push({ name: ownerCol, value: (e) => e.owner || null })
+    if (deadlineCol) columnOrder.push({ name: deadlineCol, value: (e) => e.due_date || null })
+    if (costCol) columnOrder.push({ name: costCol, value: (e) => e.cost_estimate ?? null })
+    if (statusCol) columnOrder.push({ name: statusCol, value: (e) => e.status || null })
+    if (residualCol) {
+      columnOrder.push({
+        name: residualCol,
+        value: (e) => {
+          const v = e.residual_risk
+          if (!v) return null
+          const s = String(v).toLowerCase().replace(/\s+/g, '_')
+          const allowed = ['very_high', 'high', 'medium', 'low', 'very_low']
+          if (allowed.includes(s)) return s
+          if (['veryhigh', 'very_high'].includes(s)) return 'very_high'
+          if (['verylow', 'very_low'].includes(s)) return 'very_low'
+          return null
+        }
+      })
+    }
+    if (riskIdCol) {
+      columnOrder.push({
+        name: riskIdCol,
+        value: (e) => {
+          const v = e.risk_id
+          if (!v) return null
+          const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+          return typeof v === 'string' && uuid.test(v) ? v : null
+        }
+      })
+    }
+    if (sourceDocCol) columnOrder.push({ name: sourceDocCol, value: (e) => e.source_document_id || null })
+    if (createdByCol) columnOrder.push({ name: createdByCol, value: () => userId })
+
+    if (columnOrder.length <= 1) {
+      throw new Error('risk_response_plans table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_response_plans WHERE project_id = $1', [projectId])
 
-    const values: any[] = []
+    const values: unknown[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 12
+      const offset = index * columnOrder.length
       placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12})`
+        columnOrder.map((_, i) => `$${offset + i + 1}`).join(', ')
       )
-
-      values.push(
-        projectId,
-        e.risk_id || null,
-        e.risk_title || null,
-        e.strategy || null,
-        e.actions || [],
-        e.owner || null,
-        e.due_date || null,
-        e.status || null,
-        e.cost_estimate ?? null,
-        e.residual_risk || null,
-        e.source_document_id || null,
-        userId
-      )
+      columnOrder.forEach(col => values.push(col.value(e)))
     })
 
     await client.query(
-      `INSERT INTO risk_response_plans (
-        project_id, risk_id, risk_title, strategy, actions, owner, due_date,
-        status, cost_estimate, residual_risk, source_document_id, created_by
-      )
-      VALUES ${placeholders.join(', ')}`,
+      `INSERT INTO risk_response_plans (${columnOrder.map(c => c.name).join(', ')})
+       VALUES ${placeholders.map(p => `(${p})`).join(', ')}`,
       values
     )
 

--- a/server/src/services/extraction/entities/risk_reviews/index.ts
+++ b/server/src/services/extraction/entities/risk_reviews/index.ts
@@ -1,0 +1,228 @@
+/**
+ * Risk Reviews Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RiskReview {
+  review_date?: string
+  risk_id?: string
+  risk_title?: string
+  status_before?: string
+  status_after?: string
+  actions?: string[]
+  reviewer?: string
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRiskReviews(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RiskReview>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RISK-REVIEWS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'risk_reviews',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RISK-REVIEWS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "risk_reviews": [
+    {
+      "review_date": "YYYY-MM-DD",
+      "risk_id": "Risk identifier",
+      "risk_title": "Risk title",
+      "status_before": "Open|Mitigating|Closed",
+      "status_after": "Open|Mitigating|Closed",
+      "actions": ["Action 1", "Action 2"],
+      "reviewer": "Reviewer name or role",
+      "notes": "Review notes",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture review dates and status changes',
+      'List follow-up actions when mentioned',
+      'Include reviewer information if available'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'risk_reviews',
+      'risk review records with status changes',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.risk_reviews || []
+
+    const normalized: RiskReview[] = rawEntities.map((entity: RiskReview) => ({
+      ...entity,
+      actions: coerceArray<string>(entity?.actions)
+    }))
+
+    const validEntities: RiskReview[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RISK-REVIEWS',
+        entity.risk_title || entity.risk_id || 'Risk Review'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'risk_reviews',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-REVIEWS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRiskReviews(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RiskReview[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM risk_reviews WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.review_date || null,
+        e.risk_id || null,
+        e.risk_title || null,
+        e.status_before || null,
+        e.status_after || null,
+        e.actions || [],
+        e.reviewer || null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO risk_reviews (
+        project_id, review_date, risk_id, risk_title, status_before, status_after,
+        actions, reviewer, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-REVIEWS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/risk_reviews/index.ts
+++ b/server/src/services/extraction/entities/risk_reviews/index.ts
@@ -177,37 +177,89 @@ export async function saveRiskReviews(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_reviews'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pickColumn = (options: string[]): string | null => {
+      for (const option of options) {
+        if (columnSet.has(option)) {
+          return option
+        }
+      }
+      return null
+    }
+
+    const reviewDateColumn = pickColumn(['review_date', 'reviewed_at', 'review_timestamp'])
+    const riskIdColumn = pickColumn(['risk_id', 'risk_identifier'])
+    const riskTitleColumn = pickColumn(['risk_title', 'risk_name', 'title'])
+    const statusBeforeColumn = pickColumn(['status_before', 'previous_status'])
+    const statusAfterColumn = pickColumn(['status_after', 'current_status'])
+    const actionsColumn = pickColumn(['actions', 'follow_up_actions'])
+    const reviewerColumn = pickColumn(['reviewer', 'reviewed_by', 'reviewer_name'])
+    const notesColumn = pickColumn(['notes', 'summary', 'review_notes'])
+    const sourceDocumentColumn = pickColumn(['source_document_id'])
+    const createdByColumn = pickColumn(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (entity: RiskReview) => any }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+
+    if (reviewDateColumn) {
+      columnOrder.push({ name: reviewDateColumn, value: (e) => e.review_date || null })
+    }
+    if (riskIdColumn) {
+      columnOrder.push({ name: riskIdColumn, value: (e) => e.risk_id || null })
+    }
+    if (riskTitleColumn) {
+      columnOrder.push({ name: riskTitleColumn, value: (e) => e.risk_title || null })
+    }
+    if (statusBeforeColumn) {
+      columnOrder.push({ name: statusBeforeColumn, value: (e) => e.status_before || null })
+    }
+    if (statusAfterColumn) {
+      columnOrder.push({ name: statusAfterColumn, value: (e) => e.status_after || null })
+    }
+    if (actionsColumn) {
+      columnOrder.push({ name: actionsColumn, value: (e) => e.actions || [] })
+    }
+    if (reviewerColumn) {
+      columnOrder.push({ name: reviewerColumn, value: (e) => e.reviewer || null })
+    }
+    if (notesColumn) {
+      columnOrder.push({ name: notesColumn, value: (e) => e.notes || null })
+    }
+    if (sourceDocumentColumn) {
+      columnOrder.push({ name: sourceDocumentColumn, value: (e) => e.source_document_id || null })
+    }
+    if (createdByColumn) {
+      columnOrder.push({ name: createdByColumn, value: () => userId })
+    }
+
+    if (columnOrder.length === 0) {
+      throw new Error('risk_reviews table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_reviews WHERE project_id = $1', [projectId])
 
     const values: any[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 11
-      placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
-      )
-
-      values.push(
-        projectId,
-        e.review_date || null,
-        e.risk_id || null,
-        e.risk_title || null,
-        e.status_before || null,
-        e.status_after || null,
-        e.actions || [],
-        e.reviewer || null,
-        e.notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      const offset = index * columnOrder.length
+      const rowPlaceholders = columnOrder.map((_, columnIndex) => `$${offset + columnIndex + 1}`)
+      placeholders.push(`(${rowPlaceholders.join(', ')})`)
+      columnOrder.forEach(column => {
+        values.push(column.value(e))
+      })
     })
 
     await client.query(
-      `INSERT INTO risk_reviews (
-        project_id, review_date, risk_id, risk_title, status_before, status_after,
-        actions, reviewer, notes, source_document_id, created_by
-      )
+      `INSERT INTO risk_reviews (${columnOrder.map(col => col.name).join(', ')})
       VALUES ${placeholders.join(', ')}`,
       values
     )

--- a/server/src/services/extraction/entities/risk_reviews/index.ts
+++ b/server/src/services/extraction/entities/risk_reviews/index.ts
@@ -166,6 +166,12 @@ export async function extractRiskReviews(
   }
 }
 
+function safeReviewId(date: string, riskId: string | undefined, index: number): string {
+  const d = (date || '').replace(/[^0-9-]/g, '').slice(0, 10) || 'unknown'
+  const r = (riskId || `i${index}`).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 32)
+  return `ra-${d}-${r}`
+}
+
 export async function saveRiskReviews(
   client: PoolClient,
   projectId: string,
@@ -177,38 +183,82 @@ export async function saveRiskReviews(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'risk_reviews'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pick = (opts: string[]) => opts.find(c => columnSet.has(c)) ?? null
+
+    const reviewIdCol = pick(['review_id'])
+    const reviewDateCol = pick(['review_date'])
+    const reviewTypeCol = pick(['review_type'])
+    const actionItemsCol = pick(['action_items', 'actions'])
+    const reviewedByCol = pick(['reviewed_by', 'reviewer'])
+    const keyFindingsCol = pick(['key_findings', 'notes'])
+    const statusChangesCol = pick(['status_changes'])
+    const sourceDocCol = pick(['source_document_id'])
+    const createdByCol = pick(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (e: RiskReview, index: number) => unknown }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+    if (reviewIdCol) {
+      columnOrder.push({
+        name: reviewIdCol,
+        value: (e, i) => safeReviewId(e.review_date || '', e.risk_id, i)
+      })
+    }
+    if (reviewDateCol) {
+      columnOrder.push({
+        name: reviewDateCol,
+        value: (e) => e.review_date || new Date().toISOString().split('T')[0]
+      })
+    }
+    if (reviewTypeCol) columnOrder.push({ name: reviewTypeCol, value: () => 'ad_hoc' })
+    if (actionItemsCol) columnOrder.push({ name: actionItemsCol, value: (e) => e.actions || [] })
+    if (reviewedByCol) {
+      columnOrder.push({
+        name: reviewedByCol,
+        value: (e) => (e.reviewer ? [e.reviewer] : [])
+      })
+    }
+    if (keyFindingsCol) columnOrder.push({ name: keyFindingsCol, value: (e) => e.notes || null })
+    if (statusChangesCol) {
+      columnOrder.push({
+        name: statusChangesCol,
+        value: (e) => {
+          if (!e.status_before && !e.status_after) return []
+          return [{ old_status: e.status_before, new_status: e.status_after }]
+        }
+      })
+    }
+    if (sourceDocCol) columnOrder.push({ name: sourceDocCol, value: (e) => e.source_document_id || null })
+    if (createdByCol) columnOrder.push({ name: createdByCol, value: () => userId })
+
+    if (columnOrder.length <= 1) {
+      throw new Error('risk_reviews table has no writable columns')
+    }
+
     await client.query('DELETE FROM risk_reviews WHERE project_id = $1', [projectId])
 
-    const values: any[] = []
+    const values: unknown[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 11
+      const offset = index * columnOrder.length
       placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+        columnOrder.map((_, i) => `$${offset + i + 1}`).join(', ')
       )
-
-      values.push(
-        projectId,
-        e.review_date || null,
-        e.risk_id || null,
-        e.risk_title || null,
-        e.status_before || null,
-        e.status_after || null,
-        e.actions || [],
-        e.reviewer || null,
-        e.notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      columnOrder.forEach(col => values.push(col.value(e, index)))
     })
 
     await client.query(
-      `INSERT INTO risk_reviews (
-        project_id, review_date, risk_id, risk_title, status_before, status_after,
-        actions, reviewer, notes, source_document_id, created_by
-      )
-      VALUES ${placeholders.join(', ')}`,
+      `INSERT INTO risk_reviews (${columnOrder.map(c => c.name).join(', ')})
+       VALUES ${placeholders.map(p => `(${p})`).join(', ')}`,
       values
     )
 

--- a/server/src/services/extraction/entities/risk_triggers/index.ts
+++ b/server/src/services/extraction/entities/risk_triggers/index.ts
@@ -1,0 +1,220 @@
+/**
+ * Risk Triggers Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface RiskTrigger {
+  risk_id?: string
+  risk_title?: string
+  trigger_condition?: string
+  threshold?: string
+  indicator?: string
+  response_action?: string
+  monitoring_frequency?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractRiskTriggers(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<RiskTrigger>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-RISK-TRIGGERS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'risk_triggers',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-RISK-TRIGGERS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "risk_triggers": [
+    {
+      "risk_id": "Risk identifier",
+      "risk_title": "Risk title",
+      "trigger_condition": "Condition that triggers the risk",
+      "threshold": "Numeric or qualitative threshold",
+      "indicator": "Early warning indicator",
+      "response_action": "Action to take when triggered",
+      "monitoring_frequency": "Daily|Weekly|Monthly",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'List risk triggers and early warning indicators',
+      'Include thresholds when specified',
+      'Capture response actions tied to triggers'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'risk_triggers',
+      'risk triggers and early warning indicators',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.risk_triggers || []
+
+    const validEntities: RiskTrigger[] = []
+    rawEntities.forEach((entity: RiskTrigger) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'RISK-TRIGGERS',
+        entity.risk_title || entity.risk_id || 'Risk Trigger'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'risk_triggers',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: rawEntities.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-TRIGGERS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveRiskTriggers(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: RiskTrigger[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM risk_triggers WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 10
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10})`
+      )
+
+      values.push(
+        projectId,
+        e.risk_id || null,
+        e.risk_title || null,
+        e.trigger_condition || null,
+        e.threshold || null,
+        e.indicator || null,
+        e.response_action || null,
+        e.monitoring_frequency || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO risk_triggers (
+        project_id, risk_id, risk_title, trigger_condition, threshold, indicator,
+        response_action, monitoring_frequency, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-RISK-TRIGGERS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/satisfaction_surveys/index.ts
+++ b/server/src/services/extraction/entities/satisfaction_surveys/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Satisfaction Surveys Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceArray, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface SatisfactionSurvey {
+  stakeholder_id?: string
+  stakeholder_name?: string
+  survey_date?: string
+  nps_score?: number | null
+  satisfaction_score?: number | null
+  sentiment?: string
+  feedback_summary?: string
+  themes?: string[]
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractSatisfactionSurveys(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<SatisfactionSurvey>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-SATISFACTION-SURVEYS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'satisfaction_surveys',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-SATISFACTION-SURVEYS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "satisfaction_surveys": [
+    {
+      "stakeholder_id": "Stakeholder ID",
+      "stakeholder_name": "Stakeholder name",
+      "survey_date": "YYYY-MM-DD",
+      "nps_score": 35,
+      "satisfaction_score": 4.2,
+      "sentiment": "positive|neutral|negative",
+      "feedback_summary": "Summary of feedback",
+      "themes": ["Communication", "Delivery"],
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Include NPS or satisfaction scores when present',
+      'Capture feedback themes as an array',
+      'Include survey date if provided'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'satisfaction_surveys',
+      'stakeholder satisfaction survey results',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.satisfaction_surveys || []
+
+    const normalized: SatisfactionSurvey[] = rawEntities.map((entity: SatisfactionSurvey) => ({
+      ...entity,
+      nps_score: coerceNumber(entity?.nps_score),
+      satisfaction_score: coerceNumber(entity?.satisfaction_score),
+      themes: coerceArray<string>(entity?.themes)
+    }))
+
+    const validEntities: SatisfactionSurvey[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'SATISFACTION-SURVEYS',
+        entity.stakeholder_name || entity.stakeholder_id || 'Satisfaction Survey'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'satisfaction_surveys',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-SATISFACTION-SURVEYS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveSatisfactionSurveys(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: SatisfactionSurvey[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM satisfaction_surveys WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 11
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11})`
+      )
+
+      values.push(
+        projectId,
+        e.stakeholder_id || null,
+        e.stakeholder_name || null,
+        e.survey_date || null,
+        e.nps_score ?? null,
+        e.satisfaction_score ?? null,
+        e.sentiment || null,
+        e.feedback_summary || null,
+        e.themes || [],
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO satisfaction_surveys (
+        project_id, stakeholder_id, stakeholder_name, survey_date, nps_score,
+        satisfaction_score, sentiment, feedback_summary, themes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-SATISFACTION-SURVEYS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/stakeholder_issues/index.ts
+++ b/server/src/services/extraction/entities/stakeholder_issues/index.ts
@@ -1,0 +1,230 @@
+/**
+ * Stakeholder Issues Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface StakeholderIssue {
+  issue_id?: string
+  stakeholder_id?: string
+  stakeholder_name?: string
+  issue_type?: string
+  severity?: string
+  description?: string
+  status?: string
+  reported_date?: string
+  resolution_date?: string
+  resolution_notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractStakeholderIssues(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<StakeholderIssue>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-STAKEHOLDER-ISSUES] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'stakeholder_issues',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-STAKEHOLDER-ISSUES] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "stakeholder_issues": [
+    {
+      "issue_id": "Issue identifier",
+      "stakeholder_id": "Stakeholder ID",
+      "stakeholder_name": "Stakeholder name",
+      "issue_type": "Concern|Complaint|Change Request",
+      "severity": "Low|Medium|High",
+      "description": "Issue description",
+      "status": "open|in_progress|resolved",
+      "reported_date": "YYYY-MM-DD",
+      "resolution_date": "YYYY-MM-DD",
+      "resolution_notes": "How the issue was resolved",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Capture stakeholder issues with severity and status',
+      'Include reported and resolution dates when available',
+      'Summarize resolution notes if present'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'stakeholder_issues',
+      'stakeholder issues and resolutions',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.stakeholder_issues || []
+
+    const validEntities: StakeholderIssue[] = []
+    rawEntities.forEach((entity: StakeholderIssue) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'STAKEHOLDER-ISSUES',
+        entity.issue_id || entity.stakeholder_name || 'Stakeholder Issue'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'stakeholder_issues',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: rawEntities.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-STAKEHOLDER-ISSUES] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveStakeholderIssues(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: StakeholderIssue[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM stakeholder_issues WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 13
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13})`
+      )
+
+      values.push(
+        projectId,
+        e.issue_id || null,
+        e.stakeholder_id || null,
+        e.stakeholder_name || null,
+        e.issue_type || null,
+        e.severity || null,
+        e.description || null,
+        e.status || null,
+        e.reported_date || null,
+        e.resolution_date || null,
+        e.resolution_notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO stakeholder_issues (
+        project_id, issue_id, stakeholder_id, stakeholder_name, issue_type, severity,
+        description, status, reported_date, resolution_date, resolution_notes,
+        source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-STAKEHOLDER-ISSUES] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/extraction/entities/stakeholder_issues/index.ts
+++ b/server/src/services/extraction/entities/stakeholder_issues/index.ts
@@ -176,40 +176,97 @@ export async function saveStakeholderIssues(
   }
 
   try {
+    const columnResult = await client.query<{ column_name: string }>(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'stakeholder_issues'`
+    )
+    const columnSet = new Set(columnResult.rows.map(row => row.column_name))
+
+    const pickColumn = (options: string[]): string | null => {
+      for (const option of options) {
+        if (columnSet.has(option)) {
+          return option
+        }
+      }
+      return null
+    }
+
+    const issueTypeColumn = pickColumn(['issue_type', 'issue_category', 'category', 'type'])
+    const severityColumn = pickColumn(['severity', 'priority', 'impact'])
+    const descriptionColumn = pickColumn(['description', 'issue_description', 'details'])
+    const statusColumn = pickColumn(['status', 'issue_status'])
+    const reportedDateColumn = pickColumn(['reported_date', 'reported_at'])
+    const resolutionDateColumn = pickColumn(['resolution_date', 'resolved_at'])
+    const resolutionNotesColumn = pickColumn(['resolution_notes', 'resolution_summary', 'resolution'])
+    const stakeholderIdColumn = pickColumn(['stakeholder_id'])
+    const stakeholderNameColumn = pickColumn(['stakeholder_name'])
+    const issueIdColumn = pickColumn(['issue_id'])
+    const sourceDocumentColumn = pickColumn(['source_document_id'])
+    const createdByColumn = pickColumn(['created_by'])
+
+    const columnOrder: Array<{ name: string; value: (entity: StakeholderIssue) => any }> = [
+      { name: 'project_id', value: () => projectId }
+    ]
+
+    if (issueIdColumn) {
+      columnOrder.push({ name: issueIdColumn, value: (e) => e.issue_id || null })
+    }
+    if (stakeholderIdColumn) {
+      columnOrder.push({ name: stakeholderIdColumn, value: (e) => e.stakeholder_id || null })
+    }
+    if (stakeholderNameColumn) {
+      columnOrder.push({ name: stakeholderNameColumn, value: (e) => e.stakeholder_name || null })
+    }
+    if (issueTypeColumn) {
+      columnOrder.push({ name: issueTypeColumn, value: (e) => e.issue_type || null })
+    }
+    if (severityColumn) {
+      columnOrder.push({ name: severityColumn, value: (e) => e.severity || null })
+    }
+    if (descriptionColumn) {
+      columnOrder.push({ name: descriptionColumn, value: (e) => e.description || null })
+    }
+    if (statusColumn) {
+      columnOrder.push({ name: statusColumn, value: (e) => e.status || null })
+    }
+    if (reportedDateColumn) {
+      columnOrder.push({ name: reportedDateColumn, value: (e) => e.reported_date || null })
+    }
+    if (resolutionDateColumn) {
+      columnOrder.push({ name: resolutionDateColumn, value: (e) => e.resolution_date || null })
+    }
+    if (resolutionNotesColumn) {
+      columnOrder.push({ name: resolutionNotesColumn, value: (e) => e.resolution_notes || null })
+    }
+    if (sourceDocumentColumn) {
+      columnOrder.push({ name: sourceDocumentColumn, value: (e) => e.source_document_id || null })
+    }
+    if (createdByColumn) {
+      columnOrder.push({ name: createdByColumn, value: () => userId })
+    }
+
+    if (columnOrder.length === 0) {
+      throw new Error('stakeholder_issues table has no writable columns')
+    }
+
     await client.query('DELETE FROM stakeholder_issues WHERE project_id = $1', [projectId])
 
     const values: any[] = []
     const placeholders: string[] = []
 
     entities.forEach((e, index) => {
-      const offset = index * 13
-      placeholders.push(
-        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10}, $${offset + 11}, $${offset + 12}, $${offset + 13})`
-      )
-
-      values.push(
-        projectId,
-        e.issue_id || null,
-        e.stakeholder_id || null,
-        e.stakeholder_name || null,
-        e.issue_type || null,
-        e.severity || null,
-        e.description || null,
-        e.status || null,
-        e.reported_date || null,
-        e.resolution_date || null,
-        e.resolution_notes || null,
-        e.source_document_id || null,
-        userId
-      )
+      const offset = index * columnOrder.length
+      const rowPlaceholders = columnOrder.map((_, columnIndex) => `$${offset + columnIndex + 1}`)
+      placeholders.push(`(${rowPlaceholders.join(', ')})`)
+      columnOrder.forEach(column => {
+        values.push(column.value(e))
+      })
     })
 
     await client.query(
-      `INSERT INTO stakeholder_issues (
-        project_id, issue_id, stakeholder_id, stakeholder_name, issue_type, severity,
-        description, status, reported_date, resolution_date, resolution_notes,
-        source_document_id, created_by
-      )
+      `INSERT INTO stakeholder_issues (${columnOrder.map(col => col.name).join(', ')})
       VALUES ${placeholders.join(', ')}`,
       values
     )

--- a/server/src/services/extraction/entities/utilization_records/index.ts
+++ b/server/src/services/extraction/entities/utilization_records/index.ts
@@ -1,0 +1,227 @@
+/**
+ * Utilization Records Entity Module
+ */
+
+import { logger } from '../../../../utils/logger'
+import { aiService } from '../../../aiService'
+import type { ExtractionContext } from '../../base/ExtractionContext'
+import type { ExtractionResult } from '../../base/ExtractionResult'
+import { parseAIResponse, coerceNumber } from '../../base/Parser'
+import { buildExtractionPrompt } from '../../base/PromptBuilder'
+import { resolveSourceDocumentIdStrict } from '../../base/SourceDocumentResolver'
+import { extractionCacheService } from '../../cache'
+import type { PoolClient } from 'pg'
+import type { PersistenceResult } from '../../base/Persistence'
+
+export interface UtilizationRecord {
+  resource_id?: string
+  resource_name?: string
+  period?: string
+  planned_utilization_pct?: number | null
+  actual_utilization_pct?: number | null
+  variance_pct?: number | null
+  notes?: string
+  source_document?: string
+  source_document_id?: string
+}
+
+export async function extractUtilizationRecords(
+  context: ExtractionContext,
+  options: { temperature?: number; maxTokens?: number } = {}
+): Promise<ExtractionResult<UtilizationRecord>> {
+  const startTime = Date.now()
+  let rejectedCount = 0
+
+  try {
+    logger.info('[EXTRACTION-UTILIZATION-RECORDS] Starting extraction', {
+      projectId: context.projectId,
+      documentCount: context.documents.length
+    })
+
+    const cached = await extractionCacheService.get(
+      context.projectId,
+      context.documentContext,
+      'utilization_records',
+      context.provider,
+      context.model
+    )
+
+    if (cached && cached.length > 0) {
+      logger.info(`[EXTRACTION-UTILIZATION-RECORDS] ✅ Using cached result (${cached.length} entities)`)
+      return {
+        entities: cached,
+        rejectedCount: 0,
+        skippedCount: 0,
+        stats: {
+          totalExtracted: cached.length,
+          afterDeduplication: cached.length,
+          afterSourceResolution: cached.length,
+          finalCount: cached.length,
+          cacheHit: true,
+          durationMs: Date.now() - startTime,
+          provider: context.provider,
+          model: context.model
+        }
+      }
+    }
+
+    const jsonStructure = `{
+  "utilization_records": [
+    {
+      "resource_id": "Resource ID",
+      "resource_name": "Resource name",
+      "period": "YYYY-MM",
+      "planned_utilization_pct": 80,
+      "actual_utilization_pct": 92,
+      "variance_pct": 12,
+      "notes": "Context about utilization variance",
+      "source_document": "EXACT document title from available list"
+    }
+  ]
+}`
+
+    const requirements = [
+      'Provide planned vs actual utilization percentages',
+      'Include variance_pct when possible',
+      'Include period and resource details'
+    ]
+
+    const prompt = buildExtractionPrompt(
+      context,
+      'utilization_records',
+      'resource utilization records with variances',
+      jsonStructure,
+      requirements
+    )
+
+    const response = await aiService.generateWithFallback(
+      {
+        prompt,
+        provider: context.provider,
+        model: context.model,
+        temperature: options.temperature ?? 0.2,
+        max_tokens: options.maxTokens ?? 4000
+      },
+      ['openai', 'google', 'anthropic']
+    )
+
+    const parsed = parseAIResponse(response.content)
+    const rawEntities = parsed.utilization_records || []
+
+    const normalized: UtilizationRecord[] = rawEntities.map((entity: UtilizationRecord) => ({
+      ...entity,
+      planned_utilization_pct: coerceNumber(entity?.planned_utilization_pct),
+      actual_utilization_pct: coerceNumber(entity?.actual_utilization_pct),
+      variance_pct: coerceNumber(entity?.variance_pct)
+    }))
+
+    const validEntities: UtilizationRecord[] = []
+    normalized.forEach((entity) => {
+      const resolution = resolveSourceDocumentIdStrict(
+        entity,
+        context,
+        'UTILIZATION-RECORDS',
+        entity.resource_name || entity.resource_id || 'Utilization Record'
+      )
+
+      if (resolution.resolved) {
+        validEntities.push(entity)
+      } else {
+        rejectedCount++
+      }
+    })
+
+    if (validEntities.length > 0) {
+      await extractionCacheService.set(
+        context.projectId,
+        context.documentContext,
+        'utilization_records',
+        validEntities,
+        context.provider,
+        context.model
+      )
+    }
+
+    return {
+      entities: validEntities,
+      rejectedCount,
+      skippedCount: 0,
+      stats: {
+        totalExtracted: rawEntities.length,
+        afterDeduplication: normalized.length,
+        afterSourceResolution: validEntities.length,
+        finalCount: validEntities.length,
+        cacheHit: false,
+        durationMs: Date.now() - startTime,
+        provider: context.provider,
+        model: context.model
+      }
+    }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-UTILIZATION-RECORDS] Extraction failed', {
+      projectId: context.projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    throw error
+  }
+}
+
+export async function saveUtilizationRecords(
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: UtilizationRecord[]
+): Promise<PersistenceResult> {
+  if (entities.length === 0) {
+    return { saved: 0, skipped: 0, failed: 0 }
+  }
+
+  try {
+    await client.query('DELETE FROM utilization_records WHERE project_id = $1', [projectId])
+
+    const values: any[] = []
+    const placeholders: string[] = []
+
+    entities.forEach((e, index) => {
+      const offset = index * 10
+      placeholders.push(
+        `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10})`
+      )
+
+      values.push(
+        projectId,
+        e.resource_id || null,
+        e.resource_name || null,
+        e.period || null,
+        e.planned_utilization_pct ?? null,
+        e.actual_utilization_pct ?? null,
+        e.variance_pct ?? null,
+        e.notes || null,
+        e.source_document_id || null,
+        userId
+      )
+    })
+
+    await client.query(
+      `INSERT INTO utilization_records (
+        project_id, resource_id, resource_name, period, planned_utilization_pct,
+        actual_utilization_pct, variance_pct, notes, source_document_id, created_by
+      )
+      VALUES ${placeholders.join(', ')}`,
+      values
+    )
+
+    return { saved: entities.length, skipped: 0, failed: 0 }
+  } catch (error: unknown) {
+    logger.error('[EXTRACTION-UTILIZATION-RECORDS] Failed to save', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return {
+      saved: 0,
+      skipped: 0,
+      failed: entities.length,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  }
+}

--- a/server/src/services/projectDataExtractionService.ts
+++ b/server/src/services/projectDataExtractionService.ts
@@ -12,7 +12,22 @@ import { logger } from '@/utils/logger'
 import { convertQuarterDate, isValidDate, addDays, getCurrentDate } from '@/utils/dateUtils'
 import { aiService } from './aiService'
 import { aiCacheService } from './aiCacheService'
+import { ExtractionContext } from './extraction/base/ExtractionContext'
+import type { ExtractionDocument, ExtractionResult as ModuleExtractionResult } from './extraction/base/ExtractionResult'
+import type { PersistenceResult } from './extraction/base/Persistence'
 import type { PoolClient } from 'pg'
+
+type ModuleExtractor = (
+  context: ExtractionContext,
+  options?: { temperature?: number; maxTokens?: number }
+) => Promise<ModuleExtractionResult<unknown>>
+
+type ModuleSaver = (
+  client: PoolClient,
+  projectId: string,
+  userId: string,
+  entities: unknown[]
+) => Promise<PersistenceResult>
 
 interface ExtractionResult {
   stakeholders: Stakeholder[]
@@ -459,6 +474,11 @@ interface RiskResponseRecord {
 }
 
 export class ProjectDataExtractionService {
+  private entityModuleCache = new Map<
+    string,
+    { normalizedType: string; extractor?: ModuleExtractor; saver?: ModuleSaver }
+  >()
+
   /**
    * Validate AI response and throw error if empty/invalid
    * This ensures empty responses trigger retries and provider fallback
@@ -3825,18 +3845,23 @@ Output valid JSON object with "performance_actuals" array only.`
       change_control_boards: 'governance',
       policy_compliance: 'governance',
       // Scope Domain
+      scope_baseline: 'scope',
       scope_baselines: 'scope',
       wbs_nodes: 'scope',
       scope_change_requests: 'scope',
       requirements_traceability: 'scope',
       scope_verification: 'scope',
+      dt_assets: 'scope',
       // Schedule Domain
+      schedule_baseline: 'schedule',
       schedule_baselines: 'schedule',
       schedule_activities: 'schedule',
       critical_path_activities: 'schedule',
+      critical_path: 'schedule',
       schedule_variances: 'schedule',
       schedule_forecasts: 'schedule',
       // Finance Domain
+      budget_baseline: 'finance',
       budget_baselines: 'finance',
       cost_actuals: 'finance',
       cost_estimates: 'finance',
@@ -3865,6 +3890,76 @@ Output valid JSON object with "performance_actuals" array only.`
       relationship_health: 'stakeholders_ops'
     }
     return domainMap[entityType] || 'unknown'
+  }
+
+  private normalizeEntityTypeAlias(entityType: string): { normalizedType: string; aliasApplied: boolean } {
+    const aliasMap: Record<string, string> = {
+      scope_baselines: 'scope_baseline',
+      schedule_baselines: 'schedule_baseline',
+      budget_baselines: 'budget_baseline',
+      critical_path_activities: 'critical_path'
+    }
+
+    const normalizedType = aliasMap[entityType] ?? entityType
+    return {
+      normalizedType,
+      aliasApplied: normalizedType !== entityType
+    }
+  }
+
+  private toPascalCase(value: string): string {
+    return value
+      .split('_')
+      .map(part => (part ? `${part[0].toUpperCase()}${part.slice(1)}` : ''))
+      .join('')
+  }
+
+  private async resolveEntityModule(
+    entityType: string
+  ): Promise<{ normalizedType: string; extractor?: ModuleExtractor; saver?: ModuleSaver; aliasApplied: boolean } | null> {
+    const { normalizedType, aliasApplied } = this.normalizeEntityTypeAlias(entityType)
+
+    if (this.entityModuleCache.has(normalizedType)) {
+      const cached = this.entityModuleCache.get(normalizedType)
+      if (!cached || (!cached.extractor && !cached.saver)) {
+        return null
+      }
+      return { ...cached, aliasApplied }
+    }
+
+    try {
+      const module = await import(`./extraction/entities/${normalizedType}`)
+      const suffix = this.toPascalCase(normalizedType)
+      const extractor = module[`extract${suffix}`] as ModuleExtractor | undefined
+      const saver = module[`save${suffix}`] as ModuleSaver | undefined
+
+      if (!extractor && !saver) {
+        logger.warn('[EXTRACTION] Entity module loaded but no extractor/saver found', {
+          entityType,
+          normalizedType
+        })
+        this.entityModuleCache.set(normalizedType, { normalizedType })
+        return null
+      }
+
+      const resolved = { normalizedType, extractor, saver }
+      this.entityModuleCache.set(normalizedType, resolved)
+      return { ...resolved, aliasApplied }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error)
+      const isModuleMissing =
+        message.includes('Cannot find module') || message.includes('Cannot find package')
+
+      if (!isModuleMissing) {
+        logger.warn('[EXTRACTION] Failed to load entity module', {
+          entityType,
+          normalizedType,
+          error: message
+        })
+      }
+      this.entityModuleCache.set(normalizedType, { normalizedType })
+      return null
+    }
   }
 
   /**
@@ -8734,7 +8829,7 @@ Output valid JSON object with "performance_actuals" array only.`
         break
       // ===========================================================================
       // PMBOK 8 Knowledge Area Domain entity types (Tier 2)
-      // These are placeholders - full extraction methods to be implemented
+      // These use the extraction modules when available
       // ===========================================================================
       // Governance Domain
       case 'governance_decisions':
@@ -8745,24 +8840,22 @@ Output valid JSON object with "performance_actuals" array only.`
       // Scope Domain  
       case 'scope_baseline':
       case 'scope_baselines':
-      case 'scope_baseline': // Singular form
       case 'wbs_nodes':
       case 'scope_change_requests':
       case 'requirements_traceability':
       case 'scope_verification':
+      case 'dt_assets':
       // Schedule Domain
       case 'schedule_baseline':
       case 'schedule_baselines':
-      case 'schedule_baseline': // Singular form
       case 'schedule_activities':
       case 'critical_path_activities':
-      case 'critical_path': // Singular form
+      case 'critical_path':
       case 'schedule_variances':
       case 'schedule_forecasts':
       // Finance Domain
       case 'budget_baseline':
       case 'budget_baselines':
-      case 'budget_baseline': // Singular form
       case 'cost_actuals':
       case 'cost_estimates':
       case 'funding_tranches':
@@ -8787,15 +8880,38 @@ Output valid JSON object with "performance_actuals" array only.`
       case 'communication_logs':
       case 'satisfaction_surveys':
       case 'stakeholder_issues':
-      case 'relationship_health':
-        // Log warning for Knowledge Area Domain entities (not yet implemented)
-        logger.warn(`[EXTRACTION-${entityType.toUpperCase()}] Knowledge Area Domain entity type not yet implemented, returning empty array`, {
-          entityType,
-          projectId,
-          domain: this.getKnowledgeDomainForEntityType(entityType)
-        })
+      case 'relationship_health': {
+        const resolved = await this.resolveEntityModule(entityType)
+        if (resolved?.extractor) {
+          if (resolved.aliasApplied) {
+            logger.debug('[EXTRACTION] Normalized entity type alias', {
+              entityType,
+              normalizedType: resolved.normalizedType
+            })
+          }
+
+          const context = new ExtractionContext(
+            projectId,
+            userId,
+            documents as ExtractionDocument[],
+            extractionOptions
+          )
+          const result = await resolved.extractor(context)
+          entities = result.entities
+          break
+        }
+
+        logger.warn(
+          `[EXTRACTION-${entityType.toUpperCase()}] Knowledge Area Domain entity type not yet implemented, returning empty array`,
+          {
+            entityType,
+            projectId,
+            domain: this.getKnowledgeDomainForEntityType(entityType)
+          }
+        )
         entities = []
         break
+      }
       default:
         throw new Error(`Unknown entity type: ${entityType}`)
       }
@@ -8951,7 +9067,7 @@ Output valid JSON object with "performance_actuals" array only.`
           break
         // ===========================================================================
         // PMBOK 8 Knowledge Area Domain entity types (Tier 2)
-        // These are placeholders - full save methods to be implemented
+        // These use module savers when available
         // ===========================================================================
         // Governance Domain
         case 'governance_decisions':
@@ -8966,6 +9082,7 @@ Output valid JSON object with "performance_actuals" array only.`
         case 'scope_change_requests':
         case 'requirements_traceability':
         case 'scope_verification':
+        case 'dt_assets':
         // Schedule Domain
         case 'schedule_baseline': // singular
         case 'schedule_baselines':
@@ -9001,7 +9118,23 @@ Output valid JSON object with "performance_actuals" array only.`
         case 'communication_logs':
         case 'satisfaction_surveys':
         case 'stakeholder_issues':
-        case 'relationship_health':
+        case 'relationship_health': {
+          const resolved = await this.resolveEntityModule(entityType)
+          if (resolved?.saver) {
+            if (resolved.aliasApplied) {
+              logger.debug('[EXTRACTION] Normalized entity type alias for save', {
+                entityType,
+                normalizedType: resolved.normalizedType
+              })
+            }
+
+            const result = await resolved.saver(client, projectId, userId, entities)
+            if (result.failed > 0 && result.error) {
+              throw new Error(result.error)
+            }
+            break
+          }
+
           // Log info for Knowledge Area Domain entities (save methods not yet implemented)
           if (entities.length > 0) {
             logger.warn(`[EXTRACTION-${entityType.toUpperCase()}] Save method not yet implemented for Knowledge Area Domain entity`, {
@@ -9013,6 +9146,7 @@ Output valid JSON object with "performance_actuals" array only.`
           }
           // Skip saving - these will be empty arrays from extraction anyway
           break
+        }
         default:
           throw new Error(`Unknown entity type: ${entityType}`)
       }

--- a/server/src/services/projectDataExtractionService.ts
+++ b/server/src/services/projectDataExtractionService.ts
@@ -478,6 +478,7 @@ export class ProjectDataExtractionService {
     string,
     { normalizedType: string; extractor?: ModuleExtractor; saver?: ModuleSaver }
   >()
+  private entityModuleCacheMax = 200
 
   /**
    * Validate AI response and throw error if empty/invalid
@@ -3908,10 +3909,35 @@ Output valid JSON object with "performance_actuals" array only.`
   }
 
   private toPascalCase(value: string): string {
+    if (!value || typeof value !== 'string') {
+      throw new Error('Invalid input for toPascalCase conversion')
+    }
+
     return value
       .split('_')
-      .map(part => (part ? `${part[0].toUpperCase()}${part.slice(1)}` : ''))
+      .filter(part => part.length > 0)
+      .map(part => `${part[0].toUpperCase()}${part.slice(1)}`)
       .join('')
+  }
+
+  private isValidEntityModuleName(value: string): boolean {
+    return /^[a-z_]+$/.test(value)
+  }
+
+  private setEntityModuleCache(
+    normalizedType: string,
+    entry: { normalizedType: string; extractor?: ModuleExtractor; saver?: ModuleSaver }
+  ): void {
+    if (this.entityModuleCache.has(normalizedType)) {
+      this.entityModuleCache.delete(normalizedType)
+    }
+    this.entityModuleCache.set(normalizedType, entry)
+    if (this.entityModuleCache.size > this.entityModuleCacheMax) {
+      const oldestKey = this.entityModuleCache.keys().next().value as string | undefined
+      if (oldestKey) {
+        this.entityModuleCache.delete(oldestKey)
+      }
+    }
   }
 
   private async resolveEntityModule(
@@ -3927,6 +3953,14 @@ Output valid JSON object with "performance_actuals" array only.`
       return { ...cached, aliasApplied }
     }
 
+    if (!this.isValidEntityModuleName(normalizedType)) {
+      logger.warn('[EXTRACTION] Invalid entity module name format', {
+        entityType,
+        normalizedType
+      })
+      return null
+    }
+
     try {
       const module = await import(`./extraction/entities/${normalizedType}`)
       const suffix = this.toPascalCase(normalizedType)
@@ -3938,26 +3972,27 @@ Output valid JSON object with "performance_actuals" array only.`
           entityType,
           normalizedType
         })
-        this.entityModuleCache.set(normalizedType, { normalizedType })
+        this.setEntityModuleCache(normalizedType, { normalizedType })
         return null
       }
 
       const resolved = { normalizedType, extractor, saver }
-      this.entityModuleCache.set(normalizedType, resolved)
+      this.setEntityModuleCache(normalizedType, resolved)
       return { ...resolved, aliasApplied }
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error)
       const isModuleMissing =
         message.includes('Cannot find module') || message.includes('Cannot find package')
 
-      if (!isModuleMissing) {
+      if (isModuleMissing) {
+        this.setEntityModuleCache(normalizedType, { normalizedType })
+      } else {
         logger.warn('[EXTRACTION] Failed to load entity module', {
           entityType,
           normalizedType,
           error: message
         })
       }
-      this.entityModuleCache.set(normalizedType, { normalizedType })
       return null
     }
   }


### PR DESCRIPTION
Implement configured `projectDataExtractionService` placeholder entity types using existing extraction modules.

This change enables extraction and saving for several previously unimplemented entity types by resolving them via their respective modules, including alias normalization and `dt_assets` support. It also fixes a `db` loading issue in `ExtractionOrchestrator`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3230e9ca-bf48-43e8-ad14-2e96f7463ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3230e9ca-bf48-43e8-ad14-2e96f7463ab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces dynamic resolution of extraction/saver modules and implements previously placeholder entity types, with feature flags for rollout.
> 
> - Adds extraction/save modules for `cost_actuals`, `capacity_forecasts`, `resource_assignments`, `resource_pool`, `utilization_records`, `resource_conflicts`, `onboarding_offboarding`, `risk_assessments`, `risk_response_plans`, `risk_triggers`, `risk_reviews`, `contingency_reserves`, `risk_metrics`, `engagement_actions`, `satisfaction_surveys`, `stakeholder_issues`, and `relationship_health`
> - Updates `ExtractionRegistry` to register the new modules and load corresponding env-based feature flags
> - Extends `projectDataExtractionService` with entity alias normalization, module caching, and fallback to module-based extract/save for Tier-2 domains (incl. `dt_assets` mappings)
> - Fixes `ExtractionOrchestrator` DB access to use `pool.query` and ensures pool initialization
> 
> Note: `risk_assessments` and `risk_reviews` savers include merge-conflict markers in the diff, which may break build.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86c38dd13c95d36b2146152182efd200402edf69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->