### PR TITLE
Add development environment setup (AGENTS.md + build deps)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Service Overview
+
+ADPA is a monorepo with two services:
+- **Frontend**: Next.js 16 (Pages Router) on port 3000
+- **Backend**: Express.js on port 5000
+
+### Starting Services
+
+```bash
+# Backend (in server/ directory)
+cd server && npm run dev
+
+# Frontend (in root directory, MUST specify port)
+pnpm dev --port 3000
+```
+
+**Important**: Next.js 16 defaults to port 5000 (not 3000) if `PORT` env var is set. Always pass `--port 3000` to avoid conflicting with the backend.
+
+### Database & Redis
+
+- PG 16 must be running. Start with: `sudo pg_ctlcluster 16 main start`
+- Redis must be running. Start with: `redis-server --daemonize yes`
+- DB credentials are in `server/.env` (see the example file for reference)
+- Schema setup: apply `server/migrations/000_baseline.sql` using credentials from `server/.env`
+
+### Authentication
+
+- The frontend uses Firebase Auth for login. Without Firebase credentials, use the **demo login** endpoint: `POST /api/v1/auth/demo`
+- The backend also supports direct JWT registration: `POST /api/v1/auth/register` with JSON body containing email, a secret credential, name, companyName
+- In development (`NODE_ENV=development`), Firebase Auth dependency is non-critical and the server starts without it.
+
+### Startup Dependency System
+
+The backend uses a dependency graph for startup. In development:
+- **Critical** (must succeed): Security Config, Database, Azure Backend (just a ping that warns on failure)
+- **Optional** (server works without them): Redis, Neo4j, RabbitMQ, MongoDB, Pinecone, Langfuse, Upstash, Morphic DB, Firebase Auth
+
+### Running Tests
+
+```bash
+# Backend unit tests (Jest)
+cd server && npx jest --testPathPattern="<pattern>" --no-coverage
+
+# Full test suite (117 files, takes several minutes)
+cd server && npm test
+```
+
+### Lint
+
+ESLint has a pre-existing configuration issue: ESLint 9 requires flat config (`eslint.config.js`) but the project uses legacy `.eslintrc.json`. The `pnpm lint` / `next lint` commands currently don't work due to this incompatibility. This is a known codebase issue, not an environment problem.
+
+### Environment Files
+
+- Frontend: `.env.local` (see `.env.local.example`)
+- Backend: `server/.env` (see `server/.env.example`)
+- Key env vars: `DATABASE_URL`, `REDIS_URL`, `JWT_SECRET`, `BACKEND_URL` (for frontend proxy)
+
+### API Proxy
+
+The Next.js frontend proxies `/api/*` requests to the backend via `next.config.mjs` rewrites. The `BACKEND_URL` env var controls where API calls are forwarded (defaults to the Express backend port in local dev).
+
+### Package Managers
+
+- Frontend: `pnpm` (v10.32.1, declared in `packageManager` field)
+- Backend: `npm` (uses separate package.json in `server/`)
+- Both are installed via `pnpm install` from root (workspace setup in `pnpm-workspace.yaml`)
+
+### Build Scripts Approval
+
+The `pnpm.onlyBuiltDependencies` field in root `package.json` controls which packages can run postinstall scripts. Key packages that need it: `puppeteer`, `sharp`, `esbuild`.

--- a/package.json
+++ b/package.json
@@ -312,7 +312,17 @@
       "zod@3.24.1": "patches/zod@3.24.1.patch"
     },
     "onlyBuiltDependencies": [
-      "esbuild"
+      "esbuild",
+      "puppeteer",
+      "sharp",
+      "bufferutil",
+      "utf-8-validate",
+      "@sentry/cli",
+      "core-js",
+      "msgpackr-extract",
+      "protobufjs",
+      "unrs-resolver",
+      "@firebase/util"
     ]
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for Cloud Agents with proper documentation and build script configuration.

### Changes

- **`AGENTS.md`**: New file with Cursor Cloud specific instructions covering:
  - Service startup commands (frontend on port 3000, backend on port 5000)
  - Database and Redis setup requirements
  - Authentication flow (Firebase Auth + demo login endpoint)
  - Backend startup dependency system (critical vs optional deps)
  - Test commands and lint status
  - Environment file references and API proxy configuration
  - Package manager usage (pnpm for frontend, npm for backend)

- **`package.json`**: Updated `pnpm.onlyBuiltDependencies` to include packages that require native build scripts:
  - `puppeteer` (downloads Chromium for PDF generation)
  - `sharp` (image processing native bindings)
  - `bufferutil`, `utf-8-validate` (WebSocket native bindings)
  - `@sentry/cli`, `core-js`, `msgpackr-extract`, `protobufjs`, `unrs-resolver`, `@firebase/util`

### Environment Verification

[adpa_frontend_demo.mp4](https://cursor.com/agents/bc-3a44670d-1f56-4fc8-9c45-88d02103198d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadpa_frontend_demo.mp4)

Frontend loads and renders correctly with working navigation and login UI.

Backend API verification showing health check, demo login, user registration, and project creation all working:

[backend_api_test.log](https://cursor.com/agents/bc-3a44670d-1f56-4fc8-9c45-88d02103198d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbackend_api_test.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a44670d-1f56-4fc8-9c45-88d02103198d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a44670d-1f56-4fc8-9c45-88d02103198d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

