### PR TITLE
feat(SC-27): Add async semantic processing pipeline for onboarding documents

### DIFF
--- a/app/onboarding/assessment/[batchId]/page.tsx
+++ b/app/onboarding/assessment/[batchId]/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { MaturityCard } from '@/components/onboarding/MaturityCard';
 import { MaturityScore } from '@/components/onboarding/MaturityScore';
 import { MaturityJourneyPlanner } from '@/components/onboarding/MaturityJourneyPlanner';
+import { SemanticProcessingStatus } from '@/components/onboarding/SemanticProcessingStatus';
 import { maturityTheme } from '@/lib/theme/maturity-portal-theme';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
@@ -1181,6 +1182,14 @@ export default function AssessmentResultsPage() {
             Overview
           </TabsTrigger>
           <TabsTrigger 
+            value="processing"
+            style={{ 
+              color: maturityTheme.colors.text.primary,
+            }}
+          >
+            Processing
+          </TabsTrigger>
+          <TabsTrigger 
             value="journey"
             style={{ 
               color: maturityTheme.colors.text.primary,
@@ -1710,6 +1719,27 @@ export default function AssessmentResultsPage() {
               </div>
             );
           })()}
+        </TabsContent>
+
+        {/* Semantic Processing Tab */}
+        <TabsContent value="processing" className="space-y-4">
+          <MaturityCard variant="elevated">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Target className="w-5 h-5" />
+                Semantic Processing Pipeline
+              </CardTitle>
+              <CardDescription>
+                Monitor the automatic extraction of entities and synchronization to the Governance Knowledge Graph
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <SemanticProcessingStatus 
+                batchId={batchId}
+                showDetails={true}
+              />
+            </CardContent>
+          </MaturityCard>
         </TabsContent>
 
         {/* Your Journey Tab */}

--- a/app/onboarding/processing/page.tsx
+++ b/app/onboarding/processing/page.tsx
@@ -1,0 +1,426 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+import { motion } from 'framer-motion';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  ArrowLeft,
+  RefreshCw,
+  Search,
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+  Database,
+  Network,
+  FileText
+} from 'lucide-react';
+import { SemanticProcessingStatus } from '@/components/onboarding/SemanticProcessingStatus';
+import apiClient from '@/lib/api';
+import { toast } from '@/lib/notify';
+
+interface BatchSummary {
+  batchId: string;
+  projectId: string;
+  overallState: string;
+  totalDocuments: number;
+  documentsConverted: number;
+  documentsExtracted: number;
+  documentsSynced: number;
+  documentsFailed: number;
+  totalEntitiesExtracted: number;
+  totalGkgNodesCreated: number;
+  startedAt: string;
+  completedAt: string | null;
+  progress: number;
+}
+
+interface ProjectBatches {
+  projectId: string;
+  projectName?: string;
+  batches: BatchSummary[];
+}
+
+export default function SemanticProcessingPage() {
+  const { user, isLoading: authLoading } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  
+  const batchIdParam = searchParams?.get('batchId');
+  const projectIdParam = searchParams?.get('projectId');
+
+  const [selectedBatchId, setSelectedBatchId] = useState<string | null>(batchIdParam);
+  const [projectBatches, setProjectBatches] = useState<ProjectBatches | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  useEffect(() => {
+    if (projectIdParam) {
+      fetchProjectBatches(projectIdParam);
+    } else if (batchIdParam) {
+      setSelectedBatchId(batchIdParam);
+      setLoading(false);
+    } else {
+      setLoading(false);
+    }
+  }, [projectIdParam, batchIdParam]);
+
+  const fetchProjectBatches = async (projectId: string) => {
+    try {
+      setLoading(true);
+      const response = await apiClient.get(`/api/semantic-processing/project/${projectId}`);
+      
+      if (response.data?.success) {
+        const documents = response.data.data.documents || [];
+        
+        // Group by batch
+        const batchMap = new Map<string, BatchSummary>();
+        for (const doc of documents) {
+          if (!doc.batchId) continue;
+          
+          if (!batchMap.has(doc.batchId)) {
+            batchMap.set(doc.batchId, {
+              batchId: doc.batchId,
+              projectId: doc.projectId,
+              overallState: 'processing',
+              totalDocuments: 0,
+              documentsConverted: 0,
+              documentsExtracted: 0,
+              documentsSynced: 0,
+              documentsFailed: 0,
+              totalEntitiesExtracted: 0,
+              totalGkgNodesCreated: 0,
+              startedAt: doc.uploadedAt,
+              completedAt: null,
+              progress: 0
+            });
+          }
+          
+          const batch = batchMap.get(doc.batchId)!;
+          batch.totalDocuments++;
+          
+          if (doc.convertedAt) batch.documentsConverted++;
+          if (doc.extractionCompletedAt) batch.documentsExtracted++;
+          if (doc.state === 'synced') batch.documentsSynced++;
+          if (doc.state === 'failed') batch.documentsFailed++;
+          
+          if (doc.extractionSummary) {
+            batch.totalEntitiesExtracted += doc.extractionSummary.totalEntities || 0;
+          }
+          if (doc.gkgSyncSummary) {
+            batch.totalGkgNodesCreated += doc.gkgSyncSummary.nodesCreated || 0;
+          }
+        }
+
+        // Calculate progress and state for each batch
+        for (const batch of batchMap.values()) {
+          const completed = batch.documentsSynced + batch.documentsFailed;
+          batch.progress = batch.totalDocuments > 0 
+            ? Math.round((completed / batch.totalDocuments) * 100) 
+            : 0;
+          
+          if (batch.documentsSynced === batch.totalDocuments) {
+            batch.overallState = 'complete';
+          } else if (batch.documentsFailed === batch.totalDocuments) {
+            batch.overallState = 'failed';
+          } else if (batch.documentsFailed > 0) {
+            batch.overallState = 'partial_failure';
+          }
+        }
+
+        setProjectBatches({
+          projectId,
+          batches: Array.from(batchMap.values())
+        });
+      }
+    } catch (err: unknown) {
+      console.error('Failed to fetch project batches:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    if (projectIdParam) {
+      await fetchProjectBatches(projectIdParam);
+    }
+    setRefreshing(false);
+  };
+
+  const getStateIcon = (state: string) => {
+    switch (state) {
+      case 'complete':
+        return <CheckCircle className="w-5 h-5 text-green-500" />;
+      case 'failed':
+        return <AlertCircle className="w-5 h-5 text-red-500" />;
+      case 'partial_failure':
+        return <AlertCircle className="w-5 h-5 text-orange-500" />;
+      default:
+        return <Loader2 className="w-5 h-5 animate-spin text-blue-500" />;
+    }
+  };
+
+  const getStateBadge = (state: string) => {
+    switch (state) {
+      case 'complete':
+        return <Badge className="bg-green-500">Complete</Badge>;
+      case 'failed':
+        return <Badge variant="destructive">Failed</Badge>;
+      case 'partial_failure':
+        return <Badge className="bg-orange-500">Partial Failure</Badge>;
+      default:
+        return <Badge variant="secondary">Processing</Badge>;
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-background to-muted/30 p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        {/* Header */}
+        <motion.div
+          initial={{ opacity: 0, y: -20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="flex items-center justify-between"
+        >
+          <div className="flex items-center gap-4">
+            <Button
+              variant="ghost"
+              onClick={() => router.back()}
+            >
+              <ArrowLeft className="w-4 h-4 mr-2" />
+              Back
+            </Button>
+            <div>
+              <h1 className="text-2xl font-bold">Semantic Processing Status</h1>
+              <p className="text-muted-foreground">
+                Monitor entity extraction and knowledge graph synchronization
+              </p>
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            onClick={handleRefresh}
+            disabled={refreshing}
+          >
+            <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </motion.div>
+
+        {/* Main Content */}
+        {loading ? (
+          <Card>
+            <CardContent className="flex items-center justify-center py-12">
+              <Loader2 className="w-8 h-8 animate-spin text-primary mr-3" />
+              <span className="text-muted-foreground">Loading processing status...</span>
+            </CardContent>
+          </Card>
+        ) : selectedBatchId ? (
+          /* Single Batch View */
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+          >
+            <SemanticProcessingStatus
+              batchId={selectedBatchId}
+              showDetails={true}
+            />
+          </motion.div>
+        ) : projectBatches ? (
+          /* Project Batches List */
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="space-y-4"
+          >
+            {/* Stats Overview */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-3 rounded-lg bg-blue-500/10">
+                      <FileText className="w-6 h-6 text-blue-500" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold">
+                        {projectBatches.batches.length}
+                      </div>
+                      <div className="text-xs text-muted-foreground">Total Batches</div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-3 rounded-lg bg-green-500/10">
+                      <CheckCircle className="w-6 h-6 text-green-500" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold">
+                        {projectBatches.batches.filter(b => b.overallState === 'complete').length}
+                      </div>
+                      <div className="text-xs text-muted-foreground">Completed</div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-3 rounded-lg bg-purple-500/10">
+                      <Database className="w-6 h-6 text-purple-500" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold">
+                        {projectBatches.batches.reduce((sum, b) => sum + b.totalEntitiesExtracted, 0)}
+                      </div>
+                      <div className="text-xs text-muted-foreground">Total Entities</div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="pt-6">
+                  <div className="flex items-center gap-3">
+                    <div className="p-3 rounded-lg bg-indigo-500/10">
+                      <Network className="w-6 h-6 text-indigo-500" />
+                    </div>
+                    <div>
+                      <div className="text-2xl font-bold">
+                        {projectBatches.batches.reduce((sum, b) => sum + b.totalGkgNodesCreated, 0)}
+                      </div>
+                      <div className="text-xs text-muted-foreground">GKG Nodes</div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Batches List */}
+            <Card>
+              <CardHeader>
+                <CardTitle>Processing Batches</CardTitle>
+                <CardDescription>
+                  Click on a batch to view detailed status
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {projectBatches.batches.length === 0 ? (
+                  <div className="text-center py-8 text-muted-foreground">
+                    No semantic processing batches found
+                  </div>
+                ) : (
+                  projectBatches.batches.map((batch) => (
+                    <div
+                      key={batch.batchId}
+                      className="p-4 rounded-lg border hover:bg-muted/50 cursor-pointer transition-colors"
+                      onClick={() => setSelectedBatchId(batch.batchId)}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          {getStateIcon(batch.overallState)}
+                          <div>
+                            <div className="font-medium">
+                              Batch {batch.batchId.substring(0, 8)}...
+                            </div>
+                            <div className="text-sm text-muted-foreground">
+                              {batch.totalDocuments} documents • Started {new Date(batch.startedAt).toLocaleString()}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <div className="text-right hidden md:block">
+                            <div className="text-sm">
+                              {batch.totalEntitiesExtracted} entities
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {batch.totalGkgNodesCreated} GKG nodes
+                            </div>
+                          </div>
+                          {getStateBadge(batch.overallState)}
+                        </div>
+                      </div>
+                      {batch.progress < 100 && batch.overallState === 'processing' && (
+                        <div className="mt-3">
+                          <div className="h-1.5 bg-muted rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-primary transition-all"
+                              style={{ width: `${batch.progress}%` }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+          </motion.div>
+        ) : (
+          /* No Project/Batch Selected */
+          <Card>
+            <CardContent className="py-12">
+              <div className="text-center space-y-4">
+                <div className="p-4 rounded-full bg-muted inline-flex">
+                  <Search className="w-8 h-8 text-muted-foreground" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-medium">Select a Batch or Project</h3>
+                  <p className="text-muted-foreground">
+                    Use the navigation or provide a batchId or projectId parameter
+                  </p>
+                </div>
+                <div className="max-w-md mx-auto pt-4">
+                  <Label htmlFor="batch-search" className="sr-only">Search by Batch ID</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      id="batch-search"
+                      placeholder="Enter batch ID..."
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                    />
+                    <Button
+                      onClick={() => setSelectedBatchId(searchQuery)}
+                      disabled={!searchQuery}
+                    >
+                      View Status
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Back to List Button (when viewing single batch) */}
+        {selectedBatchId && projectBatches && (
+          <Button
+            variant="outline"
+            onClick={() => setSelectedBatchId(null)}
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Batch List
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/onboarding/processing/page.tsx
+++ b/app/onboarding/processing/page.tsx
@@ -7,7 +7,6 @@ import { motion } from 'framer-motion';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {

--- a/components/onboarding/SemanticProcessingStatus.tsx
+++ b/components/onboarding/SemanticProcessingStatus.tsx
@@ -101,66 +101,77 @@ interface SemanticProcessingStatusProps {
 const STATE_CONFIG: Record<SemanticProcessingState, {
   label: string;
   color: string;
+  badgeClass: string;
   icon: typeof CheckCircle;
   description: string;
 }> = {
   uploaded: {
     label: 'Uploaded',
     color: 'bg-blue-500',
+    badgeClass: 'bg-blue-100',
     icon: FileText,
     description: 'Document uploaded successfully'
   },
   converted: {
     label: 'Converted',
     color: 'bg-blue-600',
+    badgeClass: 'bg-blue-100',
     icon: FileText,
     description: 'Converted to Markdown'
   },
   queued_extraction: {
     label: 'Queued for Extraction',
     color: 'bg-yellow-500',
+    badgeClass: 'bg-yellow-100',
     icon: Clock,
     description: 'Waiting for entity extraction'
   },
   extracting: {
     label: 'Extracting',
     color: 'bg-yellow-600',
+    badgeClass: 'bg-yellow-100',
     icon: Loader2,
     description: 'Extracting entities from document'
   },
   extracted: {
     label: 'Extracted',
     color: 'bg-green-500',
+    badgeClass: 'bg-green-100',
     icon: Database,
     description: 'Entity extraction complete'
   },
   queued_gkg_sync: {
     label: 'Queued for GKG Sync',
     color: 'bg-purple-500',
+    badgeClass: 'bg-purple-100',
     icon: Clock,
     description: 'Waiting for knowledge graph sync'
   },
   syncing: {
     label: 'Syncing to GKG',
     color: 'bg-purple-600',
+    badgeClass: 'bg-purple-100',
     icon: Network,
     description: 'Syncing to Governance Knowledge Graph'
   },
   synced: {
     label: 'Complete',
     color: 'bg-green-600',
+    badgeClass: 'bg-green-100',
     icon: CheckCircle,
     description: 'Fully processed and synced'
   },
   failed: {
     label: 'Failed',
     color: 'bg-red-500',
+    badgeClass: 'bg-red-100',
     icon: AlertCircle,
     description: 'Processing failed'
   },
   retrying: {
     label: 'Retrying',
     color: 'bg-orange-500',
+    badgeClass: 'bg-orange-100',
     icon: RotateCcw,
     description: 'Retrying after failure'
   }
@@ -509,7 +520,7 @@ function DocumentStatusRow({ document, onRetry, isRetrying }: DocumentStatusRowP
                 <TooltipTrigger asChild>
                   <Badge
                     variant="outline"
-                    className={cn('text-xs', config.color && `bg-${config.color.split('-')[1]}-100`)}
+                    className={cn('text-xs', config.badgeClass)}
                   >
                     {config.label}
                   </Badge>

--- a/components/onboarding/SemanticProcessingStatus.tsx
+++ b/components/onboarding/SemanticProcessingStatus.tsx
@@ -1,0 +1,524 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  RefreshCw,
+  ChevronDown,
+  ChevronUp,
+  FileText,
+  Database,
+  Network,
+  Clock,
+  RotateCcw
+} from 'lucide-react';
+import apiClient from '@/lib/api';
+import { toast } from '@/lib/notify';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+type SemanticProcessingState =
+  | 'uploaded'
+  | 'converted'
+  | 'queued_extraction'
+  | 'extracting'
+  | 'extracted'
+  | 'queued_gkg_sync'
+  | 'syncing'
+  | 'synced'
+  | 'failed'
+  | 'retrying';
+
+interface SemanticProcessingStatusData {
+  id: string;
+  documentId: string;
+  batchId: string | null;
+  projectId: string;
+  state: SemanticProcessingState;
+  uploadedAt: string;
+  convertedAt: string | null;
+  extractionStartedAt: string | null;
+  extractionCompletedAt: string | null;
+  gkgSyncStartedAt: string | null;
+  gkgSyncCompletedAt: string | null;
+  errorMessage: string | null;
+  retryCount: number;
+  maxRetries: number;
+  extractionSummary: {
+    entityCounts: Record<string, number>;
+    domainsProcessed: string[];
+    totalEntities: number;
+    processingTimeMs: number;
+  } | null;
+  gkgSyncSummary: {
+    nodesCreated: number;
+    nodesUpdated: number;
+    relationshipsCreated: number;
+    processingTimeMs: number;
+  } | null;
+}
+
+interface BatchProcessingStatusData {
+  batchId: string;
+  projectId: string;
+  totalDocuments: number;
+  documentsConverted: number;
+  documentsExtracted: number;
+  documentsSynced: number;
+  documentsFailed: number;
+  overallState: string;
+  startedAt: string;
+  completedAt: string | null;
+  totalEntitiesExtracted: number;
+  totalGkgNodesCreated: number;
+  progress: number;
+  documents?: SemanticProcessingStatusData[];
+}
+
+interface SemanticProcessingStatusProps {
+  batchId: string;
+  showDetails?: boolean;
+  onComplete?: () => void;
+  pollInterval?: number;
+}
+
+// ============================================================================
+// STATE HELPERS
+// ============================================================================
+
+const STATE_CONFIG: Record<SemanticProcessingState, {
+  label: string;
+  color: string;
+  icon: typeof CheckCircle;
+  description: string;
+}> = {
+  uploaded: {
+    label: 'Uploaded',
+    color: 'bg-blue-500',
+    icon: FileText,
+    description: 'Document uploaded successfully'
+  },
+  converted: {
+    label: 'Converted',
+    color: 'bg-blue-600',
+    icon: FileText,
+    description: 'Converted to Markdown'
+  },
+  queued_extraction: {
+    label: 'Queued for Extraction',
+    color: 'bg-yellow-500',
+    icon: Clock,
+    description: 'Waiting for entity extraction'
+  },
+  extracting: {
+    label: 'Extracting',
+    color: 'bg-yellow-600',
+    icon: Loader2,
+    description: 'Extracting entities from document'
+  },
+  extracted: {
+    label: 'Extracted',
+    color: 'bg-green-500',
+    icon: Database,
+    description: 'Entity extraction complete'
+  },
+  queued_gkg_sync: {
+    label: 'Queued for GKG Sync',
+    color: 'bg-purple-500',
+    icon: Clock,
+    description: 'Waiting for knowledge graph sync'
+  },
+  syncing: {
+    label: 'Syncing to GKG',
+    color: 'bg-purple-600',
+    icon: Network,
+    description: 'Syncing to Governance Knowledge Graph'
+  },
+  synced: {
+    label: 'Complete',
+    color: 'bg-green-600',
+    icon: CheckCircle,
+    description: 'Fully processed and synced'
+  },
+  failed: {
+    label: 'Failed',
+    color: 'bg-red-500',
+    icon: AlertCircle,
+    description: 'Processing failed'
+  },
+  retrying: {
+    label: 'Retrying',
+    color: 'bg-orange-500',
+    icon: RotateCcw,
+    description: 'Retrying after failure'
+  }
+};
+
+const PROCESSING_STAGES = [
+  { state: 'uploaded', label: 'Upload' },
+  { state: 'converted', label: 'Convert' },
+  { state: 'extracting', label: 'Extract' },
+  { state: 'syncing', label: 'GKG Sync' },
+  { state: 'synced', label: 'Complete' }
+];
+
+function getStageIndex(state: SemanticProcessingState): number {
+  const stageMap: Record<SemanticProcessingState, number> = {
+    uploaded: 0,
+    converted: 1,
+    queued_extraction: 1.5,
+    extracting: 2,
+    extracted: 2.5,
+    queued_gkg_sync: 2.5,
+    syncing: 3,
+    synced: 4,
+    failed: -1,
+    retrying: -1
+  };
+  return stageMap[state];
+}
+
+// ============================================================================
+// COMPONENT
+// ============================================================================
+
+export function SemanticProcessingStatus({
+  batchId,
+  showDetails = false,
+  onComplete,
+  pollInterval = 3000
+}: SemanticProcessingStatusProps) {
+  const [batchStatus, setBatchStatus] = useState<BatchProcessingStatusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState(showDetails);
+  const [retrying, setRetrying] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const response = await apiClient.get(`/api/semantic-processing/batch/${batchId}`);
+      
+      if (response.data?.success) {
+        setBatchStatus(response.data.data);
+        setError(null);
+
+        // Check if complete
+        if (response.data.data.overallState === 'complete' && onComplete) {
+          onComplete();
+        }
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to fetch status';
+      // Only set error if this is the first load or a real error (not 404 for new batches)
+      if (!batchStatus) {
+        setError(message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [batchId, onComplete, batchStatus]);
+
+  useEffect(() => {
+    fetchStatus();
+
+    // Poll while processing
+    const interval = setInterval(() => {
+      if (batchStatus?.overallState !== 'complete') {
+        fetchStatus();
+      }
+    }, pollInterval);
+
+    return () => clearInterval(interval);
+  }, [fetchStatus, pollInterval, batchStatus?.overallState]);
+
+  const handleRetryDocument = async (documentId: string) => {
+    setRetrying(documentId);
+    try {
+      const response = await apiClient.post(`/api/semantic-processing/document/${documentId}/retry`);
+      
+      if (response.data?.success) {
+        toast.success('Retry initiated successfully');
+        fetchStatus();
+      } else {
+        toast.error(response.data?.error || 'Failed to retry');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to retry';
+      toast.error(message);
+    } finally {
+      setRetrying(null);
+    }
+  };
+
+  const handleRetryAllFailed = async () => {
+    try {
+      const response = await apiClient.post(`/api/semantic-processing/batch/${batchId}/retry-failed`);
+      
+      if (response.data?.success) {
+        toast.success(`Retry initiated for ${response.data.data.successful} documents`);
+        fetchStatus();
+      } else {
+        toast.error(response.data?.error || 'Failed to retry');
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to retry';
+      toast.error(message);
+    }
+  };
+
+  if (loading && !batchStatus) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <Loader2 className="w-6 h-6 animate-spin text-primary mr-2" />
+          <span className="text-muted-foreground">Loading semantic processing status...</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error && !batchStatus) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8 text-muted-foreground">
+          <span>No semantic processing data available yet</span>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!batchStatus) {
+    return null;
+  }
+
+  const isComplete = batchStatus.overallState === 'complete';
+  const hasFailed = batchStatus.documentsFailed > 0;
+  const isProcessing = !isComplete && !hasFailed;
+
+  return (
+    <Card className="border-l-4 border-l-primary">
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            {isProcessing && <Loader2 className="w-5 h-5 animate-spin text-primary" />}
+            {isComplete && !hasFailed && <CheckCircle className="w-5 h-5 text-green-500" />}
+            {hasFailed && <AlertCircle className="w-5 h-5 text-red-500" />}
+            <CardTitle className="text-lg">Semantic Processing</CardTitle>
+          </div>
+          <Badge variant={isComplete ? 'default' : hasFailed ? 'destructive' : 'secondary'}>
+            {batchStatus.overallState}
+          </Badge>
+        </div>
+        <CardDescription>
+          Automatic entity extraction and knowledge graph synchronization
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Progress Overview */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Overall Progress</span>
+            <span className="font-medium">{batchStatus.progress}%</span>
+          </div>
+          <Progress value={batchStatus.progress} className="h-2" />
+        </div>
+
+        {/* Stats Grid */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className="text-center p-3 bg-muted/50 rounded-lg">
+            <div className="text-2xl font-bold">{batchStatus.totalDocuments}</div>
+            <div className="text-xs text-muted-foreground">Total Documents</div>
+          </div>
+          <div className="text-center p-3 bg-green-500/10 rounded-lg">
+            <div className="text-2xl font-bold text-green-600">{batchStatus.documentsSynced}</div>
+            <div className="text-xs text-muted-foreground">Completed</div>
+          </div>
+          <div className="text-center p-3 bg-blue-500/10 rounded-lg">
+            <div className="text-2xl font-bold text-blue-600">{batchStatus.totalEntitiesExtracted}</div>
+            <div className="text-xs text-muted-foreground">Entities Extracted</div>
+          </div>
+          <div className="text-center p-3 bg-purple-500/10 rounded-lg">
+            <div className="text-2xl font-bold text-purple-600">{batchStatus.totalGkgNodesCreated}</div>
+            <div className="text-xs text-muted-foreground">GKG Nodes</div>
+          </div>
+        </div>
+
+        {/* Failed Documents Alert */}
+        {hasFailed && (
+          <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <AlertCircle className="w-5 h-5 text-red-500" />
+                <span className="font-medium text-red-600">
+                  {batchStatus.documentsFailed} document(s) failed processing
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRetryAllFailed}
+                className="text-red-600 border-red-500/50 hover:bg-red-500/10"
+              >
+                <RefreshCw className="w-4 h-4 mr-1" />
+                Retry All Failed
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Document Details Collapsible */}
+        {batchStatus.documents && batchStatus.documents.length > 0 && (
+          <Collapsible open={expanded} onOpenChange={setExpanded}>
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" className="w-full justify-between">
+                <span>Document Details ({batchStatus.documents.length})</span>
+                {expanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+              </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-2 mt-2">
+              <AnimatePresence>
+                {batchStatus.documents.map((doc) => (
+                  <DocumentStatusRow
+                    key={doc.documentId}
+                    document={doc}
+                    onRetry={() => handleRetryDocument(doc.documentId)}
+                    isRetrying={retrying === doc.documentId}
+                  />
+                ))}
+              </AnimatePresence>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ============================================================================
+// DOCUMENT STATUS ROW
+// ============================================================================
+
+interface DocumentStatusRowProps {
+  document: SemanticProcessingStatusData;
+  onRetry: () => void;
+  isRetrying: boolean;
+}
+
+function DocumentStatusRow({ document, onRetry, isRetrying }: DocumentStatusRowProps) {
+  const config = STATE_CONFIG[document.state];
+  const StateIcon = config.icon;
+  const stageIndex = getStageIndex(document.state);
+  const isFailed = document.state === 'failed';
+  const canRetry = isFailed && document.retryCount < document.maxRetries;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      className={cn(
+        'p-3 rounded-lg border bg-card',
+        isFailed && 'border-red-500/50 bg-red-500/5'
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <StateIcon
+            className={cn(
+              'w-5 h-5 flex-shrink-0',
+              document.state === 'extracting' || document.state === 'syncing'
+                ? 'animate-spin text-yellow-500'
+                : isFailed
+                ? 'text-red-500'
+                : document.state === 'synced'
+                ? 'text-green-500'
+                : 'text-blue-500'
+            )}
+          />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium truncate">{document.documentId.substring(0, 8)}...</div>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="outline"
+                    className={cn('text-xs', config.color && `bg-${config.color.split('-')[1]}-100`)}
+                  >
+                    {config.label}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{config.description}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </div>
+
+        {/* Stage Progress */}
+        <div className="hidden md:flex items-center gap-1 mx-4">
+          {PROCESSING_STAGES.map((stage, idx) => (
+            <div
+              key={stage.state}
+              className={cn(
+                'w-2 h-2 rounded-full transition-colors',
+                idx <= stageIndex ? 'bg-primary' : 'bg-muted',
+                isFailed && 'bg-red-500'
+              )}
+            />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          {document.extractionSummary && (
+            <Badge variant="secondary" className="text-xs">
+              {document.extractionSummary.totalEntities} entities
+            </Badge>
+          )}
+          {canRetry && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onRetry}
+              disabled={isRetrying}
+            >
+              {isRetrying ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <RefreshCw className="w-4 h-4" />
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Error Message */}
+      {isFailed && document.errorMessage && (
+        <div className="mt-2 text-xs text-red-600 bg-red-500/10 p-2 rounded">
+          {document.errorMessage}
+          {document.retryCount > 0 && (
+            <span className="ml-2 text-muted-foreground">
+              (Retry {document.retryCount}/{document.maxRetries})
+            </span>
+          )}
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+export default SemanticProcessingStatus;

--- a/components/onboarding/SemanticProcessingStatus.tsx
+++ b/components/onboarding/SemanticProcessingStatus.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -205,43 +205,97 @@ export function SemanticProcessingStatus({
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(showDetails);
   const [retrying, setRetrying] = useState<string | null>(null);
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
 
-  const fetchStatus = useCallback(async () => {
+  const fetchStatus = useCallback(async (): Promise<BatchProcessingStatusData | null> => {
     try {
       const response = await apiClient.get(`/api/semantic-processing/batch/${batchId}`);
-      
-      if (response.data?.success) {
-        setBatchStatus(response.data.data);
-        setError(null);
 
-        // Check if complete
-        if (response.data.data.overallState === 'complete' && onComplete) {
-          onComplete();
-        }
+      if (response.data?.success) {
+        const data = response.data.data as BatchProcessingStatusData;
+        setBatchStatus(data);
+        setError(null);
+        return data;
       }
+      return null;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to fetch status';
-      // Only set error if this is the first load or a real error (not 404 for new batches)
-      if (!batchStatus) {
-        setError(message);
-      }
+      setBatchStatus((prev) => {
+        if (!prev) {
+          setError(message);
+        }
+        return prev;
+      });
+      return null;
     } finally {
       setLoading(false);
     }
-  }, [batchId, onComplete, batchStatus]);
+  }, [batchId]);
 
   useEffect(() => {
-    fetchStatus();
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | undefined;
+    let pollingStopped = false;
 
-    // Poll while processing
-    const interval = setInterval(() => {
-      if (batchStatus?.overallState !== 'complete') {
-        fetchStatus();
+    const tick = async () => {
+      if (cancelled || pollingStopped) return;
+
+      setLoading(true);
+      try {
+        const response = await apiClient.get(`/api/semantic-processing/batch/${batchId}`);
+        if (cancelled) return;
+
+        if (response.data?.success) {
+          const data = response.data.data as BatchProcessingStatusData;
+          setBatchStatus(data);
+          setError(null);
+
+          if (data.overallState === 'complete') {
+            onCompleteRef.current?.();
+          }
+
+          const terminal =
+            data.overallState === 'complete' ||
+            data.overallState === 'failed' ||
+            data.overallState === 'partial_failure';
+
+          if (terminal) {
+            pollingStopped = true;
+            if (intervalId !== undefined) {
+              clearInterval(intervalId);
+            }
+          }
+        }
+      } catch (err: unknown) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : 'Failed to fetch status';
+        setBatchStatus((prev) => {
+          if (!prev) {
+            setError(message);
+          }
+          return prev;
+        });
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
       }
+    };
+
+    void tick();
+    intervalId = setInterval(() => {
+      void tick();
     }, pollInterval);
 
-    return () => clearInterval(interval);
-  }, [fetchStatus, pollInterval, batchStatus?.overallState]);
+    return () => {
+      cancelled = true;
+      pollingStopped = true;
+      if (intervalId !== undefined) {
+        clearInterval(intervalId);
+      }
+    };
+  }, [batchId, pollInterval]);
 
   const handleRetryDocument = async (documentId: string) => {
     setRetrying(documentId);
@@ -250,7 +304,7 @@ export function SemanticProcessingStatus({
       
       if (response.data?.success) {
         toast.success('Retry initiated successfully');
-        fetchStatus();
+        await fetchStatus();
       } else {
         toast.error(response.data?.error || 'Failed to retry');
       }
@@ -268,7 +322,7 @@ export function SemanticProcessingStatus({
       
       if (response.data?.success) {
         toast.success(`Retry initiated for ${response.data.data.successful} documents`);
-        fetchStatus();
+        await fetchStatus();
       } else {
         toast.error(response.data?.error || 'Failed to retry');
       }

--- a/components/onboarding/SemanticProcessingStatus.tsx
+++ b/components/onboarding/SemanticProcessingStatus.tsx
@@ -370,7 +370,18 @@ export function SemanticProcessingStatus({
 
   const isComplete = batchStatus.overallState === 'complete';
   const hasFailed = batchStatus.documentsFailed > 0;
-  const isProcessing = !isComplete && !hasFailed;
+  const isProcessing = batchStatus.overallState === 'processing';
+
+  const progressPercent =
+    typeof batchStatus.progress === 'number' && !Number.isNaN(batchStatus.progress)
+      ? batchStatus.progress
+      : batchStatus.totalDocuments > 0
+        ? Math.round(
+            ((batchStatus.documentsSynced + batchStatus.documentsFailed) /
+              batchStatus.totalDocuments) *
+              100
+          )
+        : 0;
 
   return (
     <Card className="border-l-4 border-l-primary">
@@ -396,9 +407,9 @@ export function SemanticProcessingStatus({
         <div className="space-y-2">
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Overall Progress</span>
-            <span className="font-medium">{batchStatus.progress}%</span>
+            <span className="font-medium">{progressPercent}%</span>
           </div>
-          <Progress value={batchStatus.progress} className="h-2" />
+          <Progress value={progressPercent} className="h-2" />
         </div>
 
         {/* Stats Grid */}

--- a/server/migrations/400_add_semantic_processing_status.sql
+++ b/server/migrations/400_add_semantic_processing_status.sql
@@ -1,0 +1,138 @@
+-- Migration: 400_add_semantic_processing_status
+-- Purpose: Add semantic processing state tracking for onboarding documents
+-- Supports async pipeline: upload → convert → extract → persist → GKG sync
+
+-- Semantic processing status enum
+DO $$ BEGIN
+    CREATE TYPE semantic_processing_state AS ENUM (
+        'uploaded',           -- File uploaded, not yet processed
+        'converted',          -- Converted to Markdown
+        'queued_extraction',  -- Queued for entity extraction
+        'extracting',         -- Entity extraction in progress
+        'extracted',          -- Entity extraction complete
+        'queued_gkg_sync',    -- Queued for GKG synchronization
+        'syncing',            -- GKG sync in progress
+        'synced',             -- GKG sync complete (terminal success)
+        'failed',             -- Processing failed (retryable)
+        'retrying'            -- Retry in progress
+    );
+EXCEPTION
+    WHEN duplicate_object THEN null;
+END $$;
+
+-- Semantic processing status table (document-level tracking)
+CREATE TABLE IF NOT EXISTS semantic_processing_status (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    batch_id UUID REFERENCES upload_batches(id) ON DELETE SET NULL,
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    
+    -- Current state
+    state semantic_processing_state NOT NULL DEFAULT 'uploaded',
+    
+    -- Stage timestamps for traceability
+    uploaded_at TIMESTAMPTZ DEFAULT NOW(),
+    converted_at TIMESTAMPTZ,
+    extraction_started_at TIMESTAMPTZ,
+    extraction_completed_at TIMESTAMPTZ,
+    gkg_sync_started_at TIMESTAMPTZ,
+    gkg_sync_completed_at TIMESTAMPTZ,
+    
+    -- Error handling
+    error_message TEXT,
+    error_details JSONB,
+    retry_count INT DEFAULT 0,
+    max_retries INT DEFAULT 3,
+    last_retry_at TIMESTAMPTZ,
+    
+    -- Job tracking
+    extraction_job_id UUID,
+    gkg_sync_job_id UUID,
+    
+    -- Extraction results summary
+    extraction_summary JSONB,  -- { entity_counts: {...}, domains_processed: [...] }
+    
+    -- GKG sync results
+    gkg_sync_summary JSONB,    -- { nodes_created: N, relationships: N, ... }
+    
+    -- Metadata
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    
+    CONSTRAINT unique_document_processing UNIQUE (document_id)
+);
+
+-- Batch-level semantic processing summary
+CREATE TABLE IF NOT EXISTS semantic_processing_batches (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    batch_id UUID NOT NULL REFERENCES upload_batches(id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    
+    -- Aggregate status
+    total_documents INT NOT NULL DEFAULT 0,
+    documents_converted INT DEFAULT 0,
+    documents_extracted INT DEFAULT 0,
+    documents_synced INT DEFAULT 0,
+    documents_failed INT DEFAULT 0,
+    
+    -- Overall state (derived from document states)
+    overall_state VARCHAR(50) NOT NULL DEFAULT 'processing',
+    
+    -- Timing
+    started_at TIMESTAMPTZ DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    
+    -- Aggregate results
+    total_entities_extracted INT DEFAULT 0,
+    total_gkg_nodes_created INT DEFAULT 0,
+    
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    
+    CONSTRAINT unique_batch_processing UNIQUE (batch_id)
+);
+
+-- Indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_semantic_status_document ON semantic_processing_status(document_id);
+CREATE INDEX IF NOT EXISTS idx_semantic_status_batch ON semantic_processing_status(batch_id);
+CREATE INDEX IF NOT EXISTS idx_semantic_status_project ON semantic_processing_status(project_id);
+CREATE INDEX IF NOT EXISTS idx_semantic_status_state ON semantic_processing_status(state);
+CREATE INDEX IF NOT EXISTS idx_semantic_status_created ON semantic_processing_status(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_semantic_batch_batch ON semantic_processing_batches(batch_id);
+CREATE INDEX IF NOT EXISTS idx_semantic_batch_project ON semantic_processing_batches(project_id);
+CREATE INDEX IF NOT EXISTS idx_semantic_batch_state ON semantic_processing_batches(overall_state);
+
+-- Trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_semantic_processing_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS semantic_processing_status_updated ON semantic_processing_status;
+CREATE TRIGGER semantic_processing_status_updated
+    BEFORE UPDATE ON semantic_processing_status
+    FOR EACH ROW
+    EXECUTE FUNCTION update_semantic_processing_timestamp();
+
+DROP TRIGGER IF EXISTS semantic_processing_batches_updated ON semantic_processing_batches;
+CREATE TRIGGER semantic_processing_batches_updated
+    BEFORE UPDATE ON semantic_processing_batches
+    FOR EACH ROW
+    EXECUTE FUNCTION update_semantic_processing_timestamp();
+
+-- Add column to documents table to link semantic processing (if not exists)
+DO $$ BEGIN
+    ALTER TABLE documents ADD COLUMN IF NOT EXISTS semantic_processing_id UUID REFERENCES semantic_processing_status(id);
+EXCEPTION
+    WHEN duplicate_column THEN null;
+END $$;
+
+COMMENT ON TABLE semantic_processing_status IS 'Tracks semantic processing lifecycle for individual documents: upload → convert → extract → GKG sync';
+COMMENT ON TABLE semantic_processing_batches IS 'Aggregate semantic processing status at batch level for onboarding visibility';
+COMMENT ON COLUMN semantic_processing_status.state IS 'Current processing state: uploaded, converted, queued_extraction, extracting, extracted, queued_gkg_sync, syncing, synced, failed, retrying';
+COMMENT ON COLUMN semantic_processing_status.extraction_summary IS 'JSON summary of extraction results: entity counts, domains processed';
+COMMENT ON COLUMN semantic_processing_status.gkg_sync_summary IS 'JSON summary of GKG sync results: nodes created, relationships';

--- a/server/migrations/401_semantic_processing_job_ids_text.sql
+++ b/server/migrations/401_semantic_processing_job_ids_text.sql
@@ -1,0 +1,9 @@
+-- Migration: 401_semantic_processing_job_ids_text
+-- Purpose: Store queue / correlation job ids as TEXT (Bull/Rabbit job ids are not UUIDs)
+
+ALTER TABLE semantic_processing_status
+  ALTER COLUMN extraction_job_id TYPE TEXT USING extraction_job_id::text,
+  ALTER COLUMN gkg_sync_job_id TYPE TEXT USING gkg_sync_job_id::text;
+
+COMMENT ON COLUMN semantic_processing_status.extraction_job_id IS 'Queue job id or correlation id for extraction (TEXT)';
+COMMENT ON COLUMN semantic_processing_status.gkg_sync_job_id IS 'Queue job id or correlation id for GKG sync (TEXT)';

--- a/server/src/lib/project-access.ts
+++ b/server/src/lib/project-access.ts
@@ -30,7 +30,8 @@ export async function userHasProjectAccess(
   user: AuthenticatedUser,
   projectId: string
 ): Promise<boolean> {
-  if (user.role === "admin" || user.role === "super_admin") return true
+  const role = String(user.role || "").toLowerCase()
+  if (role === "admin" || role === "super_admin") return true
 
   const r = await pool.query<{ owner_id: string | null; team_members: unknown }>(
     "SELECT owner_id, team_members FROM public.projects WHERE id = $1",

--- a/server/src/routes/semanticProcessingRoutes.ts
+++ b/server/src/routes/semanticProcessingRoutes.ts
@@ -12,8 +12,49 @@ import { authenticateToken as authenticate } from '../middleware/auth';
 import { semanticProcessingService } from '../services/semanticProcessingService';
 import { semanticProcessingQueue } from '../services/queueService';
 import { logger } from '../utils/logger';
+import { pool } from '../database/connection';
+import { userHasProjectAccess } from '../lib/project-access';
+import type { AuthenticatedUser } from '../../../lib/auth-utils';
 
 const router = Router();
+
+function userFromReq(req: Request): AuthenticatedUser | null {
+  const u = (req as any).user;
+  if (!u?.id) return null;
+  return {
+    id: u.id,
+    email: u.email || '',
+    role: String(u.role || ''),
+    permissions: u.permissions ?? {},
+  };
+}
+
+async function requireSemanticProjectAccess(
+  req: Request,
+  res: Response,
+  projectId: string
+): Promise<boolean> {
+  const user = userFromReq(req);
+  if (!user) {
+    res.status(401).json({ success: false, error: 'Unauthorized' });
+    return false;
+  }
+  try {
+    const ok = await userHasProjectAccess(pool, user, projectId);
+    if (!ok) {
+      res.status(403).json({ success: false, error: 'Access denied' });
+      return false;
+    }
+    return true;
+  } catch (error: unknown) {
+    logger.error('Semantic route: project access check failed', {
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    res.status(500).json({ success: false, error: 'Access check failed' });
+    return false;
+  }
+}
 
 // ============================================================================
 // DOCUMENT STATUS ENDPOINTS
@@ -37,6 +78,10 @@ router.get(
           success: false,
           error: 'No semantic processing record found for this document'
         });
+      }
+
+      if (!(await requireSemanticProjectAccess(req, res, status.projectId))) {
+        return;
       }
 
       return res.json({
@@ -78,6 +123,10 @@ router.get(
         });
       }
 
+      if (!(await requireSemanticProjectAccess(req, res, status.projectId))) {
+        return;
+      }
+
       return res.json({
         success: true,
         data: status
@@ -111,6 +160,10 @@ router.get(
           success: false,
           error: 'No semantic processing record found for this batch'
         });
+      }
+
+      if (!(await requireSemanticProjectAccess(req, res, status.projectId))) {
+        return;
       }
 
       // Return lightweight summary without full document details
@@ -160,6 +213,10 @@ router.get(
     try {
       const { projectId } = req.params;
 
+      if (!(await requireSemanticProjectAccess(req, res, projectId))) {
+        return;
+      }
+
       const statuses = await semanticProcessingService.getProjectStatus(projectId);
 
       return res.json({
@@ -207,6 +264,10 @@ router.post(
           success: false,
           error: 'No semantic processing record found for this document'
         });
+      }
+
+      if (!(await requireSemanticProjectAccess(req, res, currentStatus.projectId))) {
+        return;
       }
 
       if (currentStatus.state !== 'failed') {
@@ -293,6 +354,10 @@ router.post(
         });
       }
 
+      if (!(await requireSemanticProjectAccess(req, res, batchStatus.projectId))) {
+        return;
+      }
+
       // Find failed documents that can be retried
       const failedDocs = batchStatus.documents.filter(
         doc => doc.state === 'failed' && doc.retryCount < doc.maxRetries
@@ -372,6 +437,17 @@ router.get(
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { projectId } = req.query as { projectId?: string };
+
+      if (!projectId || typeof projectId !== 'string') {
+        return res.status(400).json({
+          success: false,
+          error: 'projectId query parameter is required',
+        });
+      }
+
+      if (!(await requireSemanticProjectAccess(req, res, projectId))) {
+        return;
+      }
 
       const documents = await semanticProcessingService.getRetryableDocuments(projectId);
 

--- a/server/src/routes/semanticProcessingRoutes.ts
+++ b/server/src/routes/semanticProcessingRoutes.ts
@@ -1,0 +1,395 @@
+/**
+ * Semantic Processing Routes
+ * 
+ * API endpoints for semantic processing status retrieval and management.
+ * Provides visibility into the async processing pipeline lifecycle.
+ * 
+ * @module semanticProcessingRoutes
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { authenticateToken as authenticate } from '../middleware/auth';
+import { semanticProcessingService } from '../services/semanticProcessingService';
+import { semanticProcessingQueue } from '../services/queueService';
+import { logger } from '../utils/logger';
+
+const router = Router();
+
+// ============================================================================
+// DOCUMENT STATUS ENDPOINTS
+// ============================================================================
+
+/**
+ * GET /api/semantic-processing/document/:documentId
+ * Get semantic processing status for a single document
+ */
+router.get(
+  '/document/:documentId',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { documentId } = req.params;
+
+      const status = await semanticProcessingService.getDocumentStatus(documentId);
+
+      if (!status) {
+        return res.status(404).json({
+          success: false,
+          error: 'No semantic processing record found for this document'
+        });
+      }
+
+      return res.json({
+        success: true,
+        data: status
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to get document semantic status', {
+        documentId: req.params.documentId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+// ============================================================================
+// BATCH STATUS ENDPOINTS
+// ============================================================================
+
+/**
+ * GET /api/semantic-processing/batch/:batchId
+ * Get semantic processing status for all documents in a batch
+ */
+router.get(
+  '/batch/:batchId',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { batchId } = req.params;
+
+      const status = await semanticProcessingService.getBatchStatus(batchId);
+
+      if (!status) {
+        return res.status(404).json({
+          success: false,
+          error: 'No semantic processing record found for this batch'
+        });
+      }
+
+      return res.json({
+        success: true,
+        data: status
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to get batch semantic status', {
+        batchId: req.params.batchId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+/**
+ * GET /api/semantic-processing/batch/:batchId/summary
+ * Get a lightweight summary of batch processing status (for polling)
+ */
+router.get(
+  '/batch/:batchId/summary',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { batchId } = req.params;
+
+      const status = await semanticProcessingService.getBatchStatus(batchId);
+
+      if (!status) {
+        return res.status(404).json({
+          success: false,
+          error: 'No semantic processing record found for this batch'
+        });
+      }
+
+      // Return lightweight summary without full document details
+      return res.json({
+        success: true,
+        data: {
+          batchId: status.batchId,
+          projectId: status.projectId,
+          overallState: status.overallState,
+          totalDocuments: status.totalDocuments,
+          documentsConverted: status.documentsConverted,
+          documentsExtracted: status.documentsExtracted,
+          documentsSynced: status.documentsSynced,
+          documentsFailed: status.documentsFailed,
+          totalEntitiesExtracted: status.totalEntitiesExtracted,
+          totalGkgNodesCreated: status.totalGkgNodesCreated,
+          startedAt: status.startedAt,
+          completedAt: status.completedAt,
+          progress: status.totalDocuments > 0
+            ? Math.round((status.documentsSynced + status.documentsFailed) / status.totalDocuments * 100)
+            : 0
+        }
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to get batch semantic summary', {
+        batchId: req.params.batchId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+// ============================================================================
+// PROJECT STATUS ENDPOINTS
+// ============================================================================
+
+/**
+ * GET /api/semantic-processing/project/:projectId
+ * Get semantic processing status for all documents in a project
+ */
+router.get(
+  '/project/:projectId',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { projectId } = req.params;
+
+      const statuses = await semanticProcessingService.getProjectStatus(projectId);
+
+      return res.json({
+        success: true,
+        data: {
+          projectId,
+          totalDocuments: statuses.length,
+          documents: statuses
+        }
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to get project semantic status', {
+        projectId: req.params.projectId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+// ============================================================================
+// RETRY ENDPOINTS
+// ============================================================================
+
+/**
+ * POST /api/semantic-processing/document/:documentId/retry
+ * Retry failed semantic processing for a document
+ */
+router.post(
+  '/document/:documentId/retry',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { documentId } = req.params;
+      const userId = (req as any).user?.id || 'system';
+
+      logger.info('Initiating semantic processing retry', { documentId, userId });
+
+      // Get current status to check if retry is allowed
+      const currentStatus = await semanticProcessingService.getDocumentStatus(documentId);
+
+      if (!currentStatus) {
+        return res.status(404).json({
+          success: false,
+          error: 'No semantic processing record found for this document'
+        });
+      }
+
+      if (currentStatus.state !== 'failed') {
+        return res.status(400).json({
+          success: false,
+          error: `Cannot retry document in state: ${currentStatus.state}. Only failed documents can be retried.`
+        });
+      }
+
+      if (currentStatus.retryCount >= currentStatus.maxRetries) {
+        return res.status(400).json({
+          success: false,
+          error: `Maximum retries (${currentStatus.maxRetries}) exceeded. Manual intervention required.`
+        });
+      }
+
+      // Initiate retry
+      const newStatus = await semanticProcessingService.retry(documentId);
+
+      // Enqueue processing job
+      if (newStatus && newStatus.state === 'queued_extraction') {
+        await semanticProcessingQueue.add('semantic-process-document', {
+          documentId,
+          projectId: currentStatus.projectId,
+          batchId: currentStatus.batchId,
+          userId,
+          skipExtraction: false,
+          skipGkgSync: false
+        }, {
+          jobId: `semantic-retry-${documentId}-${Date.now()}`,
+          priority: 3 // Higher priority for retries
+        });
+      } else if (newStatus && newStatus.state === 'queued_gkg_sync') {
+        await semanticProcessingQueue.add('semantic-process-document', {
+          documentId,
+          projectId: currentStatus.projectId,
+          batchId: currentStatus.batchId,
+          userId,
+          skipExtraction: true,
+          skipGkgSync: false
+        }, {
+          jobId: `semantic-retry-gkg-${documentId}-${Date.now()}`,
+          priority: 3
+        });
+      }
+
+      return res.json({
+        success: true,
+        data: newStatus,
+        message: `Retry initiated. Attempt ${(newStatus?.retryCount || 0)} of ${currentStatus.maxRetries}`
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to retry semantic processing', {
+        documentId: req.params.documentId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+/**
+ * POST /api/semantic-processing/batch/:batchId/retry-failed
+ * Retry all failed documents in a batch
+ */
+router.post(
+  '/batch/:batchId/retry-failed',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { batchId } = req.params;
+      const userId = (req as any).user?.id || 'system';
+
+      logger.info('Initiating batch retry for failed documents', { batchId, userId });
+
+      // Get batch status
+      const batchStatus = await semanticProcessingService.getBatchStatus(batchId);
+
+      if (!batchStatus) {
+        return res.status(404).json({
+          success: false,
+          error: 'No semantic processing record found for this batch'
+        });
+      }
+
+      // Find failed documents that can be retried
+      const failedDocs = batchStatus.documents.filter(
+        doc => doc.state === 'failed' && doc.retryCount < doc.maxRetries
+      );
+
+      if (failedDocs.length === 0) {
+        return res.status(400).json({
+          success: false,
+          error: 'No failed documents eligible for retry in this batch'
+        });
+      }
+
+      // Retry each failed document
+      const results: Array<{ documentId: string; success: boolean; error?: string }> = [];
+
+      for (const doc of failedDocs) {
+        try {
+          await semanticProcessingService.retry(doc.documentId);
+          
+          await semanticProcessingQueue.add('semantic-process-document', {
+            documentId: doc.documentId,
+            projectId: doc.projectId,
+            batchId: doc.batchId,
+            userId,
+            skipExtraction: doc.extractionCompletedAt !== null,
+            skipGkgSync: false
+          }, {
+            jobId: `semantic-retry-${doc.documentId}-${Date.now()}`,
+            priority: 3
+          });
+
+          results.push({ documentId: doc.documentId, success: true });
+        } catch (error) {
+          results.push({
+            documentId: doc.documentId,
+            success: false,
+            error: error instanceof Error ? error.message : String(error)
+          });
+        }
+      }
+
+      const successful = results.filter(r => r.success).length;
+      const failed = results.filter(r => !r.success).length;
+
+      return res.json({
+        success: true,
+        data: {
+          totalRetried: results.length,
+          successful,
+          failed,
+          results
+        },
+        message: `Retry initiated for ${successful} documents. ${failed} failed to queue.`
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to retry batch documents', {
+        batchId: req.params.batchId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+// ============================================================================
+// RETRYABLE DOCUMENTS ENDPOINT
+// ============================================================================
+
+/**
+ * GET /api/semantic-processing/retryable
+ * Get all documents eligible for retry (failed with retry count < max)
+ */
+router.get(
+  '/retryable',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { projectId } = req.query as { projectId?: string };
+
+      const documents = await semanticProcessingService.getRetryableDocuments(projectId);
+
+      return res.json({
+        success: true,
+        data: {
+          totalRetryable: documents.length,
+          documents
+        }
+      });
+
+    } catch (error: unknown) {
+      logger.error('Failed to get retryable documents', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/server/src/routes/semanticProcessingRoutes.ts
+++ b/server/src/routes/semanticProcessingRoutes.ts
@@ -287,30 +287,58 @@ router.post(
       // Initiate retry
       const newStatus = await semanticProcessingService.retry(documentId);
 
-      // Enqueue processing job
-      if (newStatus && newStatus.state === 'queued_extraction') {
-        await semanticProcessingQueue.add('semantic-process-document', {
-          documentId,
-          projectId: currentStatus.projectId,
-          batchId: currentStatus.batchId,
-          userId,
-          skipExtraction: false,
-          skipGkgSync: false
-        }, {
-          jobId: `semantic-retry-${documentId}-${Date.now()}`,
-          priority: 3 // Higher priority for retries
+      if (!newStatus) {
+        return res.status(500).json({
+          success: false,
+          error: 'Retry did not return a status; cannot queue job'
         });
-      } else if (newStatus && newStatus.state === 'queued_gkg_sync') {
-        await semanticProcessingQueue.add('semantic-process-document', {
-          documentId,
-          projectId: currentStatus.projectId,
-          batchId: currentStatus.batchId,
-          userId,
-          skipExtraction: true,
-          skipGkgSync: false
-        }, {
-          jobId: `semantic-retry-gkg-${documentId}-${Date.now()}`,
-          priority: 3
+      }
+
+      try {
+        if (newStatus && newStatus.state === 'queued_extraction') {
+          await semanticProcessingQueue.add('semantic-process-document', {
+            documentId,
+            projectId: currentStatus.projectId,
+            batchId: currentStatus.batchId,
+            userId,
+            skipExtraction: false,
+            skipGkgSync: false
+          }, {
+            jobId: `semantic-retry-${documentId}-${Date.now()}`,
+            priority: 3 // Higher priority for retries
+          });
+        } else if (newStatus && newStatus.state === 'queued_gkg_sync') {
+          await semanticProcessingQueue.add('semantic-process-document', {
+            documentId,
+            projectId: currentStatus.projectId,
+            batchId: currentStatus.batchId,
+            userId,
+            skipExtraction: true,
+            skipGkgSync: false
+          }, {
+            jobId: `semantic-retry-gkg-${documentId}-${Date.now()}`,
+            priority: 3
+          });
+        }
+      } catch (enqueueErr: unknown) {
+        const msg = enqueueErr instanceof Error ? enqueueErr.message : String(enqueueErr);
+        logger.error('Semantic retry queue enqueue failed', { documentId, error: msg });
+        try {
+          await semanticProcessingService.markFailed(
+            documentId,
+            `Queue enqueue failed: ${msg}`,
+            { enqueueFailed: true }
+          );
+        } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll document back to failed after enqueue error', {
+            documentId,
+            error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+          });
+        }
+        return res.status(503).json({
+          success: false,
+          error: 'Failed to queue retry job; document marked failed so you can retry again.',
+          details: msg
         });
       }
 
@@ -376,7 +404,7 @@ router.post(
       for (const doc of failedDocs) {
         try {
           await semanticProcessingService.retry(doc.documentId);
-          
+
           await semanticProcessingQueue.add('semantic-process-document', {
             documentId: doc.documentId,
             projectId: doc.projectId,
@@ -391,10 +419,23 @@ router.post(
 
           results.push({ documentId: doc.documentId, success: true });
         } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          try {
+            await semanticProcessingService.markFailed(
+              doc.documentId,
+              `Queue enqueue failed: ${msg}`,
+              { enqueueFailed: true, batchRetry: true }
+            );
+          } catch (rollbackErr: unknown) {
+            logger.error('Failed to roll document back to failed after batch retry enqueue error', {
+              documentId: doc.documentId,
+              error: rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)
+            });
+          }
           results.push({
             documentId: doc.documentId,
             success: false,
-            error: error instanceof Error ? error.message : String(error)
+            error: msg
           });
         }
       }
@@ -429,7 +470,7 @@ router.post(
 
 /**
  * GET /api/semantic-processing/retryable
- * Get all documents eligible for retry (failed with retry count < max)
+ * List documents eligible for retry within a project (requires projectId for access control).
  */
 router.get(
   '/retryable',

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -143,6 +143,7 @@ import developmentApproachModuleRoutes from "./modules/developmentApproach/route
 import contextOrchestratorRoutes from "./routes/contextOrchestrator"
 import morphicModuleRoutes from "./modules/morphic/routes"
 import uxDocumentationRoutes from "./routes/uxDocumentationRoutes"
+import semanticProcessingRoutes from "./routes/semanticProcessingRoutes"
 import digitalTwinAssetsRoutes from "./routes/digital-twin-assets"
 import digitalTwinEventsRoutes from "./routes/digital-twin-events"
 import digitalTwinTriggersRoutes from "./routes/digital-twin-triggers"
@@ -308,6 +309,7 @@ app.use("/api/escalation", escalationRoutes)
 app.use("/api/quality-audits", qualityAuditRoutes)
 app.use("/api/admin", adminRoutes)
 app.use("/api/onboarding", documentUploadRoutes)
+app.use("/api/semantic-processing", semanticProcessingRoutes)
 app.use("/api/executive-dashboard", executiveDashboardRoutes)
 app.use("/api/rag", ragRoutes)
 app.use("/api/projects", projectSimilarityRoutes)

--- a/server/src/services/documentUploadService.ts
+++ b/server/src/services/documentUploadService.ts
@@ -1097,15 +1097,6 @@ async function updateBatchProgress(
                 });
               }
 
-              // Trigger async semantic processing pipeline (non-blocking)
-              triggerSemanticProcessing(batchId, projectId, uploadedBy).catch(err => {
-                logger.error('Failed to trigger semantic processing', {
-                  batchId,
-                  projectId,
-                  error: err.message
-                });
-              });
-
             } catch (assessmentError: any) {
               // Log error but don't fail the batch completion
               logger.error('Failed to generate assessment after batch completion', {
@@ -1123,6 +1114,15 @@ async function updateBatchProgress(
                 WHERE batch_id = $1
               `, [batchId]);
             }
+
+            // Semantic pipeline runs independently of assessment generation success
+            triggerSemanticProcessing(batchId, projectId, uploadedBy).catch((err: Error) => {
+              logger.error('Failed to trigger semantic processing', {
+                batchId,
+                projectId,
+                error: err.message
+              });
+            });
           } else if (status === 'failed') {
             // Update assessment status to 'failed' if batch failed
             await db.query(`

--- a/server/src/services/documentUploadService.ts
+++ b/server/src/services/documentUploadService.ts
@@ -1352,6 +1352,18 @@ async function triggerSemanticProcessing(
       error: error.message,
       stack: error.stack
     });
+    try {
+      const { semanticProcessingService } = await import('./semanticProcessingService');
+      await semanticProcessingService.markBatchOrchestrationFailed(
+        batchId,
+        error instanceof Error ? error.message : String(error)
+      );
+    } catch (markErr: unknown) {
+      logger.error('❌ [SEMANTIC] Failed to mark batch as failed after trigger error', {
+        batchId,
+        error: markErr instanceof Error ? markErr.message : String(markErr)
+      });
+    }
     // Don't rethrow - semantic processing failure shouldn't fail the upload
   }
 }

--- a/server/src/services/documentUploadService.ts
+++ b/server/src/services/documentUploadService.ts
@@ -1097,6 +1097,15 @@ async function updateBatchProgress(
                 });
               }
 
+              // Trigger async semantic processing pipeline (non-blocking)
+              triggerSemanticProcessing(batchId, projectId, uploadedBy).catch(err => {
+                logger.error('Failed to trigger semantic processing', {
+                  batchId,
+                  projectId,
+                  error: err.message
+                });
+              });
+
             } catch (assessmentError: any) {
               // Log error but don't fail the batch completion
               logger.error('Failed to generate assessment after batch completion', {
@@ -1256,6 +1265,98 @@ function emitFileProgress(
 }
 
 // ============================================================================
+// SEMANTIC PROCESSING TRIGGER
+// ============================================================================
+
+/**
+ * Trigger async semantic processing for all documents in a completed batch
+ * This runs in the background and does not block the upload completion
+ */
+async function triggerSemanticProcessing(
+  batchId: string,
+  projectId: string,
+  uploadedBy: string
+): Promise<void> {
+  logger.info('🚀 [SEMANTIC] Triggering semantic processing for batch', {
+    batchId,
+    projectId
+  });
+
+  try {
+    // Import semantic processing service and queue
+    const { semanticProcessingService } = await import('./semanticProcessingService');
+    const { semanticProcessingQueue } = await import('./queueService');
+
+    // Get all successfully processed documents from this batch
+    const docsQuery = `
+      SELECT d.id, d.project_id
+      FROM documents d
+      WHERE (d.metadata->>'upload_batch_id')::uuid = $1
+        AND d.content IS NOT NULL
+        AND d.content != ''
+    `;
+
+    const docsResult = await db.query(docsQuery, [batchId]);
+    const documentIds = docsResult.rows.map((row: { id: string }) => row.id);
+
+    if (documentIds.length === 0) {
+      logger.info('[SEMANTIC] No documents to process in batch', { batchId });
+      return;
+    }
+
+    logger.info('[SEMANTIC] Found documents for semantic processing', {
+      batchId,
+      documentCount: documentIds.length
+    });
+
+    // Initialize batch-level tracking
+    await semanticProcessingService.initializeBatchProcessing(
+      batchId,
+      projectId,
+      documentIds.length
+    );
+
+    // Initialize processing status for each document
+    for (const documentId of documentIds) {
+      await semanticProcessingService.initializeProcessing({
+        documentId,
+        batchId,
+        projectId,
+        alreadyConverted: true // Documents are already converted to Markdown
+      });
+    }
+
+    // Enqueue batch processing job
+    const jobId = `semantic-batch-${batchId}`;
+    await semanticProcessingQueue.add('semantic-process-batch', {
+      batchId,
+      projectId,
+      userId: uploadedBy,
+      documentIds
+    }, {
+      jobId,
+      priority: 5 // Medium priority
+    });
+
+    logger.info('✅ [SEMANTIC] Batch semantic processing job enqueued', {
+      batchId,
+      projectId,
+      jobId,
+      documentCount: documentIds.length
+    });
+
+  } catch (error: any) {
+    logger.error('❌ [SEMANTIC] Failed to trigger semantic processing', {
+      batchId,
+      projectId,
+      error: error.message,
+      stack: error.stack
+    });
+    // Don't rethrow - semantic processing failure shouldn't fail the upload
+  }
+}
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -1264,5 +1365,6 @@ export const documentUploadService = {
   addDocumentsToExistingBatch,
   processUploadedFile,
   getBatchStatus,
-  getUploadedDocuments
+  getUploadedDocuments,
+  triggerSemanticProcessing
 };

--- a/server/src/services/jobs/SemanticProcessingJobService.ts
+++ b/server/src/services/jobs/SemanticProcessingJobService.ts
@@ -12,7 +12,6 @@
 
 import { pool } from '@/database/connection';
 import { logger } from '@/utils/logger';
-import { v4 as uuidv4 } from 'uuid';
 import type { IQueueJob } from './queue/IQueue';
 import { semanticProcessingService, type ExtractionSummary, type GkgSyncSummary } from '../semanticProcessingService';
 
@@ -59,19 +58,36 @@ export async function processSemanticDocument(
   });
 
   try {
-    // Mark extraction started
+    // Extraction: state machine requires converted → queued_extraction → extracting
     if (!skipExtraction) {
-      await semanticProcessingService.markExtractionStarted(documentId);
+      let procState = await semanticProcessingService.getDocumentStatus(documentId);
+      if (!procState) {
+        throw new Error(`No semantic processing record found for document: ${documentId}`);
+      }
+
+      if (procState.state === 'converted') {
+        await semanticProcessingService.queueForExtraction(documentId, String(job.id));
+        procState = await semanticProcessingService.getDocumentStatus(documentId);
+      }
+
+      if (procState.state === 'queued_extraction') {
+        await semanticProcessingService.markExtractionStarted(documentId);
+      } else if (procState.state === 'extracting') {
+        logger.info(`${LOG_TAG} Resuming extraction`, { documentId });
+      } else {
+        throw new Error(
+          `Cannot start extraction: document ${documentId} is in state ${procState.state}`
+        );
+      }
+
       await job.progress(10);
 
-      // Run entity extraction using existing framework
       const extractionResult = await runEntityExtraction(documentId, projectId, userId);
-      
+
       await job.progress(50);
 
-      // Mark extraction completed
       await semanticProcessingService.markExtractionCompleted(documentId, extractionResult);
-      
+
       logger.info(`${LOG_TAG} Extraction completed`, {
         documentId,
         totalEntities: extractionResult.totalEntities,
@@ -79,24 +95,38 @@ export async function processSemanticDocument(
       });
     }
 
-    // Queue for GKG sync if not skipped and Neo4j is configured
+    // GKG sync: extracted → queued_gkg_sync → syncing → synced (do not re-queue if already queued_gkg_sync)
     if (!skipGkgSync) {
       const { isNeo4jConfigured } = await import('../../utils/neo4j');
-      
-      if (isNeo4jConfigured()) {
-        await semanticProcessingService.transitionState(documentId, 'queued_gkg_sync');
-        await job.progress(60);
 
-        // Mark GKG sync started
-        await semanticProcessingService.markGkgSyncStarted(documentId);
+      let docState = await semanticProcessingService.getDocumentStatus(documentId);
+      if (!docState) {
+        throw new Error(`No semantic processing record found for document: ${documentId}`);
+      }
+
+      if (isNeo4jConfigured()) {
+        if (docState.state === 'extracted') {
+          await semanticProcessingService.queueForGkgSync(documentId, String(job.id));
+          docState = await semanticProcessingService.getDocumentStatus(documentId);
+        }
+
+        if (docState.state === 'queued_gkg_sync') {
+          await semanticProcessingService.markGkgSyncStarted(documentId);
+        } else if (docState.state === 'syncing') {
+          logger.info(`${LOG_TAG} Resuming GKG sync`, { documentId });
+        } else {
+          throw new Error(
+            `Cannot run GKG sync: document ${documentId} is in state ${docState.state}`
+          );
+        }
+
+        await job.progress(60);
         await job.progress(70);
 
-        // Run GKG sync
         const gkgResult = await runGkgSync(documentId, projectId);
-        
+
         await job.progress(95);
 
-        // Mark GKG sync completed
         await semanticProcessingService.markGkgSyncCompleted(documentId, gkgResult);
 
         logger.info(`${LOG_TAG} GKG sync completed`, {
@@ -104,9 +134,17 @@ export async function processSemanticDocument(
           nodesCreated: gkgResult.nodesCreated
         });
       } else {
-        // Skip GKG sync if not configured, mark as synced anyway
         logger.info(`${LOG_TAG} Neo4j not configured, skipping GKG sync`, { documentId });
-        await semanticProcessingService.transitionState(documentId, 'queued_gkg_sync');
+        if (docState.state === 'extracted') {
+          await semanticProcessingService.queueForGkgSync(documentId, String(job.id));
+          docState = await semanticProcessingService.getDocumentStatus(documentId);
+        }
+        if (docState.state !== 'queued_gkg_sync') {
+          throw new Error(
+            `Neo4j skip path: expected queued_gkg_sync before marking synced, got ${docState.state}`
+          );
+        }
+        await semanticProcessingService.markGkgSyncStarted(documentId);
         await semanticProcessingService.markGkgSyncCompleted(documentId, {
           nodesCreated: 0,
           nodesUpdated: 0,
@@ -340,14 +378,7 @@ Return JSON in this format:
       documentId,
       error: error instanceof Error ? error.message : String(error)
     });
-
-    // Return empty result rather than failing
-    return {
-      entityCounts: {},
-      domainsProcessed: [],
-      totalEntities: 0,
-      processingTimeMs: Date.now() - startTime
-    };
+    throw error;
   }
 }
 

--- a/server/src/services/jobs/SemanticProcessingJobService.ts
+++ b/server/src/services/jobs/SemanticProcessingJobService.ts
@@ -163,59 +163,76 @@ export async function processSemanticBatch(
   let processed = 0;
   let failed = 0;
 
-  for (let i = 0; i < documentIds.length; i++) {
-    const documentId = documentIds[i];
-    const progress = Math.round(((i + 1) / documentIds.length) * 100);
+  try {
+    for (let i = 0; i < documentIds.length; i++) {
+      const documentId = documentIds[i];
+      const progress = Math.round(((i + 1) / documentIds.length) * 100);
 
-    try {
-      // Create a synthetic job for the document processor
-      const docJob: IQueueJob<SemanticProcessDocumentJobData> = {
-        id: `${job.id}-doc-${i}`,
-        data: {
-          documentId,
-          projectId,
+      try {
+        // Create a synthetic job for the document processor
+        const docJob: IQueueJob<SemanticProcessDocumentJobData> = {
+          id: `${job.id}-doc-${i}`,
+          data: {
+            documentId,
+            projectId,
+            batchId,
+            userId
+          },
+          progress: async () => {},
+          log: async () => {},
+          update: async () => {},
+          remove: async () => {},
+          retry: async () => {},
+          getState: async () => 'active',
+          finished: async () => {},
+          failed: async () => {},
+          toJSON: () => ({})
+        };
+
+        const result = await processSemanticDocument(docJob);
+
+        if (result.success) {
+          processed++;
+        } else {
+          failed++;
+        }
+      } catch (error) {
+        logger.error(`${LOG_TAG} Document processing failed in batch`, {
           batchId,
-          userId
-        },
-        progress: async () => {},
-        log: async () => {},
-        update: async () => {},
-        remove: async () => {},
-        retry: async () => {},
-        getState: async () => 'active',
-        finished: async () => {},
-        failed: async () => {},
-        toJSON: () => ({})
-      };
-
-      const result = await processSemanticDocument(docJob);
-      
-      if (result.success) {
-        processed++;
-      } else {
+          documentId,
+          error: error instanceof Error ? error.message : String(error)
+        });
         failed++;
       }
 
-    } catch (error) {
-      logger.error(`${LOG_TAG} Document processing failed in batch`, {
-        batchId,
-        documentId,
-        error: error instanceof Error ? error.message : String(error)
-      });
-      failed++;
+      await job.progress(progress);
     }
 
-    await job.progress(progress);
+    logger.info(`${LOG_TAG} Batch semantic processing complete`, {
+      batchId,
+      processed,
+      failed,
+      total: documentIds.length
+    });
+
+    return { success: failed === 0, processed, failed };
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`${LOG_TAG} Batch semantic processing aborted`, {
+      batchId,
+      error: message,
+      stack: error instanceof Error ? error.stack : undefined
+    });
+    try {
+      await semanticProcessingService.markBatchOrchestrationFailed(batchId, message);
+    } catch (markErr: unknown) {
+      logger.error(`${LOG_TAG} Could not mark batch failed after batch job error`, {
+        batchId,
+        error: markErr instanceof Error ? markErr.message : String(markErr)
+      });
+    }
+    throw error;
   }
-
-  logger.info(`${LOG_TAG} Batch semantic processing complete`, {
-    batchId,
-    processed,
-    failed,
-    total: documentIds.length
-  });
-
-  return { success: failed === 0, processed, failed };
 }
 
 // ============================================================================

--- a/server/src/services/jobs/SemanticProcessingJobService.ts
+++ b/server/src/services/jobs/SemanticProcessingJobService.ts
@@ -1,0 +1,404 @@
+/**
+ * Semantic Processing Job Service
+ * 
+ * Handles background processing of semantic pipeline jobs:
+ * - semantic-process-document: Process single document through extraction → GKG sync
+ * - semantic-process-batch: Process all documents in a batch
+ * 
+ * Integrates with existing ExtractionOrchestrationService and GKG sync infrastructure.
+ * 
+ * @module SemanticProcessingJobService
+ */
+
+import { pool } from '@/database/connection';
+import { logger } from '@/utils/logger';
+import { v4 as uuidv4 } from 'uuid';
+import type { IQueueJob } from './queue/IQueue';
+import { semanticProcessingService, type ExtractionSummary, type GkgSyncSummary } from '../semanticProcessingService';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface SemanticProcessDocumentJobData {
+  documentId: string;
+  projectId: string;
+  batchId?: string;
+  userId: string;
+  skipExtraction?: boolean;
+  skipGkgSync?: boolean;
+}
+
+export interface SemanticProcessBatchJobData {
+  batchId: string;
+  projectId: string;
+  userId: string;
+  documentIds: string[];
+}
+
+// ============================================================================
+// JOB PROCESSOR
+// ============================================================================
+
+const LOG_TAG = '[SEMANTIC-JOB]';
+
+/**
+ * Process a single document through semantic pipeline
+ */
+export async function processSemanticDocument(
+  job: IQueueJob<SemanticProcessDocumentJobData>
+): Promise<{ success: boolean; documentId: string; error?: string }> {
+  const { documentId, projectId, batchId, userId, skipExtraction, skipGkgSync } = job.data;
+  const startTime = Date.now();
+
+  logger.info(`${LOG_TAG} Starting semantic processing`, { 
+    documentId, 
+    projectId, 
+    batchId,
+    jobId: job.id 
+  });
+
+  try {
+    // Mark extraction started
+    if (!skipExtraction) {
+      await semanticProcessingService.markExtractionStarted(documentId);
+      await job.progress(10);
+
+      // Run entity extraction using existing framework
+      const extractionResult = await runEntityExtraction(documentId, projectId, userId);
+      
+      await job.progress(50);
+
+      // Mark extraction completed
+      await semanticProcessingService.markExtractionCompleted(documentId, extractionResult);
+      
+      logger.info(`${LOG_TAG} Extraction completed`, {
+        documentId,
+        totalEntities: extractionResult.totalEntities,
+        domains: extractionResult.domainsProcessed
+      });
+    }
+
+    // Queue for GKG sync if not skipped and Neo4j is configured
+    if (!skipGkgSync) {
+      const { isNeo4jConfigured } = await import('../../utils/neo4j');
+      
+      if (isNeo4jConfigured()) {
+        await semanticProcessingService.transitionState(documentId, 'queued_gkg_sync');
+        await job.progress(60);
+
+        // Mark GKG sync started
+        await semanticProcessingService.markGkgSyncStarted(documentId);
+        await job.progress(70);
+
+        // Run GKG sync
+        const gkgResult = await runGkgSync(documentId, projectId);
+        
+        await job.progress(95);
+
+        // Mark GKG sync completed
+        await semanticProcessingService.markGkgSyncCompleted(documentId, gkgResult);
+
+        logger.info(`${LOG_TAG} GKG sync completed`, {
+          documentId,
+          nodesCreated: gkgResult.nodesCreated
+        });
+      } else {
+        // Skip GKG sync if not configured, mark as synced anyway
+        logger.info(`${LOG_TAG} Neo4j not configured, skipping GKG sync`, { documentId });
+        await semanticProcessingService.transitionState(documentId, 'queued_gkg_sync');
+        await semanticProcessingService.markGkgSyncCompleted(documentId, {
+          nodesCreated: 0,
+          nodesUpdated: 0,
+          relationshipsCreated: 0,
+          processingTimeMs: 0
+        });
+      }
+    }
+
+    await job.progress(100);
+
+    const processingTimeMs = Date.now() - startTime;
+    logger.info(`${LOG_TAG} Semantic processing complete`, {
+      documentId,
+      processingTimeMs
+    });
+
+    return { success: true, documentId };
+
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
+
+    logger.error(`${LOG_TAG} Semantic processing failed`, {
+      documentId,
+      error: errorMessage,
+      stack: errorStack
+    });
+
+    // Mark as failed
+    await semanticProcessingService.markFailed(documentId, errorMessage, {
+      jobId: job.id,
+      stack: errorStack
+    });
+
+    return { success: false, documentId, error: errorMessage };
+  }
+}
+
+/**
+ * Process all documents in a batch through semantic pipeline
+ */
+export async function processSemanticBatch(
+  job: IQueueJob<SemanticProcessBatchJobData>
+): Promise<{ success: boolean; processed: number; failed: number }> {
+  const { batchId, projectId, userId, documentIds } = job.data;
+
+  logger.info(`${LOG_TAG} Starting batch semantic processing`, {
+    batchId,
+    projectId,
+    documentCount: documentIds.length
+  });
+
+  let processed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < documentIds.length; i++) {
+    const documentId = documentIds[i];
+    const progress = Math.round(((i + 1) / documentIds.length) * 100);
+
+    try {
+      // Create a synthetic job for the document processor
+      const docJob: IQueueJob<SemanticProcessDocumentJobData> = {
+        id: `${job.id}-doc-${i}`,
+        data: {
+          documentId,
+          projectId,
+          batchId,
+          userId
+        },
+        progress: async () => {},
+        log: async () => {},
+        update: async () => {},
+        remove: async () => {},
+        retry: async () => {},
+        getState: async () => 'active',
+        finished: async () => {},
+        failed: async () => {},
+        toJSON: () => ({})
+      };
+
+      const result = await processSemanticDocument(docJob);
+      
+      if (result.success) {
+        processed++;
+      } else {
+        failed++;
+      }
+
+    } catch (error) {
+      logger.error(`${LOG_TAG} Document processing failed in batch`, {
+        batchId,
+        documentId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      failed++;
+    }
+
+    await job.progress(progress);
+  }
+
+  logger.info(`${LOG_TAG} Batch semantic processing complete`, {
+    batchId,
+    processed,
+    failed,
+    total: documentIds.length
+  });
+
+  return { success: failed === 0, processed, failed };
+}
+
+// ============================================================================
+// ENTITY EXTRACTION (using existing framework)
+// ============================================================================
+
+/**
+ * Run entity extraction using AI-based lightweight extraction
+ * Extracts basic entities directly from document content
+ */
+async function runEntityExtraction(
+  documentId: string,
+  projectId: string,
+  _userId: string
+): Promise<ExtractionSummary> {
+  // Use lightweight extraction (AI-based entity extraction)
+  // The full extraction orchestration service requires additional setup
+  // For the onboarding pipeline, we use a simpler approach
+  return await runLightweightExtraction(documentId, projectId);
+}
+
+/**
+ * Lightweight extraction fallback when full extraction service is unavailable
+ * Uses AI to extract basic entities directly
+ */
+async function runLightweightExtraction(
+  documentId: string,
+  projectId: string
+): Promise<ExtractionSummary> {
+  const startTime = Date.now();
+
+  try {
+    // Get document content
+    const docResult = await pool.query(
+      'SELECT content FROM documents WHERE id = $1',
+      [documentId]
+    );
+
+    if (docResult.rows.length === 0) {
+      throw new Error(`Document not found: ${documentId}`);
+    }
+
+    const content = docResult.rows[0].content || '';
+    
+    // Skip if no content
+    if (!content.trim()) {
+      return {
+        entityCounts: {},
+        domainsProcessed: [],
+        totalEntities: 0,
+        processingTimeMs: Date.now() - startTime
+      };
+    }
+
+    // Use AI service to extract basic entities
+    const { aiService } = await import('../aiService');
+    
+    const prompt = `Extract key project management entities from this document.
+Return a JSON object with entity counts by type.
+
+Document content (first 4000 chars):
+${content.substring(0, 4000)}
+
+Return JSON in this format:
+{
+  "stakeholders": 0,
+  "requirements": 0,
+  "risks": 0,
+  "milestones": 0,
+  "deliverables": 0,
+  "constraints": 0
+}`;
+
+    const result = await aiService.generateWithFallback({
+      provider: 'auto',
+      prompt,
+      temperature: 0.3,
+      max_tokens: 500
+    });
+
+    // Parse result
+    const jsonMatch = result.content.match(/\{[\s\S]*\}/);
+    let entityCounts: Record<string, number> = {};
+    
+    if (jsonMatch) {
+      try {
+        entityCounts = JSON.parse(jsonMatch[0]);
+      } catch {
+        logger.warn(`${LOG_TAG} Failed to parse extraction result`, { documentId });
+      }
+    }
+
+    const totalEntities = Object.values(entityCounts).reduce((sum, count) => sum + count, 0);
+    const domainsProcessed = Object.keys(entityCounts).filter(k => entityCounts[k] > 0);
+
+    return {
+      entityCounts,
+      domainsProcessed,
+      totalEntities,
+      processingTimeMs: Date.now() - startTime
+    };
+
+  } catch (error) {
+    logger.error(`${LOG_TAG} Lightweight extraction failed`, {
+      documentId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+
+    // Return empty result rather than failing
+    return {
+      entityCounts: {},
+      domainsProcessed: [],
+      totalEntities: 0,
+      processingTimeMs: Date.now() - startTime
+    };
+  }
+}
+
+// ============================================================================
+// GKG SYNC (using existing framework)
+// ============================================================================
+
+/**
+ * Run GKG sync using the existing GKG sync infrastructure
+ */
+async function runGkgSync(
+  documentId: string,
+  projectId: string
+): Promise<GkgSyncSummary> {
+  const startTime = Date.now();
+
+  try {
+    const { isNeo4jConfigured, getNeo4jDriver, getNeo4jDatabase } = await import('../../utils/neo4j');
+    
+    if (!isNeo4jConfigured()) {
+      return {
+        nodesCreated: 0,
+        nodesUpdated: 0,
+        relationshipsCreated: 0,
+        processingTimeMs: Date.now() - startTime
+      };
+    }
+
+    const driver = getNeo4jDriver();
+    
+    // Use the existing syncProject function
+    const { runSyncProject } = await import('../gkg/syncProject');
+    
+    const result = await runSyncProject(pool, driver, getNeo4jDatabase(), projectId);
+
+    return {
+      nodesCreated: result.units + result.documents + (result.project ? 1 : 0),
+      nodesUpdated: 0,
+      relationshipsCreated: result.dependencies + result.tasks,
+      processingTimeMs: Date.now() - startTime
+    };
+
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    
+    // If GKG service not available, return empty result
+    if (errorMessage.includes('Cannot find module') || errorMessage.includes('not configured')) {
+      logger.warn(`${LOG_TAG} GKG sync service not available`, { documentId, projectId });
+      
+      return {
+        nodesCreated: 0,
+        nodesUpdated: 0,
+        relationshipsCreated: 0,
+        processingTimeMs: Date.now() - startTime
+      };
+    }
+
+    throw error;
+  }
+}
+
+// ============================================================================
+// EXPORTS
+// ============================================================================
+
+export const semanticProcessingJobService = {
+  processSemanticDocument,
+  processSemanticBatch
+};
+
+export default semanticProcessingJobService;

--- a/server/src/services/jobs/SemanticProcessingJobService.ts
+++ b/server/src/services/jobs/SemanticProcessingJobService.ts
@@ -68,6 +68,9 @@ export async function processSemanticDocument(
       if (procState.state === 'converted') {
         await semanticProcessingService.queueForExtraction(documentId, String(job.id));
         procState = await semanticProcessingService.getDocumentStatus(documentId);
+        if (!procState) {
+          throw new Error(`Semantic processing record disappeared for document: ${documentId}`);
+        }
       }
 
       if (procState.state === 'queued_extraction') {
@@ -108,6 +111,9 @@ export async function processSemanticDocument(
         if (docState.state === 'extracted') {
           await semanticProcessingService.queueForGkgSync(documentId, String(job.id));
           docState = await semanticProcessingService.getDocumentStatus(documentId);
+          if (!docState) {
+            throw new Error(`Semantic processing record disappeared for document: ${documentId}`);
+          }
         }
 
         if (docState.state === 'queued_gkg_sync') {
@@ -138,6 +144,9 @@ export async function processSemanticDocument(
         if (docState.state === 'extracted') {
           await semanticProcessingService.queueForGkgSync(documentId, String(job.id));
           docState = await semanticProcessingService.getDocumentStatus(documentId);
+          if (!docState) {
+            throw new Error(`Semantic processing record disappeared for document: ${documentId}`);
+          }
         }
         if (docState.state !== 'queued_gkg_sync') {
           throw new Error(

--- a/server/src/services/jobs/SemanticProcessingJobService.ts
+++ b/server/src/services/jobs/SemanticProcessingJobService.ts
@@ -13,7 +13,7 @@
 import { pool } from '@/database/connection';
 import { logger } from '@/utils/logger';
 import type { IQueueJob } from './queue/IQueue';
-import { semanticProcessingService, type ExtractionSummary, type GkgSyncSummary } from '../semanticProcessingService';
+import { semanticProcessingService, type ExtractionSummary, type GkgSyncSummary, type SemanticProcessingState } from '../semanticProcessingService';
 
 // ============================================================================
 // TYPES
@@ -58,12 +58,27 @@ export async function processSemanticDocument(
   });
 
   try {
-    // Extraction: state machine requires converted → queued_extraction → extracting
-    if (!skipExtraction) {
-      let procState = await semanticProcessingService.getDocumentStatus(documentId);
-      if (!procState) {
-        throw new Error(`No semantic processing record found for document: ${documentId}`);
-      }
+    let snap = await semanticProcessingService.getDocumentStatus(documentId);
+    if (!snap) {
+      throw new Error(`No semantic processing record found for document: ${documentId}`);
+    }
+
+    if (snap.state === 'synced') {
+      logger.info(`${LOG_TAG} Document already synced, skipping job`, { documentId, jobId: job.id });
+      await job.progress(100);
+      return { success: true, documentId };
+    }
+
+    const postExtractionStates: SemanticProcessingState[] = [
+      'extracted',
+      'queued_gkg_sync',
+      'syncing',
+      'synced'
+    ];
+    const needsExtraction = !skipExtraction && !postExtractionStates.includes(snap.state);
+
+    if (needsExtraction) {
+      let procState = snap;
 
       if (procState.state === 'converted') {
         await semanticProcessingService.queueForExtraction(documentId, String(job.id));
@@ -96,15 +111,26 @@ export async function processSemanticDocument(
         totalEntities: extractionResult.totalEntities,
         domains: extractionResult.domainsProcessed
       });
+    } else if (!skipExtraction) {
+      logger.info(`${LOG_TAG} Skipping extraction (document already past extraction stage)`, {
+        documentId,
+        state: snap.state
+      });
+      await job.progress(50);
     }
 
-    // GKG sync: extracted → queued_gkg_sync → syncing → synced (do not re-queue if already queued_gkg_sync)
     if (!skipGkgSync) {
       const { isNeo4jConfigured } = await import('../../utils/neo4j');
 
       let docState = await semanticProcessingService.getDocumentStatus(documentId);
       if (!docState) {
         throw new Error(`No semantic processing record found for document: ${documentId}`);
+      }
+
+      if (docState.state === 'synced') {
+        logger.info(`${LOG_TAG} Document already synced before GKG stage, skipping`, { documentId });
+        await job.progress(100);
+        return { success: true, documentId };
       }
 
       if (isNeo4jConfigured()) {
@@ -286,6 +312,27 @@ export async function processSemanticBatch(
 // ENTITY EXTRACTION (using existing framework)
 // ============================================================================
 
+function coerceEntityCounts(raw: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return out;
+  }
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    let n: number;
+    if (typeof val === 'number' && Number.isFinite(val)) {
+      n = val;
+    } else if (typeof val === 'string') {
+      n = parseFloat(val);
+    } else {
+      n = Number(val);
+    }
+    if (Number.isFinite(n)) {
+      out[key] = n;
+    }
+  }
+  return out;
+}
+
 /**
  * Run entity extraction using AI-based lightweight extraction
  * Extracts basic entities directly from document content
@@ -366,7 +413,8 @@ Return JSON in this format:
     
     if (jsonMatch) {
       try {
-        entityCounts = JSON.parse(jsonMatch[0]);
+        const parsed = JSON.parse(jsonMatch[0]) as unknown;
+        entityCounts = coerceEntityCounts(parsed);
       } catch {
         logger.warn(`${LOG_TAG} Failed to parse extraction result`, { documentId });
       }
@@ -396,7 +444,9 @@ Return JSON in this format:
 // ============================================================================
 
 /**
- * Run GKG sync using the existing GKG sync infrastructure
+ * Run GKG sync using the existing GKG sync infrastructure.
+ * Note: runSyncProject reconciles the whole project; batch jobs invoke this once per document today.
+ * Consider a single project-level sync per batch if Neo4j load becomes an issue.
  */
 async function runGkgSync(
   documentId: string,

--- a/server/src/services/queueService.ts
+++ b/server/src/services/queueService.ts
@@ -58,6 +58,7 @@ export const confluenceQueue = createRabbitQueue("confluence-publishing", 3, 200
 export const digitalTwinEventQueue = createRabbitQueue("digital-twin-events", 3, 2000)
 export const digitalTwinTriggerQueue = createRabbitQueue("digital-twin-triggers", 3, 3000)
 export const gkgSyncQueue = createRabbitQueue("gkg-sync", 2, 5000)
+export const semanticProcessingQueue = createRabbitQueue("semantic-processing", 3, 5000)
 
 // Trace attachment (lightweight)
 const tracer = trace.getTracer("adpa-queue-service")
@@ -115,6 +116,7 @@ const queues = [
   { name: "digital-twin-events", queue: digitalTwinEventQueue },
   { name: "digital-twin-triggers", queue: digitalTwinTriggerQueue },
   { name: "gkg-sync", queue: gkgSyncQueue },
+  { name: "semantic-processing", queue: semanticProcessingQueue },
 ]
 queues.forEach(({ name, queue }) => attachTracing(queue, name))
 
@@ -751,6 +753,43 @@ import("./digitalTwinTriggerService").then(({ processDocumentTrigger }) => {
     }
   })()
   }
+
+// Semantic Processing Queue Processors
+if (process.env.NODE_ENV !== 'test') {
+  ;(async () => {
+    try {
+      console.log("[SEMANTIC] Registering semantic processing processors...")
+      const { processSemanticDocument, processSemanticBatch } = await import("./jobs/SemanticProcessingJobService")
+
+      semanticProcessingQueue.process("semantic-process-document", QUEUE_PREFETCH, async (job) => {
+        logger.info(`[WORKER] semantic-processing worker ${WORKER_ID} picked up document job: ${job.id}`)
+        try {
+          return await processSemanticDocument(job as any)
+        } catch (err) {
+          logger.error(err, "[WORKER] semantic-processing document error")
+          throw err
+        }
+      })
+
+      semanticProcessingQueue.process("semantic-process-batch", QUEUE_PREFETCH, async (job) => {
+        logger.info(`[WORKER] semantic-processing worker ${WORKER_ID} picked up batch job: ${job.id}`)
+        try {
+          return await processSemanticBatch(job as any)
+        } catch (err) {
+          logger.error(err, "[WORKER] semantic-processing batch error")
+          throw err
+        }
+      })
+
+      logger.info(`[QUEUE] Registered semantic processing processors on semanticProcessingQueue (Rabbit)`)
+      console.log("✅ Semantic processing processors registered for queue: semantic-processing")
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      logger.error({ error: msg }, "[SEMANTIC] Failed to register semantic processing processors")
+      console.error("[SEMANTIC] Failed to register semantic processing processors:", msg)
+    }
+  })()
+}
 
 // Export Redis client for legacy consumers
 export { redisClient }

--- a/server/src/services/semanticProcessingService.ts
+++ b/server/src/services/semanticProcessingService.ts
@@ -1,0 +1,659 @@
+/**
+ * Semantic Processing Service
+ * 
+ * Orchestrates asynchronous semantic processing pipeline for onboarding documents:
+ * upload → convert → extract → persist → GKG sync
+ * 
+ * Provides strong traceability with explicit states and operational visibility.
+ * Integrates with existing entity extraction framework and GKG sync infrastructure.
+ * 
+ * @module semanticProcessingService
+ */
+
+import { pool } from '../database/connection';
+import { logger } from '../utils/logger';
+import { v4 as uuidv4 } from 'uuid';
+import { io } from '../socket';
+
+// ============================================================================
+// TYPES & INTERFACES
+// ============================================================================
+
+export type SemanticProcessingState =
+  | 'uploaded'
+  | 'converted'
+  | 'queued_extraction'
+  | 'extracting'
+  | 'extracted'
+  | 'queued_gkg_sync'
+  | 'syncing'
+  | 'synced'
+  | 'failed'
+  | 'retrying';
+
+export interface SemanticProcessingStatus {
+  id: string;
+  documentId: string;
+  batchId: string | null;
+  projectId: string;
+  state: SemanticProcessingState;
+  uploadedAt: Date;
+  convertedAt: Date | null;
+  extractionStartedAt: Date | null;
+  extractionCompletedAt: Date | null;
+  gkgSyncStartedAt: Date | null;
+  gkgSyncCompletedAt: Date | null;
+  errorMessage: string | null;
+  errorDetails: Record<string, unknown> | null;
+  retryCount: number;
+  maxRetries: number;
+  lastRetryAt: Date | null;
+  extractionJobId: string | null;
+  gkgSyncJobId: string | null;
+  extractionSummary: ExtractionSummary | null;
+  gkgSyncSummary: GkgSyncSummary | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface ExtractionSummary {
+  entityCounts: Record<string, number>;
+  domainsProcessed: string[];
+  totalEntities: number;
+  processingTimeMs: number;
+}
+
+export interface GkgSyncSummary {
+  nodesCreated: number;
+  nodesUpdated: number;
+  relationshipsCreated: number;
+  processingTimeMs: number;
+}
+
+export interface BatchProcessingStatus {
+  id: string;
+  batchId: string;
+  projectId: string;
+  totalDocuments: number;
+  documentsConverted: number;
+  documentsExtracted: number;
+  documentsSynced: number;
+  documentsFailed: number;
+  overallState: string;
+  startedAt: Date;
+  completedAt: Date | null;
+  totalEntitiesExtracted: number;
+  totalGkgNodesCreated: number;
+  documents: SemanticProcessingStatus[];
+}
+
+export interface InitializeProcessingOptions {
+  documentId: string;
+  batchId: string;
+  projectId: string;
+  alreadyConverted?: boolean;
+}
+
+// ============================================================================
+// STATE MACHINE TRANSITIONS
+// ============================================================================
+
+const VALID_TRANSITIONS: Record<SemanticProcessingState, SemanticProcessingState[]> = {
+  uploaded: ['converted', 'failed'],
+  converted: ['queued_extraction', 'failed'],
+  queued_extraction: ['extracting', 'failed', 'retrying'],
+  extracting: ['extracted', 'failed', 'retrying'],
+  extracted: ['queued_gkg_sync', 'failed'],
+  queued_gkg_sync: ['syncing', 'failed', 'retrying'],
+  syncing: ['synced', 'failed', 'retrying'],
+  synced: [], // Terminal state
+  failed: ['retrying', 'queued_extraction', 'queued_gkg_sync'], // Can retry from failed
+  retrying: ['queued_extraction', 'queued_gkg_sync', 'extracting', 'syncing', 'failed']
+};
+
+// ============================================================================
+// SERVICE IMPLEMENTATION
+// ============================================================================
+
+class SemanticProcessingService {
+  private readonly LOG_TAG = '[SEMANTIC-PROCESSING]';
+
+  /**
+   * Initialize semantic processing for a newly uploaded document
+   */
+  async initializeProcessing(options: InitializeProcessingOptions): Promise<SemanticProcessingStatus> {
+    const { documentId, batchId, projectId, alreadyConverted = false } = options;
+    const id = uuidv4();
+
+    logger.info(`${this.LOG_TAG} Initializing processing`, { id, documentId, batchId, projectId });
+
+    const initialState: SemanticProcessingState = alreadyConverted ? 'converted' : 'uploaded';
+
+    const query = `
+      INSERT INTO semantic_processing_status (
+        id, document_id, batch_id, project_id, state,
+        uploaded_at, converted_at
+      ) VALUES ($1, $2, $3, $4, $5, NOW(), $6)
+      ON CONFLICT (document_id) DO UPDATE SET
+        batch_id = EXCLUDED.batch_id,
+        state = EXCLUDED.state,
+        converted_at = EXCLUDED.converted_at,
+        error_message = NULL,
+        error_details = NULL,
+        updated_at = NOW()
+      RETURNING *
+    `;
+
+    const result = await pool.query(query, [
+      id,
+      documentId,
+      batchId,
+      projectId,
+      initialState,
+      alreadyConverted ? new Date() : null
+    ]);
+
+    const status = this.mapRowToStatus(result.rows[0]);
+
+    // Update document reference
+    await pool.query(
+      'UPDATE documents SET semantic_processing_id = $1 WHERE id = $2',
+      [status.id, documentId]
+    );
+
+    // Emit WebSocket event
+    this.emitStatusUpdate(status);
+
+    return status;
+  }
+
+  /**
+   * Initialize batch-level tracking
+   */
+  async initializeBatchProcessing(batchId: string, projectId: string, totalDocuments: number): Promise<void> {
+    logger.info(`${this.LOG_TAG} Initializing batch processing`, { batchId, projectId, totalDocuments });
+
+    const query = `
+      INSERT INTO semantic_processing_batches (
+        id, batch_id, project_id, total_documents, overall_state
+      ) VALUES ($1, $2, $3, $4, 'processing')
+      ON CONFLICT (batch_id) DO UPDATE SET
+        total_documents = GREATEST(semantic_processing_batches.total_documents, EXCLUDED.total_documents),
+        overall_state = 'processing',
+        updated_at = NOW()
+    `;
+
+    await pool.query(query, [uuidv4(), batchId, projectId, totalDocuments]);
+  }
+
+  /**
+   * Transition document to a new state with validation
+   */
+  async transitionState(
+    documentId: string,
+    newState: SemanticProcessingState,
+    options?: {
+      errorMessage?: string;
+      errorDetails?: Record<string, unknown>;
+      extractionJobId?: string;
+      gkgSyncJobId?: string;
+      extractionSummary?: ExtractionSummary;
+      gkgSyncSummary?: GkgSyncSummary;
+    }
+  ): Promise<SemanticProcessingStatus> {
+    const currentStatus = await this.getDocumentStatus(documentId);
+    
+    if (!currentStatus) {
+      throw new Error(`No semantic processing record found for document: ${documentId}`);
+    }
+
+    // Validate state transition
+    const validNextStates = VALID_TRANSITIONS[currentStatus.state];
+    if (!validNextStates.includes(newState)) {
+      throw new Error(
+        `Invalid state transition: ${currentStatus.state} → ${newState}. ` +
+        `Valid transitions: ${validNextStates.join(', ')}`
+      );
+    }
+
+    logger.info(`${this.LOG_TAG} Transitioning state`, {
+      documentId,
+      from: currentStatus.state,
+      to: newState
+    });
+
+    // Build dynamic update query
+    const updates: string[] = ['state = $2', 'updated_at = NOW()'];
+    const params: unknown[] = [documentId, newState];
+    let paramIndex = 3;
+
+    // Set timestamp based on new state
+    const timestampMap: Partial<Record<SemanticProcessingState, string>> = {
+      converted: 'converted_at',
+      extracting: 'extraction_started_at',
+      extracted: 'extraction_completed_at',
+      syncing: 'gkg_sync_started_at',
+      synced: 'gkg_sync_completed_at'
+    };
+
+    if (timestampMap[newState]) {
+      updates.push(`${timestampMap[newState]} = NOW()`);
+    }
+
+    // Handle error state
+    if (newState === 'failed' && options?.errorMessage) {
+      updates.push(`error_message = $${paramIndex++}`);
+      params.push(options.errorMessage);
+      
+      if (options.errorDetails) {
+        updates.push(`error_details = $${paramIndex++}`);
+        params.push(JSON.stringify(options.errorDetails));
+      }
+    }
+
+    // Handle retry
+    if (newState === 'retrying') {
+      updates.push('retry_count = retry_count + 1');
+      updates.push('last_retry_at = NOW()');
+    }
+
+    // Clear error on successful transition
+    if (['converted', 'extracted', 'synced'].includes(newState)) {
+      updates.push('error_message = NULL');
+      updates.push('error_details = NULL');
+    }
+
+    // Job IDs
+    if (options?.extractionJobId) {
+      updates.push(`extraction_job_id = $${paramIndex++}`);
+      params.push(options.extractionJobId);
+    }
+
+    if (options?.gkgSyncJobId) {
+      updates.push(`gkg_sync_job_id = $${paramIndex++}`);
+      params.push(options.gkgSyncJobId);
+    }
+
+    // Summaries
+    if (options?.extractionSummary) {
+      updates.push(`extraction_summary = $${paramIndex++}`);
+      params.push(JSON.stringify(options.extractionSummary));
+    }
+
+    if (options?.gkgSyncSummary) {
+      updates.push(`gkg_sync_summary = $${paramIndex++}`);
+      params.push(JSON.stringify(options.gkgSyncSummary));
+    }
+
+    const query = `
+      UPDATE semantic_processing_status
+      SET ${updates.join(', ')}
+      WHERE document_id = $1
+      RETURNING *
+    `;
+
+    const result = await pool.query(query, params);
+    const status = this.mapRowToStatus(result.rows[0]);
+
+    // Update batch counters
+    if (currentStatus.batchId) {
+      await this.updateBatchCounters(currentStatus.batchId);
+    }
+
+    // Emit WebSocket event
+    this.emitStatusUpdate(status);
+
+    return status;
+  }
+
+  /**
+   * Mark document as converted (called after document conversion completes)
+   */
+  async markConverted(documentId: string): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'converted');
+  }
+
+  /**
+   * Queue document for extraction
+   */
+  async queueForExtraction(documentId: string, jobId: string): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'queued_extraction', { extractionJobId: jobId });
+  }
+
+  /**
+   * Mark extraction as started
+   */
+  async markExtractionStarted(documentId: string): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'extracting');
+  }
+
+  /**
+   * Mark extraction as completed
+   */
+  async markExtractionCompleted(
+    documentId: string,
+    summary: ExtractionSummary
+  ): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'extracted', { extractionSummary: summary });
+  }
+
+  /**
+   * Queue document for GKG sync
+   */
+  async queueForGkgSync(documentId: string, jobId: string): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'queued_gkg_sync', { gkgSyncJobId: jobId });
+  }
+
+  /**
+   * Mark GKG sync as started
+   */
+  async markGkgSyncStarted(documentId: string): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'syncing');
+  }
+
+  /**
+   * Mark GKG sync as completed (terminal success state)
+   */
+  async markGkgSyncCompleted(
+    documentId: string,
+    summary: GkgSyncSummary
+  ): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'synced', { gkgSyncSummary: summary });
+  }
+
+  /**
+   * Mark document as failed
+   */
+  async markFailed(
+    documentId: string,
+    errorMessage: string,
+    errorDetails?: Record<string, unknown>
+  ): Promise<SemanticProcessingStatus> {
+    return this.transitionState(documentId, 'failed', { errorMessage, errorDetails });
+  }
+
+  /**
+   * Retry failed document processing
+   */
+  async retry(documentId: string): Promise<SemanticProcessingStatus | null> {
+    const status = await this.getDocumentStatus(documentId);
+    
+    if (!status) {
+      throw new Error(`No semantic processing record found for document: ${documentId}`);
+    }
+
+    if (status.state !== 'failed') {
+      throw new Error(`Cannot retry document in state: ${status.state}. Only failed documents can be retried.`);
+    }
+
+    if (status.retryCount >= status.maxRetries) {
+      throw new Error(
+        `Maximum retries (${status.maxRetries}) exceeded for document: ${documentId}`
+      );
+    }
+
+    logger.info(`${this.LOG_TAG} Initiating retry`, {
+      documentId,
+      retryCount: status.retryCount + 1,
+      maxRetries: status.maxRetries
+    });
+
+    // Determine where to resume based on what was completed
+    let resumeState: SemanticProcessingState;
+    
+    if (!status.extractionCompletedAt) {
+      // Extraction not completed, restart from extraction
+      resumeState = 'queued_extraction';
+    } else if (!status.gkgSyncCompletedAt) {
+      // Extraction done but GKG not completed, restart from GKG
+      resumeState = 'queued_gkg_sync';
+    } else {
+      // Everything was done? Shouldn't be in failed state
+      logger.warn(`${this.LOG_TAG} Document marked failed but all stages complete`, { documentId });
+      return status;
+    }
+
+    // Mark as retrying first
+    await this.transitionState(documentId, 'retrying');
+    
+    // Then queue for appropriate stage
+    return this.transitionState(documentId, resumeState);
+  }
+
+  /**
+   * Get status for a single document
+   */
+  async getDocumentStatus(documentId: string): Promise<SemanticProcessingStatus | null> {
+    const query = `
+      SELECT * FROM semantic_processing_status
+      WHERE document_id = $1
+    `;
+
+    const result = await pool.query(query, [documentId]);
+    
+    if (result.rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRowToStatus(result.rows[0]);
+  }
+
+  /**
+   * Get status for all documents in a batch
+   */
+  async getBatchStatus(batchId: string): Promise<BatchProcessingStatus | null> {
+    // Get batch summary
+    const batchQuery = `
+      SELECT * FROM semantic_processing_batches
+      WHERE batch_id = $1
+    `;
+
+    const batchResult = await pool.query(batchQuery, [batchId]);
+    
+    if (batchResult.rows.length === 0) {
+      return null;
+    }
+
+    const batch = batchResult.rows[0];
+
+    // Get all document statuses for this batch
+    const docsQuery = `
+      SELECT * FROM semantic_processing_status
+      WHERE batch_id = $1
+      ORDER BY created_at ASC
+    `;
+
+    const docsResult = await pool.query(docsQuery, [batchId]);
+    const documents = docsResult.rows.map(row => this.mapRowToStatus(row));
+
+    return {
+      id: batch.id,
+      batchId: batch.batch_id,
+      projectId: batch.project_id,
+      totalDocuments: batch.total_documents,
+      documentsConverted: batch.documents_converted,
+      documentsExtracted: batch.documents_extracted,
+      documentsSynced: batch.documents_synced,
+      documentsFailed: batch.documents_failed,
+      overallState: batch.overall_state,
+      startedAt: batch.started_at,
+      completedAt: batch.completed_at,
+      totalEntitiesExtracted: batch.total_entities_extracted,
+      totalGkgNodesCreated: batch.total_gkg_nodes_created,
+      documents
+    };
+  }
+
+  /**
+   * Get status for all documents in a project
+   */
+  async getProjectStatus(projectId: string): Promise<SemanticProcessingStatus[]> {
+    const query = `
+      SELECT * FROM semantic_processing_status
+      WHERE project_id = $1
+      ORDER BY created_at DESC
+    `;
+
+    const result = await pool.query(query, [projectId]);
+    return result.rows.map(row => this.mapRowToStatus(row));
+  }
+
+  /**
+   * Get documents that need retry (failed with retry count < max)
+   */
+  async getRetryableDocuments(projectId?: string): Promise<SemanticProcessingStatus[]> {
+    let query = `
+      SELECT * FROM semantic_processing_status
+      WHERE state = 'failed'
+        AND retry_count < max_retries
+    `;
+
+    const params: string[] = [];
+    
+    if (projectId) {
+      query += ' AND project_id = $1';
+      params.push(projectId);
+    }
+
+    query += ' ORDER BY created_at ASC';
+
+    const result = await pool.query(query, params);
+    return result.rows.map(row => this.mapRowToStatus(row));
+  }
+
+  /**
+   * Update batch-level counters based on document states
+   */
+  private async updateBatchCounters(batchId: string): Promise<void> {
+    const query = `
+      UPDATE semantic_processing_batches
+      SET
+        documents_converted = (
+          SELECT COUNT(*) FROM semantic_processing_status
+          WHERE batch_id = $1 AND converted_at IS NOT NULL
+        ),
+        documents_extracted = (
+          SELECT COUNT(*) FROM semantic_processing_status
+          WHERE batch_id = $1 AND extraction_completed_at IS NOT NULL
+        ),
+        documents_synced = (
+          SELECT COUNT(*) FROM semantic_processing_status
+          WHERE batch_id = $1 AND state = 'synced'
+        ),
+        documents_failed = (
+          SELECT COUNT(*) FROM semantic_processing_status
+          WHERE batch_id = $1 AND state = 'failed'
+        ),
+        total_entities_extracted = COALESCE((
+          SELECT SUM((extraction_summary->>'totalEntities')::int)
+          FROM semantic_processing_status
+          WHERE batch_id = $1 AND extraction_summary IS NOT NULL
+        ), 0),
+        total_gkg_nodes_created = COALESCE((
+          SELECT SUM((gkg_sync_summary->>'nodesCreated')::int)
+          FROM semantic_processing_status
+          WHERE batch_id = $1 AND gkg_sync_summary IS NOT NULL
+        ), 0),
+        overall_state = CASE
+          WHEN (
+            SELECT COUNT(*) FROM semantic_processing_status
+            WHERE batch_id = $1 AND state = 'synced'
+          ) = total_documents THEN 'complete'
+          WHEN (
+            SELECT COUNT(*) FROM semantic_processing_status
+            WHERE batch_id = $1 AND state = 'failed'
+          ) = total_documents THEN 'failed'
+          WHEN (
+            SELECT COUNT(*) FROM semantic_processing_status
+            WHERE batch_id = $1 AND state = 'failed'
+          ) > 0 THEN 'partial_failure'
+          ELSE 'processing'
+        END,
+        completed_at = CASE
+          WHEN (
+            SELECT COUNT(*) FROM semantic_processing_status
+            WHERE batch_id = $1 AND state IN ('synced', 'failed')
+          ) = total_documents THEN NOW()
+          ELSE NULL
+        END,
+        updated_at = NOW()
+      WHERE batch_id = $1
+    `;
+
+    await pool.query(query, [batchId]);
+
+    // Emit batch status update
+    const batchStatus = await this.getBatchStatus(batchId);
+    if (batchStatus) {
+      this.emitBatchStatusUpdate(batchStatus);
+    }
+  }
+
+  /**
+   * Map database row to status object
+   */
+  private mapRowToStatus(row: Record<string, unknown>): SemanticProcessingStatus {
+    return {
+      id: row.id as string,
+      documentId: row.document_id as string,
+      batchId: row.batch_id as string | null,
+      projectId: row.project_id as string,
+      state: row.state as SemanticProcessingState,
+      uploadedAt: row.uploaded_at as Date,
+      convertedAt: row.converted_at as Date | null,
+      extractionStartedAt: row.extraction_started_at as Date | null,
+      extractionCompletedAt: row.extraction_completed_at as Date | null,
+      gkgSyncStartedAt: row.gkg_sync_started_at as Date | null,
+      gkgSyncCompletedAt: row.gkg_sync_completed_at as Date | null,
+      errorMessage: row.error_message as string | null,
+      errorDetails: row.error_details as Record<string, unknown> | null,
+      retryCount: row.retry_count as number,
+      maxRetries: row.max_retries as number,
+      lastRetryAt: row.last_retry_at as Date | null,
+      extractionJobId: row.extraction_job_id as string | null,
+      gkgSyncJobId: row.gkg_sync_job_id as string | null,
+      extractionSummary: row.extraction_summary as ExtractionSummary | null,
+      gkgSyncSummary: row.gkg_sync_summary as GkgSyncSummary | null,
+      createdAt: row.created_at as Date,
+      updatedAt: row.updated_at as Date
+    };
+  }
+
+  /**
+   * Emit WebSocket event for document status update
+   */
+  private emitStatusUpdate(status: SemanticProcessingStatus): void {
+    if (io) {
+      io.to(`project:${status.projectId}`).emit('semantic:document:status', {
+        documentId: status.documentId,
+        state: status.state,
+        errorMessage: status.errorMessage,
+        retryCount: status.retryCount,
+        timestamp: new Date().toISOString()
+      });
+    }
+  }
+
+  /**
+   * Emit WebSocket event for batch status update
+   */
+  private emitBatchStatusUpdate(batch: BatchProcessingStatus): void {
+    if (io) {
+      io.to(`project:${batch.projectId}`).emit('semantic:batch:status', {
+        batchId: batch.batchId,
+        overallState: batch.overallState,
+        totalDocuments: batch.totalDocuments,
+        documentsConverted: batch.documentsConverted,
+        documentsExtracted: batch.documentsExtracted,
+        documentsSynced: batch.documentsSynced,
+        documentsFailed: batch.documentsFailed,
+        timestamp: new Date().toISOString()
+      });
+    }
+  }
+}
+
+// Export singleton instance
+export const semanticProcessingService = new SemanticProcessingService();
+
+export default semanticProcessingService;

--- a/server/src/services/semanticProcessingService.ts
+++ b/server/src/services/semanticProcessingService.ts
@@ -590,6 +590,10 @@ class SemanticProcessingService {
           ) = total_documents THEN 'failed'
           WHEN (
             SELECT COUNT(*) FROM semantic_processing_status
+            WHERE batch_id = $1 AND state IN ('synced', 'failed')
+          ) = total_documents
+          AND (
+            SELECT COUNT(*) FROM semantic_processing_status
             WHERE batch_id = $1 AND state = 'failed'
           ) > 0 THEN 'partial_failure'
           ELSE 'processing'

--- a/server/src/services/semanticProcessingService.ts
+++ b/server/src/services/semanticProcessingService.ts
@@ -168,6 +168,31 @@ class SemanticProcessingService {
   }
 
   /**
+   * Mark a batch as failed when orchestration or queue setup fails (documents would otherwise stay "processing" forever).
+   */
+  async markBatchOrchestrationFailed(batchId: string, reason: string): Promise<void> {
+    try {
+      const result = await pool.query(
+        `UPDATE semantic_processing_batches
+         SET overall_state = 'failed',
+             completed_at = COALESCE(completed_at, NOW()),
+             updated_at = NOW()
+         WHERE batch_id = $1`,
+        [batchId]
+      );
+      if (result.rowCount === 0) {
+        logger.warn(`${this.LOG_TAG} No semantic_processing_batches row to mark failed`, { batchId, reason });
+      } else {
+        logger.error(`${this.LOG_TAG} Batch orchestration marked failed`, { batchId, reason });
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`${this.LOG_TAG} Failed to persist batch failure state`, { batchId, message });
+      throw new Error(`Failed to update batch failure state: ${message}`);
+    }
+  }
+
+  /**
    * Initialize batch-level tracking
    */
   async initializeBatchProcessing(batchId: string, projectId: string, totalDocuments: number): Promise<void> {

--- a/server/src/services/semanticProcessingService.ts
+++ b/server/src/services/semanticProcessingService.ts
@@ -143,6 +143,7 @@ class SemanticProcessingService {
         error_message = NULL,
         error_details = NULL,
         updated_at = NOW()
+      WHERE semantic_processing_status.state <> 'synced'
       RETURNING *
     `;
 
@@ -155,7 +156,19 @@ class SemanticProcessingService {
       alreadyConverted ? new Date() : null
     ]);
 
-    const status = this.mapRowToStatus(result.rows[0]);
+    let row = result.rows[0];
+    if (!row) {
+      const existing = await pool.query(
+        'SELECT * FROM semantic_processing_status WHERE document_id = $1',
+        [documentId]
+      );
+      row = existing.rows[0];
+    }
+    if (!row) {
+      throw new Error(`Failed to initialize semantic processing for document: ${documentId}`);
+    }
+
+    const status = this.mapRowToStatus(row);
 
     // Update document reference
     await pool.query(
@@ -206,7 +219,11 @@ class SemanticProcessingService {
       ) VALUES ($1, $2, $3, $4, 'processing')
       ON CONFLICT (batch_id) DO UPDATE SET
         total_documents = GREATEST(semantic_processing_batches.total_documents, EXCLUDED.total_documents),
-        overall_state = 'processing',
+        overall_state = CASE
+          WHEN semantic_processing_batches.overall_state IN ('complete', 'failed', 'partial_failure')
+            THEN semantic_processing_batches.overall_state
+          ELSE 'processing'
+        END,
         updated_at = NOW()
     `;
 

--- a/server/src/services/semanticProcessingService.ts
+++ b/server/src/services/semanticProcessingService.ts
@@ -80,6 +80,8 @@ export interface BatchProcessingStatus {
   documentsSynced: number;
   documentsFailed: number;
   overallState: string;
+  /** 0–100: share of documents in terminal success or failure */
+  progress: number;
   startedAt: Date;
   completedAt: Date | null;
   totalEntitiesExtracted: number;
@@ -491,16 +493,25 @@ class SemanticProcessingService {
     const docsResult = await pool.query(docsQuery, [batchId]);
     const documents = docsResult.rows.map(row => this.mapRowToStatus(row));
 
+    const totalDocuments = batch.total_documents as number;
+    const documentsSynced = batch.documents_synced as number;
+    const documentsFailed = batch.documents_failed as number;
+    const progress =
+      totalDocuments > 0
+        ? Math.round(((documentsSynced + documentsFailed) / totalDocuments) * 100)
+        : 0;
+
     return {
       id: batch.id,
       batchId: batch.batch_id,
       projectId: batch.project_id,
-      totalDocuments: batch.total_documents,
+      totalDocuments,
       documentsConverted: batch.documents_converted,
       documentsExtracted: batch.documents_extracted,
-      documentsSynced: batch.documents_synced,
-      documentsFailed: batch.documents_failed,
+      documentsSynced,
+      documentsFailed,
       overallState: batch.overall_state,
+      progress,
       startedAt: batch.started_at,
       completedAt: batch.completed_at,
       totalEntitiesExtracted: batch.total_entities_extracted,
@@ -676,6 +687,7 @@ class SemanticProcessingService {
         documentsExtracted: batch.documentsExtracted,
         documentsSynced: batch.documentsSynced,
         documentsFailed: batch.documentsFailed,
+        progress: batch.progress,
         timestamp: new Date().toISOString()
       });
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR implements SC-27: Onboarding Ingestion to Async Semantic Processing & GKG Foundation. It extends the existing onboarding document upload flow into an asynchronous semantic processing pipeline that automatically converts uploaded documents, runs entity extraction, persists traceable results, and syncs semantic units into the Governance Knowledge Graph (GKG).

## Changes

### Database Schema
- **Migration 400**: Adds `semantic_processing_status` table for document-level tracking with explicit states (uploaded, converted, queued_extraction, extracting, extracted, queued_gkg_sync, syncing, synced, failed, retrying)
- Adds `semantic_processing_batches` table for batch-level aggregate status tracking
- Includes proper indexes, triggers for `updated_at`, and foreign key relationships

### Backend Services
- **SemanticProcessingService** (`/server/src/services/semanticProcessingService.ts`): Orchestrates the async pipeline with state machine validation, WebSocket events for real-time updates, and retry support
- **SemanticProcessingJobService** (`/server/src/services/jobs/SemanticProcessingJobService.ts`): Queue processor for document and batch semantic processing jobs, integrating with AI-based entity extraction and GKG sync

### Queue Infrastructure
- Adds `semantic-processing` RabbitMQ queue with processors for `semantic-process-document` and `semantic-process-batch` jobs
- Automatic trigger from `documentUploadService` after batch completion

### API Endpoints (`/api/semantic-processing/*`)
- `GET /document/:documentId` - Get document processing status
- `GET /batch/:batchId` - Get batch processing status with all documents
- `GET /batch/:batchId/summary` - Lightweight polling endpoint
- `GET /project/:projectId` - Get all processing status for a project
- `POST /document/:documentId/retry` - Retry failed document processing
- `POST /batch/:batchId/retry-failed` - Retry all failed documents in a batch
- `GET /retryable` - Get all documents eligible for retry

### Frontend UI
- **SemanticProcessingStatus component** (`/components/onboarding/SemanticProcessingStatus.tsx`): Real-time status monitoring with progress bars, stage indicators, retry buttons, and error display
- **Processing status page** (`/app/onboarding/processing/page.tsx`): Dedicated page for monitoring semantic processing across batches
- **Assessment page integration**: New "Processing" tab added to the assessment page for inline status monitoring

## Acceptance Criteria

- ✅ Existing onboarding ingestion remains the entry point for document upload
- ✅ Successful uploads automatically trigger background semantic processing without blocking the upload UI
- ✅ Processing lifecycle is traceable at batch and document level through explicit states
- ✅ Users can retrieve updated status information through dedicated UI without re-uploading
- ✅ Onboarding documents reuse the existing entity extraction framework and GKG sync path
- ✅ Failures are visible, auditable, and retryable without losing the original uploaded document

## Story Reference

Story URL: https://app.shortcut.com/cba-2/story/27
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93aa2c7c-0acc-480f-b5e9-9b59b67d0bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93aa2c7c-0acc-480f-b5e9-9b59b67d0bb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

