### PR TITLE
feat(openui): Integrate @openuidev/react-lang for LLM-driven document UI

### DIFF
--- a/app/ai/openui-chat/page.tsx
+++ b/app/ai/openui-chat/page.tsx
@@ -9,7 +9,9 @@ import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { DynamicComponentRenderer } from "@/components/openui-chat/DynamicComponentRenderer"
+import { looksLikeOpenUILang } from "@/lib/openui/library"
 import type { ComponentPayload } from "@/lib/openui/library"
+import { parseOpenUILangSSEBuffer } from "@/lib/openui/streaming"
 import { useAuth } from "@/contexts/AuthContext"
 import { Send, Loader2, Sparkles, MessageSquare, Plus } from "lucide-react"
 import { apiClient, type Project } from "@/lib/api"
@@ -32,7 +34,9 @@ interface UserMessage {
 interface AssistantMessage {
   id: string
   role: "assistant"
-  payload: ComponentPayload
+  response: string
+  /** Legacy JSON payload for older messages */
+  legacyPayload?: ComponentPayload
 }
 
 type ChatMessage = UserMessage | AssistantMessage
@@ -93,7 +97,7 @@ export default function OpenUIChatPage() {
       const history = messages.map((m) =>
         m.role === "user"
           ? { role: "user", content: m.text }
-          : { role: "assistant", content: JSON.stringify((m as AssistantMessage).payload) }
+          : { role: "assistant", content: (m as AssistantMessage).response }
       )
 
       const res = await fetch("/api/v1/openui-chat/chat", {
@@ -113,59 +117,55 @@ export default function OpenUIChatPage() {
         throw new Error(`Server error ${res.status}`)
       }
 
-      // Parse SSE stream
       const reader = res.body!.getReader()
       const decoder = new TextDecoder()
       let buffer = ""
-      let assistantPayload: ComponentPayload | null = null
-      let newThreadId: string | null = null
+      let accumulated = ""
+      let newThreadId: string | null = res.headers.get("x-thread-id")
+      let streamingMsgId: string | null = null
 
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
         buffer += decoder.decode(value, { stream: true })
+        const { events, remainder } = parseOpenUILangSSEBuffer(buffer)
+        buffer = remainder
 
-        const lines = buffer.split("\n")
-        buffer = lines.pop() ?? ""
-
-        for (const line of lines) {
-          if (line.startsWith("data: ")) {
-            try {
-              const json = JSON.parse(line.slice(6))
-              if (json.threadId) newThreadId = json.threadId
-              else if (json.props?.threadId) newThreadId = json.props.threadId
-              if (json.component) {
-                assistantPayload = json as ComponentPayload
-              }
-            } catch {
-              // incomplete chunk, skip
+        for (const event of events) {
+          if (event.type === "text") {
+            accumulated += event.text
+            if (event.threadId) newThreadId = event.threadId
+            if (!streamingMsgId) {
+              streamingMsgId = crypto.randomUUID()
+              setMessages((prev) => [
+                ...prev,
+                { id: streamingMsgId!, role: "assistant", response: accumulated },
+              ])
+            } else {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === streamingMsgId ? { ...m, role: "assistant" as const, response: accumulated } : m
+                )
+              )
             }
+          } else if (event.type === "done" && event.threadId) {
+            newThreadId = event.threadId
+          } else if (event.type === "error") {
+            throw new Error(event.message)
           }
         }
       }
 
       if (newThreadId) setThreadId(newThreadId)
-
-      if (assistantPayload) {
-        const assistantMsg: AssistantMessage = {
-          id: crypto.randomUUID(),
-          role: "assistant",
-          payload: assistantPayload,
-        }
-        setMessages((prev) => [...prev, assistantMsg])
-      }
     } catch (err) {
-      const errorPayload: ComponentPayload = {
-        type: "component",
-        component: "Text",
-        props: { title: "Error" },
-        data: [],
-        metadata: {},
-        content: `Request failed: ${err instanceof Error ? err.message : String(err)}`,
-      } as unknown as ComponentPayload
+      const msg = (err instanceof Error ? err.message : String(err)).replace(/"/g, "'")
       setMessages((prev) => [
         ...prev,
-        { id: crypto.randomUUID(), role: "assistant", payload: errorPayload },
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          response: `<Alert severity="error" alerts={[{"category": "Error", "impact": "${msg}", "mitigation": "Try again."}]} />`,
+        },
       ])
     } finally {
       setStreaming(false)
@@ -255,7 +255,7 @@ export default function OpenUIChatPage() {
                     msg.role === "user" ? (
                       <UserBubble key={msg.id} text={msg.text} />
                     ) : (
-                      <AssistantBubble key={msg.id} payload={(msg as AssistantMessage).payload} />
+                      <AssistantBubble key={msg.id} message={msg as AssistantMessage} isStreaming={streaming} />
                     )
                   )}
                   {streaming && <StreamingIndicator />}
@@ -320,7 +320,13 @@ function UserBubble({ text }: { text: string }) {
   )
 }
 
-function AssistantBubble({ payload }: { payload: ComponentPayload }) {
+function AssistantBubble({
+  message,
+  isStreaming,
+}: {
+  message: AssistantMessage
+  isStreaming: boolean
+}) {
   return (
     <div className="flex justify-start">
       <div className="w-full max-w-4xl">
@@ -328,7 +334,11 @@ function AssistantBubble({ payload }: { payload: ComponentPayload }) {
           <Sparkles className="h-3 w-3 text-indigo-400" />
           OpenUI
         </div>
-        <DynamicComponentRenderer payload={payload} />
+        <DynamicComponentRenderer
+          response={looksLikeOpenUILang(message.response) ? message.response : undefined}
+          payload={message.legacyPayload}
+          isStreaming={isStreaming}
+        />
       </div>
     </div>
   )

--- a/app/projects/[id]/documents/[docId]/view/page.tsx
+++ b/app/projects/[id]/documents/[docId]/view/page.tsx
@@ -19,8 +19,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Sidebar } from "@/components/sidebar"
 import { Header } from "@/components/header"
-import { PageTransition } from "@/components/page-transition"
 import { AnimatedLayout, AnimatedCard } from "@/components/animated-layout"
+import {
+  DocumentPageToolbar,
+  type DocumentSummary,
+} from "@/components/documents/DocumentPageToolbar"
 import NovelEditor from "@/components/editor/novel-editor"
 import { motion } from "framer-motion"
 import {
@@ -123,6 +126,8 @@ export default function ProjectDocumentViewer() {
   } | null>(null)
   const [isExportingPdf, setIsExportingPdf] = useState(false)
   const [isExportingWord, setIsExportingWord] = useState(false)
+  const [projectDocuments, setProjectDocuments] = useState<DocumentSummary[]>([])
+  const [docsListLoading, setDocsListLoading] = useState(true)
 
   // Feedback state
   const [feedbackDialogOpen, setFeedbackDialogOpen] = useState(false)
@@ -352,6 +357,29 @@ export default function ProjectDocumentViewer() {
       window.document.removeEventListener('scroll', handleInteraction)
     }
   }, [projectId, documentId, router, authLoading, isAuthenticated, token])
+
+  useEffect(() => {
+    if (!projectId || !isAuthenticated) return
+    const fetchProjectDocuments = async () => {
+      setDocsListLoading(true)
+      try {
+        const res = await apiClient.get<{ documents: DocumentSummary[] }>(
+          `/documents/project/${projectId}?limit=100`
+        )
+        setProjectDocuments(res.documents ?? [])
+      } catch (err) {
+        console.error("Failed to fetch project documents", err)
+        setProjectDocuments([])
+      } finally {
+        setDocsListLoading(false)
+      }
+    }
+    void fetchProjectDocuments()
+  }, [projectId, isAuthenticated])
+
+  const handleDocChange = (newDocId: string) => {
+    router.push(`/projects/${projectId}/documents/${newDocId}/view`)
+  }
 
   // WebSocket effect
   useEffect(() => {
@@ -589,80 +617,115 @@ export default function ProjectDocumentViewer() {
     }
   }
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background flex">
-        <Sidebar />
-        <div className="flex-1 flex flex-col">
-          <Header title="Loading..." />
-          <main className="flex-1 flex items-center justify-center">
-            <Loader2 className="h-8 w-8 animate-spin text-primary" />
-          </main>
-        </div>
+  const pageShell = (content: React.ReactNode, toolbarDocId = documentId) => (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <Header />
+        <DocumentPageToolbar
+          projectId={projectId}
+          mode="view"
+          documents={projectDocuments}
+          docsLoading={docsListLoading}
+          selectedDocId={toolbarDocId}
+          onDocChange={handleDocChange}
+        />
+        {content}
       </div>
+    </div>
+  )
+
+  if (isLoading) {
+    return pageShell(
+      <main className="flex min-h-0 flex-1 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-600" />
+      </main>
     )
   }
 
   if (!documentData) {
-    return (
-      <div className="min-h-screen bg-background flex">
-        <Sidebar />
-        <div className="flex-1 flex flex-col">
-          <Header title="Document Not Found" />
-          <main className="flex-1 flex flex-col items-center justify-center">
-            <AlertCircle className="h-12 w-12 text-destructive mb-4" />
-            <h2 className="text-2xl font-bold">Document Not Found</h2>
-            <Button className="mt-4" onClick={() => router.push(`/projects/${projectId}/documents`)}>
-              Back to Documents
-            </Button>
-          </main>
-        </div>
-      </div>
+    return pageShell(
+      <main className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 px-6">
+        <AlertCircle className="h-12 w-12 text-destructive" />
+        <h2 className="text-xl font-semibold text-slate-900">Document not found</h2>
+        <Button onClick={() => router.push(`/projects/${projectId}/documents`)}>
+          Back to documents
+        </Button>
+      </main>
     )
   }
 
   return (
-    <div className="h-screen bg-background flex overflow-hidden">
+    <div className="flex h-screen overflow-hidden bg-slate-50">
       <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <Header title={documentData.title || documentData.name || "Document View"} />
-        <main className="flex-1 overflow-y-auto p-6">
-          <PageTransition>
-            <AnimatedLayout>
-              <div className="max-w-7xl mx-auto">
-                {/* Header Section */}
-                <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
-                  <div>
-                    <div className="flex items-center space-x-2 text-sm text-muted-foreground mb-1">
-                      <Folder className="h-4 w-4" />
-                      <span>{documentData.project_name || 'Project'}</span>
-                    </div>
-                    <h1 className="text-3xl font-bold">{documentData.title || documentData.name}</h1>
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="secondary">{documentData.status}</Badge>
-                    <Button variant="outline" size="sm" onClick={() => setShowVersionsDialog(true)}>
-                      <History className="h-4 w-4 mr-2" />
-                      v{documentData.loaded_version || documentData.version}
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={() => setShowComments(!showComments)}>
-                      <MessageSquare className="h-4 w-4 mr-2" />
-                      {documentData.comments?.length || 0}
-                    </Button>
-                    <Button variant="outline" size="sm" onClick={() => setShowRegenerateModal(true)}>
-                      <Sparkles className="h-4 w-4 mr-2" />
-                      Regenerate
-                    </Button>
-                    <Button variant="outline" size="sm" asChild>
-                      <Link href={`/projects/${projectId}/documents/${documentId}`}>
-                        <Settings className="h-4 w-4 mr-2" />
-                        Metadata
-                      </Link>
-                    </Button>
-                  </div>
-                </div>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <Header />
+        <DocumentPageToolbar
+          projectId={projectId}
+          mode="view"
+          documents={projectDocuments}
+          docsLoading={docsListLoading}
+          selectedDocId={documentId}
+          onDocChange={handleDocChange}
+          docSelectorDisabled={isSaving}
+        >
+          <Badge variant="secondary" className="text-[10px] uppercase">
+            {documentData.status}
+          </Badge>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => setShowVersionsDialog(true)}
+          >
+            <History className="h-3.5 w-3.5" />
+            v{documentData.loaded_version || documentData.version}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => setShowComments(!showComments)}
+          >
+            <MessageSquare className="h-3.5 w-3.5" />
+            {documentData.comments?.length || 0}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={() => setShowRegenerateModal(true)}
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Regenerate
+          </Button>
+          <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs" asChild>
+            <Link href={`/projects/${projectId}/documents/${documentId}`}>
+              <Settings className="h-3.5 w-3.5" />
+              Metadata
+            </Link>
+          </Button>
+        </DocumentPageToolbar>
+        <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
+          <AnimatedLayout>
+            <div className="mx-auto w-full max-w-7xl px-4 py-6 sm:px-8">
+              <div className="mb-6">
+                <p className="mb-1 flex items-center gap-2 text-xs text-slate-500">
+                  <Folder className="h-3.5 w-3.5" />
+                  {documentData.project_name || "Project"}
+                  {templateName ? (
+                    <>
+                      <span className="text-slate-300">·</span>
+                      {templateName}
+                    </>
+                  ) : null}
+                </p>
+                <h1 className="text-2xl font-bold text-slate-900 sm:text-3xl">
+                  {documentData.title || documentData.name}
+                </h1>
+              </div>
 
-                <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+              <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                   {/* Editor Column */}
                   <div className="lg:col-span-3">
                     <AnimatedCard>
@@ -820,9 +883,8 @@ export default function ProjectDocumentViewer() {
                     </div>
                   </div>
                 )}
-              </div>
-            </AnimatedLayout>
-          </PageTransition>
+            </div>
+          </AnimatedLayout>
         </main>
       </div>
 

--- a/app/projects/[id]/documents/page.tsx
+++ b/app/projects/[id]/documents/page.tsx
@@ -1739,19 +1739,27 @@ export default function ProjectDocuments() {
                                 <Button
                                   variant="outline"
                                   size="sm"
-                                  className="text-indigo-600 border-indigo-200 bg-indigo-50/50 hover:bg-indigo-50 hover:text-indigo-700 hover:border-indigo-300"
-                                  onClick={() => router.push(`/projects/${projectId}/documents/ui?docId=${document.id}`)}
-                                >
-                                  <Wand2 className="h-4 w-4 mr-2 text-indigo-500" />
-                                  UI Chat
-                                </Button>
-                                <Button
-                                  variant="outline"
-                                  size="sm"
                                   onClick={() => router.push(`/projects/${projectId}/documents/${document.id}/view`)}
                                 >
                                   <Eye className="h-4 w-4 mr-2" />
                                   View
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => router.push(`/projects/${projectId}/documents/source?docId=${document.id}`)}
+                                >
+                                  <FileText className="h-4 w-4 mr-2" />
+                                  Source
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="text-indigo-600 border-indigo-200 bg-indigo-50/50 hover:bg-indigo-50 hover:text-indigo-700 hover:border-indigo-300"
+                                  onClick={() => router.push(`/projects/${projectId}/documents/ui?docId=${document.id}`)}
+                                >
+                                  <Wand2 className="h-4 w-4 mr-2 text-indigo-500" />
+                                  Report
                                 </Button>
                                 <Button
                                   variant="outline"

--- a/app/projects/[id]/documents/page.tsx
+++ b/app/projects/[id]/documents/page.tsx
@@ -1739,6 +1739,15 @@ export default function ProjectDocuments() {
                                 <Button
                                   variant="outline"
                                   size="sm"
+                                  className="text-indigo-600 border-indigo-200 bg-indigo-50/50 hover:bg-indigo-50 hover:text-indigo-700 hover:border-indigo-300"
+                                  onClick={() => router.push(`/projects/${projectId}/documents/ui?docId=${document.id}`)}
+                                >
+                                  <Wand2 className="h-4 w-4 mr-2 text-indigo-500" />
+                                  UI Chat
+                                </Button>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
                                   onClick={() => router.push(`/projects/${projectId}/documents/${document.id}/view`)}
                                 >
                                   <Eye className="h-4 w-4 mr-2" />

--- a/app/projects/[id]/documents/source/page.tsx
+++ b/app/projects/[id]/documents/source/page.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { useParams, useSearchParams, useRouter } from "next/navigation"
+import { Sidebar } from "@/components/sidebar"
+import { Header } from "@/components/header"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/contexts/AuthContext"
+import { apiClient } from "@/lib/api"
+import { extractDocumentMarkdown } from "@/lib/documents/extractContent"
+import {
+  DocumentPageToolbar,
+  type DocumentSummary,
+} from "@/components/documents/DocumentPageToolbar"
+import { Copy, Check, Loader2 } from "lucide-react"
+
+export default function ProjectDocumentSourcePage() {
+  const params = useParams()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const { user } = useAuth()
+
+  const projectId = params?.id as string | undefined
+  const initialDocId = searchParams?.get("docId") ?? undefined
+
+  const [documents, setDocuments] = useState<DocumentSummary[]>([])
+  const [docsLoading, setDocsLoading] = useState(true)
+  const [selectedDocId, setSelectedDocId] = useState<string>(initialDocId ?? "")
+  const [contentLoading, setContentLoading] = useState(false)
+  const [markdown, setMarkdown] = useState<string>("")
+  const [updatedAt, setUpdatedAt] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const selectedDoc = documents.find((d) => d.id === selectedDocId) ?? null
+
+  useEffect(() => {
+    if (!projectId || !user) return
+    const fetchDocs = async () => {
+      setDocsLoading(true)
+      try {
+        const res = await apiClient.get<{ documents: DocumentSummary[] }>(
+          `/documents/project/${projectId}?limit=100`
+        )
+        const docs = res.documents ?? []
+        setDocuments(docs)
+        if (!initialDocId && docs.length > 0) {
+          setSelectedDocId(docs[0].id)
+        } else if (initialDocId && !docs.find((d) => d.id === initialDocId) && docs.length > 0) {
+          setSelectedDocId(docs[0].id)
+        }
+      } catch (err) {
+        console.error("Failed to fetch project documents", err)
+      } finally {
+        setDocsLoading(false)
+      }
+    }
+    fetchDocs()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, user])
+
+  const loadDocumentContent = useCallback(async (docId: string) => {
+    if (!docId) {
+      setMarkdown("")
+      setUpdatedAt(null)
+      return
+    }
+    setContentLoading(true)
+    try {
+      const doc = await apiClient.getDocument(docId)
+      setMarkdown(extractDocumentMarkdown(doc.content))
+      setUpdatedAt(doc.updated_at ?? doc.created_at ?? null)
+    } catch (err) {
+      console.error("Failed to load document content", err)
+      setMarkdown("")
+      setUpdatedAt(null)
+    } finally {
+      setContentLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (selectedDocId) {
+      void loadDocumentContent(selectedDocId)
+    }
+  }, [selectedDocId, loadDocumentContent])
+
+  const handleDocChange = (docId: string) => {
+    setSelectedDocId(docId)
+    router.replace(`/projects/${projectId}/documents/source?docId=${docId}`)
+  }
+
+  const handleCopy = async () => {
+    if (!markdown) return
+    try {
+      await navigator.clipboard.writeText(markdown)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      /* clipboard may be unavailable */
+    }
+  }
+
+  const charCount = markdown.length
+  const lineCount = markdown ? markdown.split("\n").length : 0
+
+  if (!projectId) return null
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        <Header />
+        <DocumentPageToolbar
+          projectId={projectId}
+          mode="source"
+          documents={documents}
+          docsLoading={docsLoading}
+          selectedDocId={selectedDocId}
+          onDocChange={handleDocChange}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={handleCopy}
+            disabled={!markdown || contentLoading}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-600" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </DocumentPageToolbar>
+
+        <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
+          <div className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-8">
+            {!selectedDocId ? (
+              <p className="text-sm text-slate-500">Select a document to view its stored markdown.</p>
+            ) : contentLoading ? (
+              <div className="flex items-center gap-2 py-12 text-sm text-slate-500">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading document from database…
+              </div>
+            ) : markdown ? (
+              <>
+                <div className="mb-3 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                  <span>{lineCount.toLocaleString()} lines</span>
+                  <span>{charCount.toLocaleString()} characters</span>
+                  {updatedAt ? (
+                    <span>Updated {new Date(updatedAt).toLocaleString()}</span>
+                  ) : null}
+                  {selectedDoc?.template_name ? (
+                    <span>Template: {selectedDoc.template_name}</span>
+                  ) : null}
+                </div>
+                <pre className="overflow-x-auto rounded-lg border border-slate-200 bg-white p-4 sm:p-6 text-[13px] leading-relaxed text-slate-800 font-mono whitespace-pre-wrap break-words shadow-sm">
+                  {markdown}
+                </pre>
+              </>
+            ) : (
+              <p className="text-sm text-slate-500">This document has no stored content.</p>
+            )}
+          </div>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/app/projects/[id]/documents/ui/page.tsx
+++ b/app/projects/[id]/documents/ui/page.tsx
@@ -4,11 +4,9 @@ import { useState, useRef, useEffect, useCallback } from "react"
 import { useParams, useSearchParams, useRouter } from "next/navigation"
 import { Sidebar } from "@/components/sidebar"
 import { Header } from "@/components/header"
-import { PageTransition } from "@/components/page-transition"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Badge } from "@/components/ui/badge"
-import { ScrollArea } from "@/components/ui/scroll-area"
 import { DynamicComponentRenderer } from "@/components/openui-chat/DynamicComponentRenderer"
 import { parseOpenUILangSSEBuffer } from "@/lib/openui/streaming"
 import { useAuth } from "@/contexts/AuthContext"
@@ -27,9 +25,11 @@ import {
   MessageSquare,
   Plus,
   ArrowLeft,
+  Eye,
   FileText,
   ChevronLeft,
   ChevronRight,
+  Printer,
 } from "lucide-react"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -78,9 +78,9 @@ const DOCUMENT_PROMPTS: { keywords: string[]; prompts: string[] }[] = [
   {
     keywords: ["charter", "project"],
     prompts: [
-      "Summarize the project objectives",
-      "Show project timeline",
-      "List key deliverables",
+      "Render full charter as a numbered report",
+      "Add a milestones timeline section",
+      "Expand the scope section with a table",
       "Who is the project sponsor?",
     ],
   },
@@ -112,11 +112,11 @@ function getDocumentPrompts(docName: string, templateName?: string): string[] {
     }
   }
   return [
-    "Summarize this document",
-    "Show key data as a table",
-    "What are the main findings?",
-    "Create a visual overview",
-    "List action items",
+    "Render the full document with every section",
+    "Use tables only where all rows are shown",
+    "Show narrative sections as complete prose",
+    "List every action item from the source",
+    "Expand section 3 with all original text",
   ]
 }
 
@@ -281,12 +281,14 @@ export default function ProjectDocumentUIPage() {
       const docLabel = doc ? `"${doc.name}"` : "this document"
       
       setTimeout(() => {
-        sendMessage(`Visualize ${docLabel} as a comprehensive dashboard with appropriate tables, lists, and status indicators.`)
+        sendMessage(
+          `Transform ${docLabel} from markdown into a professional presentation-ready report (root = Report). Preserve all content and meaning. One Section per source heading; Prose for full narrative; Table/Bullets/Card only when every item fits. Add Table of Contents if 4+ sections. No summaries. No tabs.`
+        )
       }, 100)
     }
   }, [docsLoading, selectedDocId, streaming, documents, messages.length, sendMessage])
 
-  const refreshDashboard = () => {
+  const refreshReport = () => {
     if (!selectedDocId || streaming) return
     setLangResponse(null)
     setMessages([])
@@ -299,12 +301,9 @@ export default function ProjectDocumentUIPage() {
   return (
     <div className="flex h-screen overflow-hidden bg-slate-50">
       <Sidebar />
-      <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <Header />
-        <PageTransition>
-          <div className="flex flex-1 flex-col overflow-hidden">
-            {/* Toolbar */}
-            <div className="flex flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="flex shrink-0 flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6 print:hidden">
               <div className="flex items-center gap-3 min-w-0">
                 {/* Back to documents */}
                 <Button
@@ -321,9 +320,9 @@ export default function ProjectDocumentUIPage() {
                 {/* Page identity */}
                 <div className="flex items-center gap-2 shrink-0">
                   <Sparkles className="h-5 w-5 text-indigo-600" />
-                  <span className="font-semibold text-slate-900">Document Dashboard</span>
-                  <Badge variant="secondary" className="bg-indigo-100 text-indigo-800 text-[10px] uppercase font-bold tracking-wider px-2 py-0.5">
-                    Live UI
+                  <span className="font-semibold text-slate-900">Document Report</span>
+                  <Badge variant="secondary" className="bg-slate-100 text-slate-700 text-[10px] uppercase font-bold tracking-wider px-2 py-0.5">
+                    Live
                   </Badge>
                 </div>
                 <div className="h-4 w-px bg-slate-200 shrink-0" />
@@ -361,64 +360,99 @@ export default function ProjectDocumentUIPage() {
                 </div>
               </div>
 
-              <div className="flex items-center gap-2 shrink-0">
+              <div className="flex items-center gap-2 shrink-0 print:hidden">
+                {selectedDocId ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5 text-xs"
+                      onClick={() =>
+                        router.push(`/projects/${projectId}/documents/${selectedDocId}/view`)
+                      }
+                    >
+                      <Eye className="h-3.5 w-3.5" />
+                      View
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5 text-xs"
+                      onClick={() =>
+                        router.push(`/projects/${projectId}/documents/source?docId=${selectedDocId}`)
+                      }
+                    >
+                      <FileText className="h-3.5 w-3.5" />
+                      Source
+                    </Button>
+                  </>
+                ) : null}
                 <Button
                   variant="outline"
                   size="sm"
-                  onClick={refreshDashboard}
+                  onClick={() => window.print()}
+                  disabled={!langResponse}
+                  className="h-8 gap-1.5 text-xs text-slate-600 border-slate-200 hover:bg-slate-50 shrink-0"
+                >
+                  <Printer className="h-3.5 w-3.5" />
+                  Print
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshReport}
                   disabled={streaming || !selectedDocId}
                   className="h-8 gap-1.5 text-xs text-indigo-600 border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 transition-all shrink-0"
                 >
                   <Sparkles className="h-3.5 w-3.5" />
-                  Re-visualize
+                  Regenerate report
                 </Button>
               </div>
-            </div>
+        </div>
 
-            {/* Main Pane */}
-            <div className="flex-1 overflow-hidden">
-              <ScrollArea className="h-full w-full">
+        <main className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar">
                 {docsLoading ? (
-                  <DashboardLoader docName="documents" />
+                  <ReportLoader docName="documents" />
                 ) : streaming && !langResponse ? (
-                  <DashboardLoader docName={selectedDoc?.name} />
+                  <ReportLoader docName={selectedDoc?.name} />
                 ) : !selectedDocId ? (
-                  <EmptyDashboardState />
+                  <EmptyReportState />
                 ) : langResponse ? (
-                  <div className="mx-auto max-w-7xl w-full p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+                  <div className="mx-auto w-full max-w-4xl px-4 py-8 sm:px-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
                     {streaming && (
-                      <div className="mb-4 flex items-center justify-between rounded-xl border border-indigo-100 bg-indigo-50 px-4 py-2.5 text-xs text-indigo-700 shadow-sm animate-pulse">
+                      <div className="mb-6 flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-4 py-2.5 text-xs text-slate-600">
                         <div className="flex items-center gap-2">
                           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                          <span>Compiling live dashboard edits...</span>
+                          <span>Building report sections…</span>
                         </div>
-                        <span className="font-semibold uppercase tracking-wider text-[10px] text-indigo-500">Streaming</span>
+                        <span className="font-medium uppercase tracking-wider text-[10px] text-slate-400">
+                          Streaming
+                        </span>
                       </div>
                     )}
-                    <DynamicComponentRenderer response={langResponse} isStreaming={streaming} />
+                    <div className="rounded-lg border border-slate-200 bg-white px-6 py-10 shadow-sm sm:px-10 sm:py-12 print:shadow-none">
+                      <DynamicComponentRenderer response={langResponse} isStreaming={streaming} />
+                    </div>
                   </div>
                 ) : (
                   <div className="flex h-full min-h-[70vh] flex-col items-center justify-center gap-4 p-8 text-center">
-                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 shadow-sm border border-indigo-100">
-                      <Sparkles className="h-8 w-8 text-indigo-500" />
+                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 text-slate-600 shadow-sm border border-slate-200">
+                      <FileText className="h-8 w-8 text-slate-500" />
                     </div>
-                    <h2 className="text-lg font-semibold text-slate-800">Generate Dashboard</h2>
+                    <h2 className="text-lg font-semibold text-slate-800">Generate Report</h2>
                     <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
-                      Click the button below to compile a gorgeous, interactive interface from "{selectedDoc?.name}".
+                      Build a structured report from &ldquo;{selectedDoc?.name}&rdquo; with numbered sections and tables.
                     </p>
                     <Button
-                      onClick={refreshDashboard}
-                      className="mt-2 bg-indigo-600 hover:bg-indigo-700 text-white gap-2"
+                      onClick={refreshReport}
+                      className="mt-2 gap-2 bg-slate-900 hover:bg-slate-800 text-white"
                     >
-                      <Sparkles className="h-4 w-4" />
-                      Compile UI Dashboard
+                      <FileText className="h-4 w-4" />
+                      Generate Report
                     </Button>
                   </div>
                 )}
-              </ScrollArea>
-            </div>
-          </div>
-        </PageTransition>
+        </main>
       </div>
     </div>
   )
@@ -426,21 +460,21 @@ export default function ProjectDocumentUIPage() {
 
 // ─── Simplified Sub-components ──────────────────────────────────────────────────
 
-function DashboardLoader({ docName }: { docName?: string }) {
+function ReportLoader({ docName }: { docName?: string }) {
   return (
     <div className="flex h-full min-h-[75vh] flex-col items-center justify-center gap-4 p-8 text-center animate-pulse">
-      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 shadow-sm border border-indigo-100">
-        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 text-slate-600 shadow-sm border border-slate-200">
+        <Loader2 className="h-8 w-8 animate-spin text-slate-500" />
       </div>
-      <h2 className="text-lg font-semibold text-slate-800">Compiling Generative UI Dashboard</h2>
+      <h2 className="text-lg font-semibold text-slate-800">Generating Document Report</h2>
       <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
-        Parsing {docName ? `"${docName}"` : "document content"} and building high-integrity visual structures...
+        Structuring {docName ? `"${docName}"` : "document content"} into numbered sections…
       </p>
     </div>
   )
 }
 
-function EmptyDashboardState() {
+function EmptyReportState() {
   return (
     <div className="flex h-full min-h-[75vh] flex-col items-center justify-center gap-4 p-8 text-center">
       <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 text-slate-500">
@@ -448,7 +482,7 @@ function EmptyDashboardState() {
       </div>
       <h2 className="text-lg font-semibold text-slate-800">No Document Selected</h2>
       <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
-        Choose a document from the selector in the toolbar above to generate its dashboard.
+        Choose a document from the selector above to generate its report view.
       </p>
     </div>
   )

--- a/app/projects/[id]/documents/ui/page.tsx
+++ b/app/projects/[id]/documents/ui/page.tsx
@@ -1,0 +1,455 @@
+"use client"
+
+import { useState, useRef, useEffect, useCallback } from "react"
+import { useParams, useSearchParams, useRouter } from "next/navigation"
+import { Sidebar } from "@/components/sidebar"
+import { Header } from "@/components/header"
+import { PageTransition } from "@/components/page-transition"
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { Badge } from "@/components/ui/badge"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { DynamicComponentRenderer } from "@/components/openui-chat/DynamicComponentRenderer"
+import { parseOpenUILangSSEBuffer } from "@/lib/openui/streaming"
+import { useAuth } from "@/contexts/AuthContext"
+import { apiClient } from "@/lib/api"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  Send,
+  Loader2,
+  Sparkles,
+  MessageSquare,
+  Plus,
+  ArrowLeft,
+  FileText,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react"
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface DocumentSummary {
+  id: string
+  name: string
+  template_name?: string
+  status: string
+}
+
+interface UserMessage {
+  id: string
+  role: "user"
+  text: string
+}
+
+interface AssistantMessage {
+  id: string
+  role: "assistant"
+  response: string
+}
+
+type ChatMessage = UserMessage | AssistantMessage
+
+// Document-specific prompt chips keyed loosely by template name keywords
+const DOCUMENT_PROMPTS: { keywords: string[]; prompts: string[] }[] = [
+  {
+    keywords: ["risk"],
+    prompts: [
+      "Show all risks as a table",
+      "Which risks are critical?",
+      "Visualize risk probability vs impact",
+      "List mitigation strategies",
+    ],
+  },
+  {
+    keywords: ["stakeholder"],
+    prompts: [
+      "Show stakeholder matrix",
+      "List all stakeholders by influence",
+      "Who are the key decision makers?",
+      "Engagement level by stakeholder",
+    ],
+  },
+  {
+    keywords: ["charter", "project"],
+    prompts: [
+      "Summarize the project objectives",
+      "Show project timeline",
+      "List key deliverables",
+      "Who is the project sponsor?",
+    ],
+  },
+  {
+    keywords: ["quality"],
+    prompts: [
+      "List quality metrics",
+      "Show quality gates",
+      "What are the acceptance criteria?",
+      "Quality KPIs table",
+    ],
+  },
+  {
+    keywords: ["communication", "plan"],
+    prompts: [
+      "Show communication matrix",
+      "List reporting cadence",
+      "Who receives which reports?",
+      "Visualize communication flow",
+    ],
+  },
+]
+
+function getDocumentPrompts(docName: string, templateName?: string): string[] {
+  const haystack = `${docName} ${templateName ?? ""}`.toLowerCase()
+  for (const entry of DOCUMENT_PROMPTS) {
+    if (entry.keywords.some((kw) => haystack.includes(kw))) {
+      return entry.prompts
+    }
+  }
+  return [
+    "Summarize this document",
+    "Show key data as a table",
+    "What are the main findings?",
+    "Create a visual overview",
+    "List action items",
+  ]
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function ProjectDocumentUIPage() {
+  const params = useParams()
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const { user, token } = useAuth()
+
+  const projectId = params?.id as string | undefined
+  const initialDocId = searchParams?.get("docId") ?? undefined
+
+  const [documents, setDocuments] = useState<DocumentSummary[]>([])
+  const [docsLoading, setDocsLoading] = useState(true)
+  const [selectedDocId, setSelectedDocId] = useState<string>(initialDocId ?? "")
+
+  const selectedDoc = documents.find((d) => d.id === selectedDocId) ?? null
+
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState("")
+  const [streaming, setStreaming] = useState(false)
+  const [threadId, setThreadId] = useState<string | null>(null)
+  const [panelOpen, setPanelOpen] = useState(false)
+  const [langResponse, setLangResponse] = useState<string | null>(null)
+
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const autoVisualizedDocs = useRef<Record<string, boolean>>({})
+
+  // Fetch project documents
+  useEffect(() => {
+    if (!projectId || !user) return
+    const fetchDocs = async () => {
+      setDocsLoading(true)
+      try {
+        const res = await apiClient.get<{ documents: DocumentSummary[] }>(
+          `/documents/project/${projectId}?limit=100`
+        )
+        const docs = res.documents ?? []
+        setDocuments(docs)
+        // If a docId came in via query param and exists, keep it; otherwise default to first
+        if (!initialDocId && docs.length > 0) {
+          setSelectedDocId(docs[0].id)
+        } else if (initialDocId && !docs.find((d) => d.id === initialDocId) && docs.length > 0) {
+          setSelectedDocId(docs[0].id)
+        }
+      } catch (err) {
+        console.error("Failed to fetch project documents", err)
+      } finally {
+        setDocsLoading(false)
+      }
+    }
+    fetchDocs()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, user])
+
+  // Auto-scroll
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
+
+  // Reset thread when document changes
+  const handleDocChange = (docId: string) => {
+    setSelectedDocId(docId)
+    setMessages([])
+    setThreadId(null)
+    setLangResponse(null)
+    if (autoVisualizedDocs.current[docId]) {
+      delete autoVisualizedDocs.current[docId]
+    }
+  }
+
+  const canSend = !docsLoading && !!selectedDocId && !streaming
+
+  const sendMessage = useCallback(
+    async (overrideText?: string) => {
+      const text = (overrideText ?? input).trim()
+      if (!text || streaming || !canSend || !selectedDocId) return
+
+      const userMsg: UserMessage = { id: crypto.randomUUID(), role: "user", text }
+      setMessages((prev) => [...prev, userMsg])
+      setInput("")
+      setStreaming(true)
+      setLangResponse("")
+
+      try {
+        const history = messages.map((m) =>
+          m.role === "user"
+            ? { role: "user", content: m.text }
+            : { role: "assistant", content: (m as AssistantMessage).response }
+        )
+
+        const res = await fetch("/api/v1/openui-chat/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            projectId,
+            documentId: selectedDocId,
+            threadId,
+            messages: [...history, { role: "user", content: text }],
+          }),
+        })
+
+        if (!res.ok) throw new Error(`Server error ${res.status}`)
+
+        const reader = res.body!.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ""
+        let accumulated = ""
+        let newThreadId: string | null = res.headers.get("x-thread-id")
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const { events, remainder } = parseOpenUILangSSEBuffer(buffer)
+          buffer = remainder
+
+          for (const event of events) {
+            if (event.type === "text") {
+              accumulated += event.text
+              if (event.threadId) newThreadId = event.threadId
+              setLangResponse(accumulated)
+            } else if (event.type === "done" && event.threadId) {
+              newThreadId = event.threadId
+            } else if (event.type === "error") {
+              throw new Error(event.message)
+            }
+          }
+        }
+
+        if (newThreadId) setThreadId(newThreadId)
+        if (accumulated) {
+          setMessages((prev) => [
+            ...prev,
+            { id: crypto.randomUUID(), role: "assistant", response: accumulated },
+          ])
+        }
+      } catch (err) {
+        const msg = (err instanceof Error ? err.message : String(err)).replace(/"/g, "'")
+        setLangResponse(
+          `<Alert severity="error" alerts={[{"category": "Generation Failed", "impact": "${msg}", "mitigation": "Try again or re-visualize the document."}]} />`
+        )
+      } finally {
+        setStreaming(false)
+      }
+    },
+    [input, streaming, canSend, selectedDocId, messages, token, projectId, threadId]
+  )
+
+  // Auto-visualize document by default when selected or loaded with empty thread
+  useEffect(() => {
+    if (!docsLoading && selectedDocId && !streaming && !autoVisualizedDocs.current[selectedDocId] && messages.length === 0) {
+      autoVisualizedDocs.current[selectedDocId] = true
+      
+      const doc = documents.find((d) => d.id === selectedDocId)
+      const docLabel = doc ? `"${doc.name}"` : "this document"
+      
+      setTimeout(() => {
+        sendMessage(`Visualize ${docLabel} as a comprehensive dashboard with appropriate tables, lists, and status indicators.`)
+      }, 100)
+    }
+  }, [docsLoading, selectedDocId, streaming, documents, messages.length, sendMessage])
+
+  const refreshDashboard = () => {
+    if (!selectedDocId || streaming) return
+    setLangResponse(null)
+    setMessages([])
+    setThreadId(null)
+    if (autoVisualizedDocs.current[selectedDocId]) {
+      delete autoVisualizedDocs.current[selectedDocId]
+    }
+  }
+
+  return (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <Header />
+        <PageTransition>
+          <div className="flex flex-1 flex-col overflow-hidden">
+            {/* Toolbar */}
+            <div className="flex flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+              <div className="flex items-center gap-3 min-w-0">
+                {/* Back to documents */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 gap-1.5 text-xs text-slate-500 hover:text-slate-900 shrink-0"
+                  onClick={() => router.push(`/projects/${projectId}/documents`)}
+                >
+                  <ArrowLeft className="h-3.5 w-3.5" />
+                  Documents
+                </Button>
+                <div className="h-4 w-px bg-slate-200 shrink-0" />
+
+                {/* Page identity */}
+                <div className="flex items-center gap-2 shrink-0">
+                  <Sparkles className="h-5 w-5 text-indigo-600" />
+                  <span className="font-semibold text-slate-900">Document Dashboard</span>
+                  <Badge variant="secondary" className="bg-indigo-100 text-indigo-800 text-[10px] uppercase font-bold tracking-wider px-2 py-0.5">
+                    Live UI
+                  </Badge>
+                </div>
+                <div className="h-4 w-px bg-slate-200 shrink-0" />
+
+                {/* Document selector */}
+                <div className="flex items-center gap-2 min-w-0">
+                  <FileText className="h-4 w-4 text-slate-400 shrink-0" />
+                  {docsLoading ? (
+                    <div className="flex h-8 w-[240px] items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 text-xs text-slate-400">
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                      Loading documents…
+                    </div>
+                  ) : documents.length === 0 ? (
+                    <div className="flex h-8 items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 text-xs text-amber-600">
+                      No documents found in this project
+                    </div>
+                  ) : (
+                    <Select
+                      value={selectedDocId}
+                      onValueChange={handleDocChange}
+                      disabled={streaming}
+                    >
+                      <SelectTrigger className="h-8 w-[280px] border-slate-200 bg-slate-50 text-xs focus:ring-indigo-500">
+                        <SelectValue placeholder="Select a document…" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {documents.map((d) => (
+                          <SelectItem key={d.id} value={d.id} className="text-xs">
+                            <span className="truncate max-w-[260px]">{d.name}</span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 shrink-0">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshDashboard}
+                  disabled={streaming || !selectedDocId}
+                  className="h-8 gap-1.5 text-xs text-indigo-600 border-indigo-200 hover:bg-indigo-50 hover:text-indigo-700 transition-all shrink-0"
+                >
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Re-visualize
+                </Button>
+              </div>
+            </div>
+
+            {/* Main Pane */}
+            <div className="flex-1 overflow-hidden">
+              <ScrollArea className="h-full w-full">
+                {docsLoading ? (
+                  <DashboardLoader docName="documents" />
+                ) : streaming && !langResponse ? (
+                  <DashboardLoader docName={selectedDoc?.name} />
+                ) : !selectedDocId ? (
+                  <EmptyDashboardState />
+                ) : langResponse ? (
+                  <div className="mx-auto max-w-7xl w-full p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+                    {streaming && (
+                      <div className="mb-4 flex items-center justify-between rounded-xl border border-indigo-100 bg-indigo-50 px-4 py-2.5 text-xs text-indigo-700 shadow-sm animate-pulse">
+                        <div className="flex items-center gap-2">
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          <span>Compiling live dashboard edits...</span>
+                        </div>
+                        <span className="font-semibold uppercase tracking-wider text-[10px] text-indigo-500">Streaming</span>
+                      </div>
+                    )}
+                    <DynamicComponentRenderer response={langResponse} isStreaming={streaming} />
+                  </div>
+                ) : (
+                  <div className="flex h-full min-h-[70vh] flex-col items-center justify-center gap-4 p-8 text-center">
+                    <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 shadow-sm border border-indigo-100">
+                      <Sparkles className="h-8 w-8 text-indigo-500" />
+                    </div>
+                    <h2 className="text-lg font-semibold text-slate-800">Generate Dashboard</h2>
+                    <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
+                      Click the button below to compile a gorgeous, interactive interface from "{selectedDoc?.name}".
+                    </p>
+                    <Button
+                      onClick={refreshDashboard}
+                      className="mt-2 bg-indigo-600 hover:bg-indigo-700 text-white gap-2"
+                    >
+                      <Sparkles className="h-4 w-4" />
+                      Compile UI Dashboard
+                    </Button>
+                  </div>
+                )}
+              </ScrollArea>
+            </div>
+          </div>
+        </PageTransition>
+      </div>
+    </div>
+  )
+}
+
+// ─── Simplified Sub-components ──────────────────────────────────────────────────
+
+function DashboardLoader({ docName }: { docName?: string }) {
+  return (
+    <div className="flex h-full min-h-[75vh] flex-col items-center justify-center gap-4 p-8 text-center animate-pulse">
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-indigo-50 text-indigo-600 shadow-sm border border-indigo-100">
+        <Loader2 className="h-8 w-8 animate-spin text-indigo-500" />
+      </div>
+      <h2 className="text-lg font-semibold text-slate-800">Compiling Generative UI Dashboard</h2>
+      <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
+        Parsing {docName ? `"${docName}"` : "document content"} and building high-integrity visual structures...
+      </p>
+    </div>
+  )
+}
+
+function EmptyDashboardState() {
+  return (
+    <div className="flex h-full min-h-[75vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-slate-100 text-slate-500">
+        <FileText className="h-8 w-8 text-slate-400" />
+      </div>
+      <h2 className="text-lg font-semibold text-slate-800">No Document Selected</h2>
+      <p className="text-sm text-slate-500 max-w-sm leading-relaxed">
+        Choose a document from the selector in the toolbar above to generate its dashboard.
+      </p>
+    </div>
+  )
+}

--- a/components/documents/DocumentPageToolbar.tsx
+++ b/components/documents/DocumentPageToolbar.tsx
@@ -1,0 +1,180 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  ArrowLeft,
+  Eye,
+  FileText,
+  Loader2,
+  Sparkles,
+  Wand2,
+} from "lucide-react"
+import type { LucideIcon } from "lucide-react"
+
+export type DocumentPageMode = "view" | "source" | "report"
+
+export interface DocumentSummary {
+  id: string
+  name: string
+  template_name?: string
+  status: string
+}
+
+const MODE_CONFIG: Record<
+  DocumentPageMode,
+  { icon: LucideIcon; title: string; badge: string; iconClassName?: string }
+> = {
+  view: { icon: Eye, title: "Document View", badge: "Editor" },
+  source: { icon: FileText, title: "Source Markdown", badge: "Plain text" },
+  report: {
+    icon: Sparkles,
+    title: "Document Report",
+    badge: "Live",
+    iconClassName: "text-indigo-600",
+  },
+}
+
+interface DocumentPageToolbarProps {
+  projectId: string
+  mode: DocumentPageMode
+  documents: DocumentSummary[]
+  docsLoading: boolean
+  selectedDocId: string
+  onDocChange: (docId: string) => void
+  docSelectorDisabled?: boolean
+  className?: string
+  children?: React.ReactNode
+}
+
+export function DocumentPageToolbar({
+  projectId,
+  mode,
+  documents,
+  docsLoading,
+  selectedDocId,
+  onDocChange,
+  docSelectorDisabled = false,
+  className = "",
+  children,
+}: DocumentPageToolbarProps) {
+  const router = useRouter()
+  const config = MODE_CONFIG[mode]
+  const ModeIcon = config.icon
+
+  return (
+    <div
+      className={`flex shrink-0 flex-col gap-3 border-b border-slate-200 bg-white px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6 print:hidden ${className}`}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 shrink-0 gap-1.5 text-xs text-slate-500 hover:text-slate-900"
+          onClick={() => router.push(`/projects/${projectId}/documents`)}
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Documents
+        </Button>
+        <div className="h-4 w-px shrink-0 bg-slate-200" />
+        <div className="flex shrink-0 items-center gap-2">
+          <ModeIcon className={`h-5 w-5 ${config.iconClassName ?? "text-slate-600"}`} />
+          <span className="font-semibold text-slate-900">{config.title}</span>
+          <Badge
+            variant="secondary"
+            className="px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider"
+          >
+            {config.badge}
+          </Badge>
+        </div>
+        <div className="h-4 w-px shrink-0 bg-slate-200" />
+        {docsLoading ? (
+          <div className="flex h-8 w-[240px] items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 text-xs text-slate-400">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading…
+          </div>
+        ) : documents.length === 0 ? (
+          <div className="flex h-8 items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 text-xs text-amber-600">
+            No documents in this project
+          </div>
+        ) : (
+          <Select
+            value={selectedDocId}
+            onValueChange={onDocChange}
+            disabled={docSelectorDisabled}
+          >
+            <SelectTrigger className="h-8 w-[280px] border-slate-200 bg-slate-50 text-xs">
+              <SelectValue placeholder="Select a document…" />
+            </SelectTrigger>
+            <SelectContent>
+              {documents.map((d) => (
+                <SelectItem key={d.id} value={d.id} className="text-xs">
+                  {d.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        {selectedDocId ? (
+          <>
+            {mode !== "view" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 text-xs"
+                onClick={() =>
+                  router.push(`/projects/${projectId}/documents/${selectedDocId}/view`)
+                }
+              >
+                <Eye className="h-3.5 w-3.5" />
+                View
+              </Button>
+            ) : null}
+            {mode !== "source" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 text-xs"
+                onClick={() =>
+                  router.push(`/projects/${projectId}/documents/source?docId=${selectedDocId}`)
+                }
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Source
+              </Button>
+            ) : null}
+            {mode !== "report" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className={`h-8 gap-1.5 text-xs ${
+                  mode === "source"
+                    ? "border-indigo-200 text-indigo-600"
+                    : ""
+                }`}
+                onClick={() =>
+                  router.push(`/projects/${projectId}/documents/ui?docId=${selectedDocId}`)
+                }
+              >
+                <Wand2 className="h-3.5 w-3.5" />
+                Report
+              </Button>
+            ) : null}
+          </>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/openui-chat/DynamicComponentRenderer.tsx
+++ b/components/openui-chat/DynamicComponentRenderer.tsx
@@ -1,16 +1,20 @@
 /**
  * Dynamic Component Renderer
- * Renders different UI components based on type (Table, Chart, Form, Card, Timeline, Kanban)
+ * Renders OpenUI Lang streams via @openuidev/react-lang <Renderer>,
+ * with a legacy JSON payload fallback for older thread messages.
  */
 
 "use client"
 
+import { Renderer } from "@openuidev/react-lang"
 import { Sparkles, Telescope } from "lucide-react"
-import { MarkdownRenderer } from "@/components/documents/MarkdownRenderer"
 
+import { MarkdownRenderer } from "@/components/documents/MarkdownRenderer"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { adpaLibrary } from "@/lib/openui/adpaLibrary"
 import type { ComponentPayload, OpenUIChatJson } from "@/lib/openui/library"
+import { isLegacyComponentPayload, looksLikeOpenUILang } from "@/lib/openui/library"
 
 import { TableComponent } from "./components/TableComponent"
 import { ChartComponent } from "./components/ChartComponent"
@@ -30,93 +34,89 @@ import { ComparisonComponent } from "./components/ComparisonComponent"
 import { CalendarComponent } from "./components/CalendarComponent"
 import { TeamComponent } from "./components/TeamComponent"
 
-interface DynamicComponentRendererProps {
-  payload: ComponentPayload | OpenUIChatJson
+export interface DynamicComponentRendererProps {
+  /** Accumulated OpenUI Lang text from the LLM stream */
+  response?: string | null
+  /** @deprecated Legacy JSON component payload from pre–react-lang threads */
+  payload?: ComponentPayload | OpenUIChatJson
+  isStreaming?: boolean
 }
 
-/**
- * Main dynamic renderer that dispatches to the appropriate component
- */
-export function DynamicComponentRenderer({ payload }: DynamicComponentRendererProps) {
-  // Validate payload structure
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    return <FallbackRenderer content={payload} />
+export function DynamicComponentRenderer({
+  response,
+  payload,
+  isStreaming = false,
+}: DynamicComponentRendererProps) {
+  const langText =
+    response ??
+    (typeof payload === "string" && looksLikeOpenUILang(payload) ? payload : null)
+
+  if (langText) {
+    return (
+      <Renderer
+        library={adpaLibrary}
+        response={langText}
+        isStreaming={isStreaming}
+      />
+    )
   }
 
+  if (payload && isLegacyComponentPayload(payload)) {
+    return <LegacyComponentRenderer payload={payload} />
+  }
+
+  return <FallbackRenderer content={payload ?? response} />
+}
+
+/** Legacy JSON dispatch for messages stored before OpenUI Lang migration */
+function LegacyComponentRenderer({ payload }: { payload: ComponentPayload }) {
   const record = payload as Record<string, OpenUIChatJson>
-
-  // Check if it's a component payload
-  if (record.type !== "component") {
-    return <FallbackRenderer content={payload} />
-  }
-
-  const componentType = record.component as string
+  const componentType = (record.component || "") as string
   const props = (record.props || {}) as Record<string, OpenUIChatJson>
   const data = (record.data || []) as Array<Record<string, OpenUIChatJson>>
   const metadata = (record.metadata || {}) as Record<string, OpenUIChatJson>
 
-  // Render based on component type
   switch (componentType) {
     case "Table":
       return <TableComponent props={props} data={data} />
-
     case "Chart":
       return <ChartComponent props={props} data={data} />
-
     case "Form":
       return <FormComponent props={props} schema={record.schema as any} />
-
     case "Card":
       return <CardComponent props={props} data={data} />
-
     case "Timeline":
       return <TimelineComponent props={props} data={data} />
-
     case "Kanban":
       return <KanbanComponent props={props} data={data} />
-
     case "Bullets":
       return <BulletsComponent props={props} data={data} />
-
     case "Tabs":
       return <TabsComponent props={props} data={data} />
-
     case "Accordion":
       return <AccordionComponent props={props} data={data} />
-
     case "Carousel":
       return <CarouselComponent props={props} data={data} />
-
     case "Alert":
       return <AlertComponent props={props} data={data} />
-
     case "Steps":
       return <StepsComponent props={props} data={data} />
-
     case "Breadcrumb":
       return <BreadcrumbComponent props={props} data={data} />
-
     case "Sidebar":
       return <SidebarComponent props={props} data={data} />
-
     case "Comparison":
       return <ComparisonComponent props={props} data={data} />
-
     case "Calendar":
       return <CalendarComponent props={props} data={data} />
-
     case "Team":
       return <TeamComponent props={props} data={data} />
-
     default:
       return <TextFallbackRenderer props={props} data={data} metadata={metadata} />
   }
 }
 
-/**
- * Fallback for unstructured content
- */
-function FallbackRenderer({ content }: { content: OpenUIChatJson }) {
+function FallbackRenderer({ content }: { content: OpenUIChatJson | string | null | undefined }) {
   return (
     <Card className="border-slate-200 bg-white/90 shadow-sm">
       <CardContent className="pt-6 text-sm text-slate-600">
@@ -126,9 +126,6 @@ function FallbackRenderer({ content }: { content: OpenUIChatJson }) {
   )
 }
 
-/**
- * Fallback text renderer with metadata
- */
 function TextFallbackRenderer({
   props,
   data,
@@ -141,12 +138,14 @@ function TextFallbackRenderer({
   const title = (props.title as string) || undefined
   const supportingEvidence = (metadata.supportingEvidence as number) || 0
 
-  // Resolve body content: prefer explicit content fields, then data items
   const bodyContent =
     (props.content as string) ||
     (props.text as string) ||
     (props.body as string) ||
     (props.markdown as string) ||
+    (props.synopsis as string) ||
+    (props.description as string) ||
+    (typeof metadata.synopsis === "string" ? metadata.synopsis : null) ||
     (data.length > 0
       ? data
           .map(
@@ -158,8 +157,7 @@ function TextFallbackRenderer({
           )
           .filter(Boolean)
           .join("\n\n")
-      : null) ||
-    (typeof metadata.synopsis === "string" ? metadata.synopsis : null)
+      : null)
 
   return (
     <Card className="overflow-hidden border-emerald-200 bg-[radial-gradient(circle_at_top_left,_rgba(16,185,129,0.18),_rgba(255,255,255,0.92)_45%)] shadow-lg shadow-emerald-100/60">

--- a/components/openui-chat/DynamicComponentRenderer.tsx
+++ b/components/openui-chat/DynamicComponentRenderer.tsx
@@ -51,12 +51,30 @@ export function DynamicComponentRenderer({
     response ??
     (typeof payload === "string" && looksLikeOpenUILang(payload) ? payload : null)
 
-  if (langText) {
+  const trimmed = langText?.trim() ?? ""
+  const hasRoot = /^root\s*=/m.test(trimmed)
+
+  if (isStreaming && trimmed && !hasRoot) {
+    return (
+      <Card className="border-indigo-100 bg-indigo-50/50 shadow-sm">
+        <CardContent className="py-8 text-center text-sm text-indigo-700">
+          Generating visualization…
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (hasRoot) {
     return (
       <Renderer
         library={adpaLibrary}
-        response={langText}
+        response={trimmed}
         isStreaming={isStreaming}
+        onError={(errors) => {
+          if (errors.length > 0) {
+            console.warn("[OpenUI Renderer]", errors)
+          }
+        }}
       />
     )
   }

--- a/components/openui-chat/components/ProseComponent.tsx
+++ b/components/openui-chat/components/ProseComponent.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import { MarkdownRenderer } from "@/components/documents/MarkdownRenderer"
+import type { OpenUIChatJson } from "@/lib/openui/library"
+
+interface ProseComponentProps {
+  props: Record<string, OpenUIChatJson>
+  data: Array<Record<string, OpenUIChatJson>>
+}
+
+/** Renders full section narrative — default when structured UI cannot hold all source text. */
+export function ProseComponent({ props }: ProseComponentProps) {
+  const paragraphs = props.paragraphs as string[] | undefined
+  const body = props.body as string | undefined
+  const text =
+    body?.trim() ||
+    (paragraphs?.length ? paragraphs.map((p) => p.trim()).filter(Boolean).join("\n\n") : "") ||
+    ""
+
+  if (!text) {
+    return <p className="text-sm italic text-slate-400">No content for this section.</p>
+  }
+
+  return (
+    <div className="report-prose prose prose-slate max-w-none text-[15px] leading-relaxed prose-p:my-3 prose-headings:scroll-mt-6 prose-headings:font-semibold prose-headings:text-slate-900 prose-ul:my-3 prose-ol:my-3 prose-li:my-0.5 prose-table:my-4 prose-table:w-full prose-table:border prose-table:border-slate-200 prose-th:bg-slate-50 prose-th:px-3 prose-th:py-2 prose-td:px-3 prose-td:py-2 prose-pre:my-4 prose-pre:rounded-lg prose-pre:bg-slate-900 prose-pre:text-slate-100 prose-code:text-[0.9em] prose-blockquote:border-l-slate-300 prose-blockquote:text-slate-600">
+      <MarkdownRenderer content={text} />
+    </div>
+  )
+}

--- a/components/openui-chat/components/ReportComponent.tsx
+++ b/components/openui-chat/components/ReportComponent.tsx
@@ -1,0 +1,60 @@
+"use client"
+
+import type { OpenUIChatJson } from "@/lib/openui/library"
+import { FileText } from "lucide-react"
+import type { ReactNode } from "react"
+
+interface ReportComponentProps {
+  props: Record<string, OpenUIChatJson>
+  data: Array<Record<string, OpenUIChatJson>>
+  sectionContent?: ReactNode[]
+}
+
+export function ReportComponent({ props, sectionContent }: ReportComponentProps) {
+  const title = (props.title as string) || "Document Report"
+  const subtitle = props.subtitle as string | undefined
+  const meta = (props.meta as Record<string, string> | undefined) ?? {}
+  const sections = sectionContent ?? []
+
+  return (
+    <article className="report-document">
+      <header className="mb-10 border-b border-slate-200 pb-8">
+        <div className="flex items-start gap-3">
+          <FileText className="mt-1 h-6 w-6 shrink-0 text-slate-500" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <h1 className="font-serif text-3xl font-bold tracking-tight text-slate-950 md:text-4xl">
+              {title}
+            </h1>
+            {subtitle ? <p className="mt-2 text-base text-slate-600">{subtitle}</p> : null}
+          </div>
+        </div>
+        {Object.keys(meta).length > 0 ? (
+          <dl className="mt-6 grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3 md:grid-cols-4">
+            {Object.entries(meta).map(([key, value]) => (
+              <div key={key}>
+                <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">{key}</dt>
+                <dd className="mt-0.5 font-medium text-slate-900">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </header>
+
+      <div className="space-y-12">
+        {sections.map((section, idx) => (
+          <div
+            key={idx}
+            className={idx > 0 ? "border-t border-slate-100 pt-10" : undefined}
+          >
+            {section}
+          </div>
+        ))}
+      </div>
+
+      <footer className="report-footer mt-16 hidden border-t border-slate-200 pt-4 text-center text-xs text-slate-400 print:block">
+        {title}
+        {subtitle ? ` · ${subtitle}` : ""}
+      </footer>
+    </article>
+  )
+}

--- a/components/openui-chat/components/SectionComponent.tsx
+++ b/components/openui-chat/components/SectionComponent.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import type { OpenUIChatJson } from "@/lib/openui/library"
+import type { ReactNode } from "react"
+
+interface SectionComponentProps {
+  props: Record<string, OpenUIChatJson>
+  data: Array<Record<string, OpenUIChatJson>>
+  content?: ReactNode
+}
+
+export function SectionComponent({ props, content }: SectionComponentProps) {
+  const heading = (props.heading as string) || "Section"
+  const intro = props.intro as string | undefined
+  const level = (props.level as number) === 3 ? 3 : (props.level as number) === 2 ? 2 : 1
+
+  const HeadingTag = level === 3 ? "h4" : level === 2 ? "h3" : "h2"
+  const headingClass =
+    level === 3
+      ? "text-base font-semibold text-slate-800"
+      : level === 2
+        ? "text-lg font-semibold text-slate-900 border-l-2 border-slate-400 pl-3"
+        : "text-xl font-semibold tracking-tight text-slate-900 border-l-4 border-slate-800 pl-4"
+
+  return (
+    <section className="report-section scroll-mt-6">
+      <HeadingTag className={headingClass}>{heading}</HeadingTag>
+      {intro ? (
+        <p className="mt-3 max-w-prose text-sm leading-relaxed text-slate-600">{intro}</p>
+      ) : null}
+      {content ? <div className="mt-5 report-section-body">{content}</div> : null}
+    </section>
+  )
+}

--- a/components/openui-chat/components/TableOfContentsComponent.tsx
+++ b/components/openui-chat/components/TableOfContentsComponent.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import type { OpenUIChatJson } from "@/lib/openui/library"
+import { List } from "lucide-react"
+
+interface TableOfContentsComponentProps {
+  props: Record<string, OpenUIChatJson>
+  data: Array<Record<string, OpenUIChatJson>>
+}
+
+export function TableOfContentsComponent({ props }: TableOfContentsComponentProps) {
+  const title = (props.title as string) || "Table of Contents"
+  const entries =
+    (props.entries as { title: string; level?: number }[] | undefined) ??
+    (props.items as string[] | undefined)?.map((t) => ({ title: t, level: 1 })) ??
+    []
+
+  return (
+    <nav className="report-toc rounded-lg border border-slate-200 bg-slate-50/80 px-5 py-4 print:break-after-page">
+      <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-600">
+        <List className="h-4 w-4" aria-hidden />
+        {title}
+      </h2>
+      <ol className="space-y-1.5 text-sm">
+        {entries.map((entry, idx) => {
+          const level = entry.level ?? 1
+          const indent = level === 1 ? "" : level === 2 ? "ml-4" : "ml-8"
+          return (
+            <li key={idx} className={indent}>
+              <span className="text-slate-800">{entry.title}</span>
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/components/openui-chat/components/TabsComponent.tsx
+++ b/components/openui-chat/components/TabsComponent.tsx
@@ -13,11 +13,17 @@ import { Layers2 } from "lucide-react"
 interface TabsComponentProps {
   props: Record<string, OpenUIChatJson>
   data: Array<Record<string, OpenUIChatJson>>
+  /** Rendered tab panels from OpenUI Lang nested children (via renderNode) */
+  panelContent?: React.ReactNode[]
 }
 
-export function TabsComponent({ props, data }: TabsComponentProps) {
+export function TabsComponent({ props, data, panelContent }: TabsComponentProps) {
   const title = (props.title as string) || "Sections"
-  const tabNames = (props.tabs as string[]) || data.map((_, idx) => `Section ${idx + 1}`)
+  const panels = panelContent ?? []
+  const tabNames =
+    (props.tabs as string[]) ||
+    panels.map((_, idx) => `Section ${idx + 1}`) ||
+    data.map((_, idx) => `Section ${idx + 1}`)
 
   return (
     <Card className="overflow-hidden border-slate-200 shadow-lg">
@@ -28,8 +34,23 @@ export function TabsComponent({ props, data }: TabsComponentProps) {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        {data.length > 0 ? (
-          <TabsPrimitive defaultValue={`tab-0`} className="w-full">
+        {panels.length > 0 ? (
+          <TabsPrimitive defaultValue="tab-0" className="w-full">
+            <TabsList className="grid w-full gap-2" style={{ gridTemplateColumns: `repeat(auto-fit, minmax(120px, 1fr))` }}>
+              {tabNames.map((tabName, idx) => (
+                <TabsTrigger key={idx} value={`tab-${idx}`} className="text-sm">
+                  {tabName}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {panels.map((panel, idx) => (
+              <TabsContent key={idx} value={`tab-${idx}`} className="mt-4">
+                <div className="rounded-lg border border-slate-100 bg-slate-50/50 p-1">{panel}</div>
+              </TabsContent>
+            ))}
+          </TabsPrimitive>
+        ) : data.length > 0 ? (
+          <TabsPrimitive defaultValue="tab-0" className="w-full">
             <TabsList className="grid w-full gap-2" style={{ gridTemplateColumns: `repeat(auto-fit, minmax(120px, 1fr))` }}>
               {tabNames.map((tabName, idx) => (
                 <TabsTrigger key={idx} value={`tab-${idx}`} className="text-sm">
@@ -40,16 +61,28 @@ export function TabsComponent({ props, data }: TabsComponentProps) {
 
             {data.map((tabContent, idx) => (
               <TabsContent key={idx} value={`tab-${idx}`} className="mt-4">
-                <div className="rounded-lg border border-slate-200 bg-white p-4">
-                  <div className="space-y-3">
-                    {Object.entries(tabContent).map(([key, value]) => (
-                      <div key={key} className="text-sm">
-                        <span className="font-semibold text-slate-700">{key}:</span>{" "}
-                        <span className="text-slate-600">{renderTabValue(value)}</span>
-                      </div>
-                    ))}
+                {tabContent && typeof tabContent === "object" && tabContent.type === "component" ? (
+                  <div className="w-full">
+                    {/* Dynamically invoke the child component renderer for recursive Option A tabs */}
+                    <div className="rounded-lg border border-slate-100 bg-slate-50/50 p-1">
+                      {(() => {
+                        const DynamicRenderer = require("../DynamicComponentRenderer").DynamicComponentRenderer
+                        return <DynamicRenderer payload={tabContent} />
+                      })()}
+                    </div>
                   </div>
-                </div>
+                ) : (
+                  <div className="rounded-lg border border-slate-200 bg-white p-4">
+                    <div className="space-y-3">
+                      {Object.entries(tabContent).map(([key, value]) => (
+                        <div key={key} className="text-sm">
+                          <span className="font-semibold text-slate-700">{key}:</span>{" "}
+                          <span className="text-slate-600">{renderTabValue(value)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
               </TabsContent>
             ))}
           </TabsPrimitive>

--- a/components/openui-chat/openui-chat-shell.tsx
+++ b/components/openui-chat/openui-chat-shell.tsx
@@ -22,14 +22,16 @@ import {
   buildThreadPreview,
   extractMessageText,
   formatMessageTimestamp,
-  inferThreadId,
-  parseAssistantPayload,
+  isLegacyComponentPayload,
+  looksLikeOpenUILang,
   type OpenUIAssistantPayload,
   type OpenUIMessage,
   type OpenUIProjectsResponse,
   type OpenUIThread,
   type OpenUIThreadSummary,
 } from "@/lib/openui/library"
+import { parseOpenUILangSSEBuffer } from "@/lib/openui/streaming"
+import { DynamicComponentRenderer } from "./DynamicComponentRenderer"
 import { openUIStarterPrompts, type OpenUIStarterPrompt } from "@/lib/openui/system-prompt"
 
 import { ProjectSelector } from "./project-selector"
@@ -59,6 +61,7 @@ export function OpenUIChatShell() {
   const [messagesLoading, setMessagesLoading] = useState(false)
   const [draft, setDraft] = useState("")
   const [isSending, setIsSending] = useState(false)
+  const [streamingResponse, setStreamingResponse] = useState<string | null>(null)
   const [runtimeError, setRuntimeError] = useState<string | null>(null)
 
   const selectedProject = useMemo(
@@ -171,6 +174,8 @@ export function OpenUIChatShell() {
     setMessages((current) => [...current, optimisticUserMessage])
     setDraft("")
 
+    setStreamingResponse("")
+
     try {
       const response = await fetch("/api/v1/openui-chat/chat", {
         method: "POST",
@@ -185,40 +190,69 @@ export function OpenUIChatShell() {
         }),
       })
 
-      const raw = await response.text()
       if (!response.ok) {
+        const raw = await response.text()
         throw new Error(raw || "Unable to send chat message")
       }
 
-      const assistantPayload = parseAssistantPayload(raw)
-      if (!assistantPayload) {
+      const reader = response.body?.getReader()
+      if (!reader) {
+        throw new Error("Response has no body")
+      }
+
+      const decoder = new TextDecoder()
+      let buffer = ""
+      let accumulated = ""
+      let resolvedThreadId = response.headers.get("x-thread-id") || activeThreadId
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const { events, remainder } = parseOpenUILangSSEBuffer(buffer)
+        buffer = remainder
+
+        for (const event of events) {
+          if (event.type === "text") {
+            accumulated += event.text
+            if (event.threadId) resolvedThreadId = event.threadId
+            setStreamingResponse(accumulated)
+          } else if (event.type === "done" && event.threadId) {
+            resolvedThreadId = event.threadId
+          } else if (event.type === "error") {
+            throw new Error(event.message)
+          }
+        }
+      }
+
+      if (!accumulated) {
         throw new Error("Assistant response was empty")
       }
 
       const assistantMessage: LocalMessage = {
         id: `local-assistant-${Date.now()}`,
-        threadId: activeThreadId,
+        threadId: resolvedThreadId || activeThreadId,
         userId: "assistant",
         role: "assistant",
-        content: assistantPayload,
+        content: accumulated,
         createdAt: new Date().toISOString(),
       }
 
-      const inferredThreadId = inferThreadId(assistantPayload)
-      setMessages((current) => current.map((message) => (
-        message.id === optimisticUserMessage.id ? { ...message, pending: false } : message
-      )).concat(assistantMessage))
+      setMessages((current) =>
+        current
+          .map((message) => (message.id === optimisticUserMessage.id ? { ...message, pending: false } : message))
+          .concat(assistantMessage)
+      )
+      setStreamingResponse(null)
 
-      await loadThreads(selectedProjectId, inferredThreadId || activeThreadId)
+      await loadThreads(selectedProjectId, resolvedThreadId || activeThreadId)
 
-      if (!activeThreadId) {
-        const resolvedThreadId = inferredThreadId || threads[0]?.id
-        if (resolvedThreadId) {
-          setActiveThreadId(resolvedThreadId)
-        }
+      if (!activeThreadId && resolvedThreadId) {
+        setActiveThreadId(resolvedThreadId)
       }
     } catch (error) {
       setMessages((current) => current.filter((message) => message.id !== optimisticUserMessage.id))
+      setStreamingResponse(null)
       setRuntimeError(error instanceof Error ? error.message : "Unable to send chat message")
     } finally {
       setIsSending(false)
@@ -422,6 +456,14 @@ export function OpenUIChatShell() {
                   </div>
                 ) : null}
 
+                {isSending && streamingResponse ? (
+                  <div className="flex justify-start">
+                    <div className="max-w-[88%] w-full rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm">
+                      <DynamicComponentRenderer response={streamingResponse} isStreaming />
+                    </div>
+                  </div>
+                ) : null}
+
                 {messages.map((message) => {
                   const isAssistant = message.role === "assistant"
                   const isReport = isAssistant && isStructuredReport(message.content)
@@ -434,6 +476,13 @@ export function OpenUIChatShell() {
                         </div>
                         {isReport ? (
                           <ReportComponents payload={message.content} />
+                        ) : isAssistant && shouldRenderOpenUI(message.content) ? (
+                          <div className="rounded-[24px] border border-slate-200 bg-white p-4 shadow-sm">
+                            <DynamicComponentRenderer
+                              response={getOpenUILangResponse(message.content)}
+                              payload={isLegacyComponentPayload(message.content) ? message.content : undefined}
+                            />
+                          </div>
                         ) : (
                           <div className={`rounded-[24px] px-5 py-4 text-sm leading-7 shadow-sm ${
                             isAssistant
@@ -524,4 +573,19 @@ function ShellFrame({
 
 function isStructuredReport(payload: OpenUIAssistantPayload): boolean {
   return Boolean(payload && typeof payload === "object" && !Array.isArray(payload) && (payload as Record<string, unknown>).type === "report")
+}
+
+function shouldRenderOpenUI(content: OpenUIAssistantPayload): boolean {
+  if (typeof content === "string") {
+    return looksLikeOpenUILang(content)
+  }
+  return isLegacyComponentPayload(content)
+}
+
+function getOpenUILangResponse(content: OpenUIAssistantPayload): string | undefined {
+  if (typeof content === "string" && looksLikeOpenUILang(content)) {
+    return content
+  }
+  const text = extractMessageText(content)
+  return looksLikeOpenUILang(text) ? text : undefined
 }

--- a/components/page-transition.tsx
+++ b/components/page-transition.tsx
@@ -65,7 +65,7 @@ export function PageTransition({ children }: PageTransitionProps) {
         exit="out"
         variants={pageVariants}
         transition={pageTransition}
-        className="w-full h-full"
+        className="flex h-full min-h-0 w-full flex-col"
       >
         {children}
       </motion.div>
@@ -85,7 +85,7 @@ export function SlideTransition({ children }: PageTransitionProps) {
         exit="out"
         variants={slideVariants}
         transition={slideTransition}
-        className="w-full h-full"
+        className="flex h-full min-h-0 w-full flex-col"
       >
         {children}
       </motion.div>
@@ -104,7 +104,7 @@ export function FadeTransition({ children }: PageTransitionProps) {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         transition={{ duration: 0.3, ease: "easeInOut" }}
-        className="w-full h-full"
+        className="flex h-full min-h-0 w-full flex-col"
       >
         {children}
       </motion.div>

--- a/lib/documents/extractContent.ts
+++ b/lib/documents/extractContent.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalize document.content from the API into a markdown/plain-text string.
+ */
+export function extractDocumentMarkdown(content: unknown): string {
+  if (content == null) return ""
+  if (typeof content === "string") return content
+  if (typeof content === "object") {
+    const record = content as Record<string, unknown>
+    const candidate =
+      record.markdown ?? record.text ?? record.content ?? record.body
+    if (typeof candidate === "string") return candidate
+    return JSON.stringify(content, null, 2)
+  }
+  return String(content)
+}

--- a/lib/openui/adpaLibrary.tsx
+++ b/lib/openui/adpaLibrary.tsx
@@ -1,0 +1,308 @@
+/**
+ * ADPA OpenUI Library
+ * Defines the full ADPA component library using @openuidev/react-lang.
+ * The LLM generates OpenUI Lang XML; <Renderer> parses and renders it on the client.
+ */
+
+import { createLibrary, defineComponent } from "@openuidev/react-lang"
+import { z } from "zod/v4"
+import type { ReactNode } from "react"
+
+// ─── Table ────────────────────────────────────────────────────────────────────
+const TableDef = defineComponent({
+  name: "Table",
+  description: "Renders tabular data with column headers and rows. Use for registers, lists of stakeholders, deliverables, risks, or any matrix-style data.",
+  props: z.object({
+    title: z.string().optional().describe("Section heading for the table"),
+    columns: z.array(z.string()).optional().describe("Column headers (inferred from row keys if omitted)"),
+    rows: z.array(z.record(z.any())).describe("Array of row objects, keys match column headers"),
+    striped: z.boolean().optional().default(false).describe("Alternate row shading"),
+  }),
+  component: ({ props }) => {
+    const { TableComponent } = require("@/components/openui-chat/components/TableComponent")
+    const rows = (props.rows as Record<string, unknown>[]) ?? []
+    const columns = (props.columns as string[]) ?? (rows[0] ? Object.keys(rows[0]) : [])
+    return (
+      <TableComponent
+        props={{ title: props.title, ...props } as any}
+        data={rows}
+      />
+    )
+  },
+})
+
+// ─── Chart ────────────────────────────────────────────────────────────────────
+const ChartDef = defineComponent({
+  name: "Chart",
+  description: "Renders a bar, pie, or line chart. Use for budgets, resource allocation, metrics, or any quantitative comparison.",
+  props: z.object({
+    title: z.string().optional().describe("Chart title"),
+    chartType: z.enum(["bar", "pie", "line", "donut"]).default("bar").describe("Chart type"),
+    data: z.array(z.object({
+      label: z.string().describe("Category or series name"),
+      value: z.number().describe("Numeric value"),
+      color: z.string().optional().describe("Hex color override"),
+    })).describe("Chart data points"),
+  }),
+  component: ({ props }) => {
+    const { ChartComponent } = require("@/components/openui-chat/components/ChartComponent")
+    return (
+      <ChartComponent
+        props={{ ...props, chartType: props.chartType ?? "bar" } as any}
+        data={(props.data as any[]) ?? []}
+      />
+    )
+  },
+})
+
+// ─── Timeline ─────────────────────────────────────────────────────────────────
+const TimelineDef = defineComponent({
+  name: "Timeline",
+  description: "Renders a chronological sequence of milestones or phases. Use for project schedules, roadmaps, or phase gates.",
+  props: z.object({
+    title: z.string().optional().describe("Timeline heading"),
+    milestones: z.array(z.object({
+      date: z.string().describe("Date or phase label, e.g. '2025-10-01' or 'Phase 1'"),
+      title: z.string().describe("Milestone name"),
+      description: z.string().optional().describe("Additional context"),
+      status: z.enum(["completed", "in-progress", "upcoming"]).optional(),
+    })).describe("Ordered list of milestones"),
+  }),
+  component: ({ props }) => {
+    const { TimelineComponent } = require("@/components/openui-chat/components/TimelineComponent")
+    return (
+      <TimelineComponent
+        props={{ title: props.title } as any}
+        data={(props.milestones as any[]) ?? []}
+      />
+    )
+  },
+})
+
+// ─── Card ─────────────────────────────────────────────────────────────────────
+const CardDef = defineComponent({
+  name: "Card",
+  description: "Renders a structured info card with key-value fields. Use for project overview, authorization details, or single-entity summaries.",
+  props: z.object({
+    title: z.string().optional().describe("Card heading"),
+    subtitle: z.string().optional().describe("Card subheading or section label"),
+    fields: z.record(z.string()).optional().describe("Key-value pairs to display in the card body"),
+    children: z.any().optional().describe("Nested OpenUI components inside this card"),
+  }),
+  component: ({ props, renderNode }) => {
+    const { CardComponent } = require("@/components/openui-chat/components/CardComponent")
+    const fieldRows = props.fields ? Object.entries(props.fields as Record<string, string>).map(([k, v]) => ({ title: k, value: v })) : []
+    return (
+      <CardComponent
+        props={{ title: props.title, subtitle: props.subtitle } as any}
+        data={fieldRows}
+      />
+    )
+  },
+})
+
+// ─── Team ─────────────────────────────────────────────────────────────────────
+const TeamDef = defineComponent({
+  name: "Team",
+  description: "Renders a team roster with member cards showing name, role, department, email, and responsibilities. Use for governance boards, stakeholder registers, or project teams.",
+  props: z.object({
+    title: z.string().optional().describe("Team section heading"),
+    members: z.array(z.object({
+      name: z.string().describe("Full name"),
+      role: z.string().describe("Project role or title"),
+      department: z.string().optional().describe("Organizational unit"),
+      email: z.string().optional().describe("Contact email"),
+      responsibility: z.string().optional().describe("Key responsibilities"),
+    })).describe("Team members"),
+  }),
+  component: ({ props }) => {
+    const { TeamComponent } = require("@/components/openui-chat/components/TeamComponent")
+    return (
+      <TeamComponent
+        props={{ title: props.title } as any}
+        data={(props.members as any[]) ?? []}
+      />
+    )
+  },
+})
+
+// ─── Bullets ──────────────────────────────────────────────────────────────────
+const BulletsDef = defineComponent({
+  name: "Bullets",
+  description: "Renders a bulleted or numbered list. Use for objectives, requirements, assumptions, lessons learned, or any list of items.",
+  props: z.object({
+    title: z.string().optional().describe("List heading"),
+    style: z.enum(["bullet", "numbered", "checklist"]).optional().default("bullet"),
+    items: z.array(z.string()).describe("List items"),
+  }),
+  component: ({ props }) => {
+    const { BulletsComponent } = require("@/components/openui-chat/components/BulletsComponent")
+    return (
+      <BulletsComponent
+        props={{ title: props.title, style: props.style ?? "bullet" } as any}
+        data={((props.items as string[]) ?? []).map(text => ({ text }))}
+      />
+    )
+  },
+})
+
+// ─── Alert ────────────────────────────────────────────────────────────────────
+const AlertDef = defineComponent({
+  name: "Alert",
+  description: "Renders risk, warning, or info alerts. Use for risks, issues, constraints, or important notices.",
+  props: z.object({
+    title: z.string().optional().describe("Alert section heading"),
+    severity: z.enum(["info", "warning", "error", "success"]).default("warning"),
+    alerts: z.array(z.object({
+      category: z.string().describe("Risk or alert category"),
+      impact: z.string().optional().describe("Impact description"),
+      mitigation: z.string().optional().describe("Mitigation or response strategy"),
+    })).describe("List of alerts or risks"),
+  }),
+  component: ({ props }) => {
+    const { AlertComponent } = require("@/components/openui-chat/components/AlertComponent")
+    return (
+      <AlertComponent
+        props={{ title: props.title, severity: props.severity ?? "warning" } as any}
+        data={((props.alerts as any[]) ?? []).map(a => ({
+          "Risk Category": a.category,
+          "Impact": a.impact ?? "",
+          "Mitigation": a.mitigation ?? "",
+        }))}
+      />
+    )
+  },
+})
+
+// ─── Accordion ────────────────────────────────────────────────────────────────
+const AccordionDef = defineComponent({
+  name: "Accordion",
+  description: "Renders collapsible sections. Use for assumptions, constraints, FAQs, or grouped details that benefit from progressive disclosure.",
+  props: z.object({
+    title: z.string().optional().describe("Accordion heading"),
+    sections: z.array(z.object({
+      heading: z.string().describe("Section title (clickable to expand)"),
+      content: z.record(z.string()).optional().describe("Key-value details inside the section"),
+      body: z.string().optional().describe("Free text body if key-value not applicable"),
+    })).describe("Accordion sections"),
+  }),
+  component: ({ props }) => {
+    const { AccordionComponent } = require("@/components/openui-chat/components/AccordionComponent")
+    return (
+      <AccordionComponent
+        props={{ title: props.title } as any}
+        data={((props.sections as any[]) ?? []).map(s => ({
+          title: s.heading,
+          ...(s.content ?? {}),
+          ...(s.body ? { "Details": s.body } : {}),
+        }))}
+      />
+    )
+  },
+})
+
+// ─── Comparison ───────────────────────────────────────────────────────────────
+const ComparisonDef = defineComponent({
+  name: "Comparison",
+  description: "Renders a side-by-side comparison table. Use for in-scope vs out-of-scope, options analysis, or feature comparisons.",
+  props: z.object({
+    title: z.string().optional().describe("Comparison heading"),
+    sides: z.array(z.object({
+      name: z.string().describe("Column heading, e.g. 'In-Scope'"),
+      highlighted: z.boolean().optional().default(false),
+      attributes: z.record(z.string()).describe("Attribute name → value pairs"),
+    })).describe("Comparison columns"),
+  }),
+  component: ({ props }) => {
+    const { ComparisonComponent } = require("@/components/openui-chat/components/ComparisonComponent")
+    return (
+      <ComparisonComponent
+        props={{ title: props.title } as any}
+        data={((props.sides as any[]) ?? []).map(s => ({
+          name: s.name,
+          highlighted: s.highlighted ?? false,
+          ...s.attributes,
+        }))}
+      />
+    )
+  },
+})
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+const StepsDef = defineComponent({
+  name: "Steps",
+  description: "Renders a sequential step-by-step process. Use for workflows, procedures, onboarding guides, or phase execution plans.",
+  props: z.object({
+    title: z.string().optional().describe("Process heading"),
+    steps: z.array(z.object({
+      label: z.string().describe("Step title"),
+      description: z.string().optional().describe("Step detail"),
+    })).describe("Ordered steps"),
+  }),
+  component: ({ props }) => {
+    const { StepsComponent } = require("@/components/openui-chat/components/StepsComponent")
+    return (
+      <StepsComponent
+        props={{ title: props.title } as any}
+        data={((props.steps as any[]) ?? []).map(s => ({ title: s.label, description: s.description ?? "" }))}
+      />
+    )
+  },
+})
+
+// Panel components that can appear inside Tabs (defined after all panel types exist)
+const TabPanelRef = z.union([
+  CardDef.ref,
+  TeamDef.ref,
+  TableDef.ref,
+  ChartDef.ref,
+  TimelineDef.ref,
+  BulletsDef.ref,
+  AlertDef.ref,
+  AccordionDef.ref,
+  ComparisonDef.ref,
+  StepsDef.ref,
+])
+
+// ─── Tabs ─────────────────────────────────────────────────────────────────────
+const TabsDef = defineComponent({
+  name: "Tabs",
+  description: "Renders switchable tab panels. Use as the top-level wrapper for multi-section documents like project charters, plans, or reports. Nest one child component per tab.",
+  props: z.object({
+    title: z.string().optional().describe("Dashboard or document title shown above the tabs"),
+    tabs: z.array(z.string()).optional().describe("Tab labels (one per nested child panel)"),
+    panels: z.array(TabPanelRef).optional().describe("Tab panel content — one nested component per tab"),
+  }),
+  component: ({ props, renderNode }) => {
+    const { TabsComponent } = require("@/components/openui-chat/components/TabsComponent")
+    const panels = (props.panels as unknown[]) ?? []
+    const panelContent: ReactNode[] = panels.map((panel) => renderNode(panel))
+    return (
+      <TabsComponent
+        props={{ title: props.title, tabs: props.tabs } as any}
+        data={[]}
+        panelContent={panelContent}
+      />
+    )
+  },
+})
+
+// ─── Library ──────────────────────────────────────────────────────────────────
+export const adpaLibrary = createLibrary({
+  components: [
+    TableDef,
+    ChartDef,
+    TimelineDef,
+    CardDef,
+    TeamDef,
+    BulletsDef,
+    AlertDef,
+    AccordionDef,
+    ComparisonDef,
+    StepsDef,
+    TabsDef,
+  ],
+  root: "Tabs",
+})
+
+export type { Library } from "@openuidev/react-lang"

--- a/lib/openui/adpaLibrary.tsx
+++ b/lib/openui/adpaLibrary.tsx
@@ -8,14 +8,19 @@ import { createLibrary, defineComponent } from "@openuidev/react-lang"
 import { z } from "zod/v4"
 import type { ReactNode } from "react"
 
+/** Zod 4 requires key + value schemas; single-arg z.record() breaks OpenUI's schema walker. */
+const stringRecord = z.record(z.string(), z.string())
+const looseRecord = z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+
 // ─── Table ────────────────────────────────────────────────────────────────────
 const TableDef = defineComponent({
   name: "Table",
-  description: "Renders tabular data with column headers and rows. Use for registers, lists of stakeholders, deliverables, risks, or any matrix-style data.",
+  description:
+    "Tabular data with column headers and rows. Use ONLY when the section is clearly a table/matrix AND every row from the source is included. Otherwise use Prose.",
   props: z.object({
     title: z.string().optional().describe("Section heading for the table"),
     columns: z.array(z.string()).optional().describe("Column headers (inferred from row keys if omitted)"),
-    rows: z.array(z.record(z.any())).describe("Array of row objects, keys match column headers"),
+    rows: z.array(looseRecord).describe("Array of row objects, keys match column headers"),
     striped: z.boolean().optional().default(false).describe("Alternate row shading"),
   }),
   component: ({ props }) => {
@@ -82,12 +87,12 @@ const TimelineDef = defineComponent({
 // ─── Card ─────────────────────────────────────────────────────────────────────
 const CardDef = defineComponent({
   name: "Card",
-  description: "Renders a structured info card with key-value fields. Use for project overview, authorization details, or single-entity summaries.",
+  description:
+    "Key-value fields. Use ONLY for small sets where every field from the source is included. Otherwise use Prose.",
   props: z.object({
     title: z.string().optional().describe("Card heading"),
     subtitle: z.string().optional().describe("Card subheading or section label"),
-    fields: z.record(z.string()).optional().describe("Key-value pairs to display in the card body"),
-    children: z.any().optional().describe("Nested OpenUI components inside this card"),
+    fields: stringRecord.optional().describe("Key-value pairs to display in the card body"),
   }),
   component: ({ props, renderNode }) => {
     const { CardComponent } = require("@/components/openui-chat/components/CardComponent")
@@ -104,7 +109,8 @@ const CardDef = defineComponent({
 // ─── Team ─────────────────────────────────────────────────────────────────────
 const TeamDef = defineComponent({
   name: "Team",
-  description: "Renders a team roster with member cards showing name, role, department, email, and responsibilities. Use for governance boards, stakeholder registers, or project teams.",
+  description:
+    "Team roster. Use ONLY when every person from the source is listed with their attributes. Otherwise use Prose or Table.",
   props: z.object({
     title: z.string().optional().describe("Team section heading"),
     members: z.array(z.object({
@@ -126,10 +132,27 @@ const TeamDef = defineComponent({
   },
 })
 
+// ─── Prose ────────────────────────────────────────────────────────────────────
+const ProseDef = defineComponent({
+  name: "Prose",
+  description:
+    "Default section body: full narrative content from the source document. Use when text cannot be fully captured in Table/Card/Bullets without loss. Include every paragraph and list item — never summarize.",
+  props: z.object({
+    title: z.string().optional().describe("Optional subheading inside the section (usually omit; Section already has the heading)"),
+    paragraphs: z.array(z.string()).optional().describe("Each paragraph or list block from the source, copied verbatim"),
+    body: z.string().optional().describe("Full section markdown when a single block is easier than paragraphs array"),
+  }),
+  component: ({ props }) => {
+    const { ProseComponent } = require("@/components/openui-chat/components/ProseComponent")
+    return <ProseComponent props={props as Record<string, unknown>} data={[]} />
+  },
+})
+
 // ─── Bullets ──────────────────────────────────────────────────────────────────
 const BulletsDef = defineComponent({
   name: "Bullets",
-  description: "Renders a bulleted or numbered list. Use for objectives, requirements, assumptions, lessons learned, or any list of items.",
+  description:
+    "Bulleted or numbered list. Use ONLY when the section is a list AND every item from the source is included. Otherwise use Prose.",
   props: z.object({
     title: z.string().optional().describe("List heading"),
     style: z.enum(["bullet", "numbered", "checklist"]).optional().default("bullet"),
@@ -182,7 +205,7 @@ const AccordionDef = defineComponent({
     title: z.string().optional().describe("Accordion heading"),
     sections: z.array(z.object({
       heading: z.string().describe("Section title (clickable to expand)"),
-      content: z.record(z.string()).optional().describe("Key-value details inside the section"),
+      content: stringRecord.optional().describe("Key-value details inside the section"),
       body: z.string().optional().describe("Free text body if key-value not applicable"),
     })).describe("Accordion sections"),
   }),
@@ -210,7 +233,7 @@ const ComparisonDef = defineComponent({
     sides: z.array(z.object({
       name: z.string().describe("Column heading, e.g. 'In-Scope'"),
       highlighted: z.boolean().optional().default(false),
-      attributes: z.record(z.string()).describe("Attribute name → value pairs"),
+      attributes: stringRecord.describe("Attribute name → value pairs"),
     })).describe("Comparison columns"),
   }),
   component: ({ props }) => {
@@ -250,8 +273,28 @@ const StepsDef = defineComponent({
   },
 })
 
-// Panel components that can appear inside Tabs (defined after all panel types exist)
-const TabPanelRef = z.union([
+// ─── Table of Contents ────────────────────────────────────────────────────────
+const TableOfContentsDef = defineComponent({
+  name: "TableOfContents",
+  description:
+    "Navigation list of report sections. Use as the first Section body when the document has 4+ major sections. List every section title in order — do not invent entries.",
+  props: z.object({
+    title: z.string().optional().describe("Usually 'Table of Contents'"),
+    entries: z.array(z.object({
+      title: z.string().describe("Section title as it appears in the report"),
+      level: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional().describe("1 = major, 2 = subsection"),
+    })).describe("All section headings in document order"),
+  }),
+  component: ({ props }) => {
+    const { TableOfContentsComponent } = require("@/components/openui-chat/components/TableOfContentsComponent")
+    return <TableOfContentsComponent props={props as Record<string, unknown>} data={[]} />
+  },
+})
+
+// Content blocks used inside Report sections or Tabs panels
+const ContentBlockRef = z.union([
+  ProseDef.ref,
+  TableOfContentsDef.ref,
   CardDef.ref,
   TeamDef.ref,
   TableDef.ref,
@@ -264,14 +307,62 @@ const TabPanelRef = z.union([
   StepsDef.ref,
 ])
 
+// ─── Section ──────────────────────────────────────────────────────────────────
+const SectionDef = defineComponent({
+  name: "Section",
+  description:
+    "One section from the source document (match each # / ## heading). Body is Prose (full text) OR a structured block only when it can hold ALL information from that section.",
+  props: z.object({
+    heading: z.string().describe("Section title matching the source heading"),
+    intro: z.string().optional().describe("Omit when using Prose with full body; only for a one-line lead-in before a Table/Team block"),
+    level: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional().default(1).describe("Heading depth: 1 = major section, 2 = subsection"),
+    content: ContentBlockRef.describe("Prose (default) or Table/Bullets/Card/Team only when nothing is omitted"),
+  }),
+  component: ({ props, renderNode }) => {
+    const { SectionComponent } = require("@/components/openui-chat/components/SectionComponent")
+    const body = props.content ? renderNode(props.content) : null
+    return (
+      <SectionComponent
+        props={{ heading: props.heading, intro: props.intro, level: props.level ?? 1 } as any}
+        data={[]}
+        content={body}
+      />
+    )
+  },
+})
+
+// ─── Report ───────────────────────────────────────────────────────────────────
+const ReportDef = defineComponent({
+  name: "Report",
+  description:
+    "Complete document report: header plus every source section in order. Must include ALL content from the document — no summaries or skipped sections.",
+  props: z.object({
+    title: z.string().describe("Document title"),
+    subtitle: z.string().optional().describe("Document type or template name"),
+    meta: stringRecord.optional().describe("Header metadata: Status, Version, Author, Date, etc."),
+    sections: z.array(SectionDef.ref).describe("Ordered report sections — one Section per major document part"),
+  }),
+  component: ({ props, renderNode }) => {
+    const { ReportComponent } = require("@/components/openui-chat/components/ReportComponent")
+    const sections = ((props.sections as unknown[]) ?? []).map((section) => renderNode(section))
+    return (
+      <ReportComponent
+        props={{ title: props.title, subtitle: props.subtitle, meta: props.meta } as any}
+        data={[]}
+        sectionContent={sections}
+      />
+    )
+  },
+})
+
 // ─── Tabs ─────────────────────────────────────────────────────────────────────
 const TabsDef = defineComponent({
   name: "Tabs",
-  description: "Renders switchable tab panels. Use as the top-level wrapper for multi-section documents like project charters, plans, or reports. Nest one child component per tab.",
+  description: "Switchable tab panels — use ONLY when the user explicitly asks for a tabbed or dashboard layout. Prefer Report for document views.",
   props: z.object({
     title: z.string().optional().describe("Dashboard or document title shown above the tabs"),
     tabs: z.array(z.string()).optional().describe("Tab labels (one per nested child panel)"),
-    panels: z.array(TabPanelRef).optional().describe("Tab panel content — one nested component per tab"),
+    panels: z.array(ContentBlockRef).optional().describe("Tab panel content — one nested component per tab"),
   }),
   component: ({ props, renderNode }) => {
     const { TabsComponent } = require("@/components/openui-chat/components/TabsComponent")
@@ -289,20 +380,48 @@ const TabsDef = defineComponent({
 
 // ─── Library ──────────────────────────────────────────────────────────────────
 export const adpaLibrary = createLibrary({
+  root: "Report",
   components: [
+    ReportDef,
+    SectionDef,
+    ProseDef,
+    TableOfContentsDef,
+    TabsDef,
+    CardDef,
+    TeamDef,
     TableDef,
     ChartDef,
     TimelineDef,
-    CardDef,
-    TeamDef,
     BulletsDef,
     AlertDef,
     AccordionDef,
     ComparisonDef,
     StepsDef,
-    TabsDef,
   ],
-  root: "Tabs",
+  componentGroups: [
+    {
+      name: "Report layout",
+      components: ["Report", "Section"],
+      notes: [
+        "Every response MUST start with: root = Report(title, subtitle, meta, [sectionRef1, sectionRef2, ...])",
+        "Create one Section per heading in the source document — do not merge or skip sections.",
+        "FIDELITY: Include every paragraph, list item, table row, and field from the source. Never summarize, sample, or use placeholder text.",
+        "Default content block is Prose with all section text. Use Table/Bullets/Card/Team ONLY when they can contain the same information without omission.",
+        "Each section: sectionRef = Section(heading, introOrNull, level, contentRef); define contentRef on a separate line below.",
+        "Do NOT use Tabs unless the user explicitly requests a tabbed dashboard.",
+      ],
+    },
+    {
+      name: "Content",
+      components: ["Prose", "TableOfContents", "Card", "Team", "Table", "Timeline", "Bullets", "Alert", "Accordion", "Comparison", "Steps", "Chart"],
+      notes: ["Prefer Prose when in doubt. Charts only for numeric data already in the source."],
+    },
+    {
+      name: "Optional dashboard",
+      components: ["Tabs"],
+      notes: ["Tabbed layout only on explicit user request."],
+    },
+  ],
 })
 
 export type { Library } from "@openuidev/react-lang"

--- a/lib/openui/documentTransformationAgent.ts
+++ b/lib/openui/documentTransformationAgent.ts
@@ -1,0 +1,52 @@
+/**
+ * Document transformation agent — converts source markdown into
+ * presentation-ready OpenUI reports without altering meaning or facts.
+ */
+
+export const DOCUMENT_TRANSFORMATION_AGENT_ROLE = `You are a specialized document transformation agent that converts raw markdown content into professionally formatted, visually appealing reports. You take project documentation written in markdown and transform it into polished, presentation-ready documents using OpenUI Lang (Report + Section + content blocks).`
+
+export const DOCUMENT_TRANSFORMATION_TASKS = [
+  "Parse and analyze markdown to understand structure, headings, and content organization.",
+  "Preserve the original meaning, facts, and wording — format and structure only, unless the user explicitly asks to edit content.",
+  "Map each source heading to a Report Section in the same order; use clear visual hierarchy (numbered sections, consistent heading levels).",
+  "Convert markdown into Prose blocks (full section text) or structured blocks (Table, Bullets, Card, Team) only when every item from that section fits without omission.",
+  "Apply professional report layout: title, subtitle, metadata (status, version, date from source when present), and readable typography.",
+  "Optimize presentation of tables, lists, and code blocks — use Table for complete tabular data, Prose for narrative and mixed content.",
+  "Include a TableOfContents section at the start when the document has four or more major sections, listing section titles in order.",
+  "Suggest structure improvements only when the user asks; default mode is faithful reproduction, not rewriting.",
+]
+
+export const DOCUMENT_TRANSFORMATION_RESTRICTIONS = [
+  "Do not modify core content or meaning without explicit user consent.",
+  "Do not add fictional information or content not in the source.",
+  "Do not summarize, sample rows, or use placeholder text — include complete section content.",
+  "Do not assume custom branding, colors, or logos unless the user specifies them.",
+  "Do not process or highlight content that appears to contain passwords or secrets — omit redacted values if present.",
+]
+
+export const DOCUMENT_TRANSFORMATION_TONE = [
+  "Professional and precise in formatting choices.",
+  "Detail-oriented: complete sections, correct heading order, faithful data.",
+  "Prefer Prose for narrative; use structured UI only as a faithful visual substitute for the same information.",
+]
+
+/** Output note for the live UI (export pipelines are separate ADPA features). */
+export const DOCUMENT_TRANSFORMATION_OUTPUT_NOTE =
+  "Primary output is a styled HTML report in the browser. PDF, Word, or file export use ADPA document export when the user needs a downloadable file."
+
+export function buildDocumentTransformationAgentPrompt(): string {
+  return [
+    DOCUMENT_TRANSFORMATION_AGENT_ROLE,
+    "",
+    "## Tasks",
+    ...DOCUMENT_TRANSFORMATION_TASKS.map((t) => `- ${t}`),
+    "",
+    "## Restrictions",
+    ...DOCUMENT_TRANSFORMATION_RESTRICTIONS.map((r) => `- ${r}`),
+    "",
+    "## Tone",
+    ...DOCUMENT_TRANSFORMATION_TONE.map((t) => `- ${t}`),
+    "",
+    `## Output\n${DOCUMENT_TRANSFORMATION_OUTPUT_NOTE}`,
+  ].join("\n")
+}

--- a/lib/openui/library.ts
+++ b/lib/openui/library.ts
@@ -95,6 +95,19 @@ export function isComponentPayload(payload: OpenUIAssistantPayload): payload is 
     && "type" in payload && payload.type === "component"
 }
 
+/** Legacy JSON component payload (pre–OpenUI Lang threads) */
+export function isLegacyComponentPayload(
+  payload: OpenUIChatJson
+): payload is ComponentPayload {
+  return isComponentPayload(payload as OpenUIAssistantPayload)
+}
+
+/** Heuristic: assistant content looks like OpenUI Lang XML */
+export function looksLikeOpenUILang(text: string): boolean {
+  const trimmed = text.trim()
+  return trimmed.startsWith("<") && /<[A-Z][a-zA-Z]*/.test(trimmed)
+}
+
 // Helper to check if payload is text
 
 export function isTextPayload(payload: OpenUIAssistantPayload): payload is TextPayload {

--- a/lib/openui/library.ts
+++ b/lib/openui/library.ts
@@ -23,6 +23,8 @@ export type ComponentType =
   | "Calendar"
   | "Team"
   | "Text"
+  | "Prose"
+  | "TableOfContents"
 
 // Structured JSON type for chat messages
 export type OpenUIChatJson =
@@ -102,10 +104,12 @@ export function isLegacyComponentPayload(
   return isComponentPayload(payload as OpenUIAssistantPayload)
 }
 
-/** Heuristic: assistant content looks like OpenUI Lang XML */
+/** Heuristic: assistant content looks like OpenUI Lang (statement syntax, not XML) */
 export function looksLikeOpenUILang(text: string): boolean {
   const trimmed = text.trim()
-  return trimmed.startsWith("<") && /<[A-Z][a-zA-Z]*/.test(trimmed)
+  if (/^root\s*=/m.test(trimmed)) return true
+  if (trimmed.startsWith("<") && /<[A-Z][a-zA-Z]*/.test(trimmed)) return false
+  return /^[A-Za-z][\w]*\s*=/.test(trimmed)
 }
 
 // Helper to check if payload is text

--- a/lib/openui/streaming.ts
+++ b/lib/openui/streaming.ts
@@ -1,0 +1,126 @@
+/**
+ * SSE helpers for OpenUI Lang text streaming from /api/v1/openui-chat/chat
+ */
+
+export type OpenUILangStreamEvent =
+  | { type: "text"; text: string; threadId?: string | null }
+  | { type: "done"; threadId: string | null; length?: number }
+  | { type: "error"; message: string }
+
+export type ParsedOpenUILangStream = {
+  events: OpenUILangStreamEvent[]
+  remainder: string
+}
+
+/**
+ * Parse one or more complete SSE events from a buffer.
+ * Supports `event: text` / `event: done` / `event: error` with JSON data lines.
+ */
+export function parseOpenUILangSSEBuffer(buffer: string): ParsedOpenUILangStream {
+  const events: OpenUILangStreamEvent[] = []
+  const blocks = buffer.split("\n\n")
+  const remainder = blocks.pop() ?? ""
+
+  for (const block of blocks) {
+    const event = parseSSEBlock(block)
+    if (event) {
+      events.push(event)
+    }
+  }
+
+  return { events, remainder }
+}
+
+function parseSSEBlock(block: string): OpenUILangStreamEvent | null {
+  const lines = block.split("\n").map((line) => line.trim()).filter(Boolean)
+  if (lines.length === 0) {
+    return null
+  }
+
+  let eventName = "message"
+  const dataLines: string[] = []
+
+  for (const line of lines) {
+    if (line.startsWith("event:")) {
+      eventName = line.slice(6).trim()
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice(5).trim())
+    }
+  }
+
+  if (dataLines.length === 0) {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(dataLines.join("\n")) as Record<string, unknown>
+
+    if (eventName === "text" && typeof payload.text === "string") {
+      return {
+        type: "text",
+        text: payload.text,
+        threadId: typeof payload.threadId === "string" ? payload.threadId : null,
+      }
+    }
+
+    if (eventName === "done") {
+      return {
+        type: "done",
+        threadId: typeof payload.threadId === "string" ? payload.threadId : null,
+        length: typeof payload.length === "number" ? payload.length : undefined,
+      }
+    }
+
+    if (eventName === "error") {
+      return {
+        type: "error",
+        message: typeof payload.message === "string" ? payload.message : "Stream failed",
+      }
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+/**
+ * Read an entire fetch Response body as accumulated OpenUI Lang text.
+ */
+export async function readOpenUILangStream(
+  response: Response,
+  onChunk?: (accumulated: string, chunk: string) => void
+): Promise<{ text: string; threadId: string | null }> {
+  const reader = response.body?.getReader()
+  if (!reader) {
+    throw new Error("Response has no body")
+  }
+
+  const decoder = new TextDecoder()
+  let buffer = ""
+  let accumulated = ""
+  let threadId: string | null = response.headers.get("x-thread-id") || null
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+    const { events, remainder } = parseOpenUILangSSEBuffer(buffer)
+    buffer = remainder
+
+    for (const event of events) {
+      if (event.type === "text") {
+        accumulated += event.text
+        if (event.threadId) threadId = event.threadId
+        onChunk?.(accumulated, event.text)
+      } else if (event.type === "done") {
+        if (event.threadId) threadId = event.threadId
+      } else if (event.type === "error") {
+        throw new Error(event.message)
+      }
+    }
+  }
+
+  return { text: accumulated, threadId }
+}

--- a/lib/openui/systemPrompt.ts
+++ b/lib/openui/systemPrompt.ts
@@ -1,0 +1,80 @@
+/**
+ * ADPA OpenUI System Prompt
+ * Uses adpaLibrary.prompt() to auto-generate the LLM system prompt.
+ * Safe to import from the Express backend (component renderers are not invoked).
+ */
+
+import { adpaLibrary } from "./adpaLibrary"
+
+const ADPA_ADDITIONAL_RULES = [
+  "Render the ENTIRE document — not just the first section. Read every section before responding.",
+  "Always wrap multi-section documents in a <Tabs> component with one tab per major section.",
+  "For project charters: use Tabs with Authorization, Governance Board, Stakeholder Register, Objectives, Scope, Assumptions, Budget, Milestones, and Risks.",
+  "Extract REAL data from the provided document — never invent placeholder names, dates, or numbers.",
+  "Chart `data` values must be numbers, not strings.",
+  "Start your response immediately with the root component — no preamble, markdown, or JSON.",
+]
+
+/**
+ * Base system prompt generated from the ADPA component library schema.
+ */
+export function buildADPALibraryPrompt(documentContext?: {
+  documentName?: string
+  documentType?: string
+}): string {
+  const preamble = documentContext?.documentName
+    ? `You are an ADPA document visualization assistant rendering "${documentContext.documentName}"${documentContext.documentType ? ` (${documentContext.documentType})` : ""}.`
+    : "You are an ADPA document visualization assistant for project management documents."
+
+  return adpaLibrary.prompt({
+    preamble,
+    additionalRules: ADPA_ADDITIONAL_RULES,
+  })
+}
+
+/**
+ * Build the full ADPA OpenUI system prompt for a chat request.
+ */
+export function buildOpenUISystemPrompt(options?: {
+  documentName?: string
+  documentType?: string
+}): string {
+  return buildADPALibraryPrompt({
+    documentName: options?.documentName,
+    documentType: options?.documentType,
+  })
+}
+
+/**
+ * Assemble the full user message from document context + user request.
+ */
+export function buildOpenUIUserMessage(options: {
+  prompt: string
+  documentContent?: string
+  documentName?: string
+  ragContext?: string
+  projectName?: string
+  projectDescription?: string
+}): string {
+  const parts: string[] = []
+
+  if (options.documentName && options.documentContent) {
+    parts.push(`=== DOCUMENT: ${options.documentName} ===`)
+    parts.push(options.documentContent)
+    parts.push("=== END DOCUMENT ===")
+  } else if (options.ragContext && !options.ragContext.startsWith("No internal")) {
+    parts.push("=== CONTEXT ===")
+    parts.push(options.ragContext)
+    parts.push("=== END CONTEXT ===")
+  } else if (options.projectName) {
+    parts.push(`Project: ${options.projectName}`)
+    if (options.projectDescription) {
+      parts.push(`Description: ${options.projectDescription}`)
+    }
+  }
+
+  parts.push(`\nUser request: ${options.prompt}`)
+  parts.push("\nGenerate the full OpenUI Lang visualization now:")
+
+  return parts.join("\n")
+}

--- a/lib/openui/systemPrompt.ts
+++ b/lib/openui/systemPrompt.ts
@@ -1,40 +1,58 @@
 /**
  * ADPA OpenUI System Prompt
- * Uses adpaLibrary.prompt() to auto-generate the LLM system prompt.
+ * Uses adpaLibrary.prompt() + document transformation agent spec.
  * Safe to import from the Express backend (component renderers are not invoked).
  */
 
 import { adpaLibrary } from "./adpaLibrary"
+import { buildDocumentTransformationAgentPrompt } from "./documentTransformationAgent"
 
-const ADPA_ADDITIONAL_RULES = [
-  "Render the ENTIRE document — not just the first section. Read every section before responding.",
-  "Always wrap multi-section documents in a <Tabs> component with one tab per major section.",
-  "For project charters: use Tabs with Authorization, Governance Board, Stakeholder Register, Objectives, Scope, Assumptions, Budget, Milestones, and Risks.",
-  "Extract REAL data from the provided document — never invent placeholder names, dates, or numbers.",
-  "Chart `data` values must be numbers, not strings.",
-  "Start your response immediately with the root component — no preamble, markdown, or JSON.",
+const ADPA_OPENUI_RULES = [
+  "Output ONLY OpenUI Lang statement syntax — never XML tags, never JSON, never raw Markdown outside Prose strings.",
+  "The FIRST line must be: root = Report(title, subtitle, meta, [sectionRef1, sectionRef2, ...])",
+  "Create one Section for every major heading in the source markdown, in the same order. Do not skip or merge sections.",
+  "COMPLETE FIDELITY: Every paragraph, list item, table row, and field from the source must appear. Never summarize, abbreviate with 'etc.', or invent content.",
+  "Default section body is Prose(null, paragraphs) or Prose(null, null, body) with full section text from the source.",
+  "Use Table, Bullets, Card, or Team ONLY when that block can hold ALL information from that section without loss. Otherwise use Prose.",
+  "For 4+ major sections, add an early Section('Table of Contents', ...) whose content is TableOfContents with every section title.",
+  "Report meta: include Status, Version, Author, Date from the source when present — do not fabricate.",
+  "Layout is a vertical formal report — no tabs unless explicitly requested.",
+  "Chart values must be numbers. Use Chart only for numeric data already in the source.",
+  "Use positional arguments in Zod key order; omit optional trailing args rather than passing null when possible.",
 ]
 
+const ADPA_PROMPT_EXAMPLE = `root = Report("Project Charter", "PMBOK", {Status: "Draft", Version: "1.0"}, [tocSec, sec1, sec2, sec3])
+tocSec = Section("Table of Contents", null, 1, toc)
+toc = TableOfContents("Table of Contents", [{title: "1. Purpose", level: 1}, {title: "2. Objectives", level: 1}, {title: "3. Authorization", level: 1}])
+sec1 = Section("1. Purpose", null, 1, purposeProse)
+purposeProse = Prose(null, ["The purpose of this project is to deliver the customer portal upgrade by Q4.", "Success criteria include user adoption above 80% and zero critical defects at launch."])
+sec2 = Section("2. Objectives", null, 1, objectives)
+objectives = Bullets(null, "numbered", ["Deliver MVP by 31 Dec 2025", "Stay within approved budget of $1.2M", "Maintain ISO 27001 compliance throughout"])
+sec3 = Section("3. Authorization", null, 1, authProse)
+authProse = Prose(null, ["This charter authorizes the project manager to apply organizational resources to project activities.", "The executive sponsor approves scope changes over $50k."])`
+
 /**
- * Base system prompt generated from the ADPA component library schema.
+ * Base system prompt: transformation agent + component library schema.
  */
 export function buildADPALibraryPrompt(documentContext?: {
   documentName?: string
   documentType?: string
 }): string {
-  const preamble = documentContext?.documentName
-    ? `You are an ADPA document visualization assistant rendering "${documentContext.documentName}"${documentContext.documentType ? ` (${documentContext.documentType})` : ""}.`
-    : "You are an ADPA document visualization assistant for project management documents."
+  const agent = buildDocumentTransformationAgentPrompt()
+
+  const documentLine = documentContext?.documentName
+    ? `Current document: "${documentContext.documentName}"${documentContext.documentType ? ` (${documentContext.documentType})` : ""}.`
+    : ""
+
+  const preamble = [agent, documentLine].filter(Boolean).join("\n\n")
 
   return adpaLibrary.prompt({
     preamble,
-    additionalRules: ADPA_ADDITIONAL_RULES,
+    additionalRules: ADPA_OPENUI_RULES,
+    examples: [ADPA_PROMPT_EXAMPLE],
   })
 }
 
-/**
- * Build the full ADPA OpenUI system prompt for a chat request.
- */
 export function buildOpenUISystemPrompt(options?: {
   documentName?: string
   documentType?: string
@@ -45,9 +63,6 @@ export function buildOpenUISystemPrompt(options?: {
   })
 }
 
-/**
- * Assemble the full user message from document context + user request.
- */
 export function buildOpenUIUserMessage(options: {
   prompt: string
   documentContent?: string
@@ -59,9 +74,12 @@ export function buildOpenUIUserMessage(options: {
   const parts: string[] = []
 
   if (options.documentName && options.documentContent) {
-    parts.push(`=== DOCUMENT: ${options.documentName} ===`)
+    parts.push(`=== SOURCE MARKDOWN: ${options.documentName} ===`)
     parts.push(options.documentContent)
-    parts.push("=== END DOCUMENT ===")
+    parts.push("=== END SOURCE ===")
+    parts.push(
+      "Transform this markdown into a complete OpenUI Report: preserve all content and meaning; improve presentation only. One Section per heading; Prose for full narrative; structured blocks only when nothing is omitted."
+    )
   } else if (options.ragContext && !options.ragContext.startsWith("No internal")) {
     parts.push("=== CONTEXT ===")
     parts.push(options.ragContext)
@@ -74,7 +92,9 @@ export function buildOpenUIUserMessage(options: {
   }
 
   parts.push(`\nUser request: ${options.prompt}`)
-  parts.push("\nGenerate the full OpenUI Lang visualization now:")
+  parts.push(
+    "\nRespond with OpenUI Lang only. root = Report(...). Faithful transformation — no content changes unless the user explicitly asked to edit."
+  )
 
   return parts.join("\n")
 }

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@neondatabase/serverless": "^1.0.1",
     "@octokit/rest": "^20.1.2",
-    "@openuidev/react-headless": "^0.8.1",
-    "@openuidev/react-ui": "^0.11.6",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "0.75.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.217.0",
@@ -64,6 +62,9 @@
     "@opentelemetry/sdk-trace-base": "2.7.1",
     "@opentelemetry/sdk-trace-node": "2.7.1",
     "@opentelemetry/semantic-conventions": "1.27.0",
+    "@openuidev/react-headless": "^0.8.1",
+    "@openuidev/react-lang": "^0.2.5",
+    "@openuidev/react-ui": "^0.11.6",
     "@pinecone-database/pinecone": "^7.0.0",
     "@qdrant/js-client-rest": "^1.16.2",
     "@radix-ui/react-accordion": "latest",
@@ -224,7 +225,7 @@
     "vaul": "^0.9.0",
     "voyageai": "^0.1.0",
     "winston": "^3.19.0",
-    "zod": "^3.24.1"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@ai-sdk/anthropic": "^3.0.45",
@@ -309,9 +310,6 @@
       "jspdf": "^4.0.0",
       "mdast-util-to-hast": "^13.2.1",
       "diff": "^8.0.3"
-    },
-    "patchedDependencies": {
-      "zod@3.24.1": "patches/zod@3.24.1.patch"
     },
     "onlyBuiltDependencies": [
       "esbuild"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,8 +909,8 @@ importers:
         specifier: ^0.5.16
         version: 0.5.16
       ai:
-        specifier: ^5.0.116
-        version: 5.0.156(zod@3.25.76)
+        specifier: ^6.0.64
+        version: 6.0.90(zod@3.25.76)
       amqp-connection-manager:
         specifier: ^4.1.5
         version: 4.1.15(amqplib@0.10.9)
@@ -1027,7 +1027,7 @@ importers:
         version: 8.0.5
       ollama-ai-provider-v2:
         specifier: ^3.3.1
-        version: 3.3.1(ai@5.0.156(zod@3.25.76))(zod@3.25.76)
+        version: 3.3.1(ai@6.0.90(zod@3.25.76))(zod@3.25.76)
       openai:
         specifier: ^6.15.0
         version: 6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
@@ -1222,12 +1222,6 @@ packages:
 
   '@ai-sdk/deepseek@2.0.20':
     resolution: {integrity: sha512-MAL04sDTOWUiBjAGWaVgyeE4bYRb9QpKYRlIeCTZFga6I8yQs50XakhWEssrmvVihdpHGkqpDtCHsFqCydsWLA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@2.0.60':
-    resolution: {integrity: sha512-1wrIHHv+W/zFgGKDno5pHJeUpkbITbEq+oJRDhT0/t6cxoPCCPvBtzxof3vUxTOn4Aokhmo64C5yi2/tjbtVrQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6749,12 +6743,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  ai@5.0.156:
-    resolution: {integrity: sha512-TwpwdC4YAyxg4s1Infm2lrFB8KTfL9Sy0Gzbomlh2ldcw6rnGMKj3WSUnulXDQJvIVHWN+g8uCYJ3wLJZuVGOA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   ai@6.0.90:
     resolution: {integrity: sha512-3l6MgR7GDMUWkpLZ8tnrXUWVxbTs0m8rPOBe6A60FxtPnxwdgRyqaaYlHcMuSc4SJ0HHdt49a3Bah3zFBguA8w==}
@@ -13407,13 +13395,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/gateway@2.0.60(zod@3.25.76)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
-      '@vercel/oidc': 3.1.0
-      zod: 3.25.76
-
   '@ai-sdk/gateway@3.0.49(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -19595,14 +19576,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.156(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/gateway': 2.0.60(zod@3.25.76)
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
-      '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
-
   ai@6.0.90(zod@3.25.76):
     dependencies:
       '@ai-sdk/gateway': 3.0.49(zod@3.25.76)
@@ -24988,13 +24961,6 @@ snapshots:
       es-object-atoms: 1.1.1
 
   obuf@1.1.2: {}
-
-  ollama-ai-provider-v2@3.3.1(ai@5.0.156(zod@3.25.76))(zod@3.25.76):
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
-      ai: 5.0.156(zod@3.25.76)
-      zod: 3.25.76
 
   ollama-ai-provider-v2@3.3.1(ai@6.0.90(zod@3.25.76))(zod@3.25.76):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,6 @@ overrides:
   mdast-util-to-hast: ^13.2.1
   diff: ^8.0.3
 
-patchedDependencies:
-  zod@3.24.1:
-    hash: 99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52
-    path: patches/zod@3.24.1.patch
-
 importers:
 
   .:
@@ -38,16 +33,16 @@ importers:
         version: 4.0.1
       '@ai-sdk/deepseek':
         specifier: ^2.0.20
-        version: 2.0.20(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 2.0.20(zod@3.25.76)
       '@ai-sdk/provider-utils':
         specifier: ^4.0.15
-        version: 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 4.0.15(zod@3.25.76)
       '@ai-sdk/xai':
         specifier: ^3.0.56
-        version: 3.0.56(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.56(zod@3.25.76)
       '@anthropic-ai/sdk':
         specifier: ^0.74.0
-        version: 0.74.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 0.74.0(zod@3.25.76)
       '@cantoo/pdf-lib':
         specifier: ^2.5.3
         version: 2.5.3
@@ -71,7 +66,7 @@ importers:
         version: 1.0.0-beta.4
       '@google/genai':
         specifier: ^1.42.0
-        version: 1.42.0(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+        version: 1.42.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       '@google/generative-ai':
         specifier: latest
         version: 0.24.1
@@ -107,7 +102,7 @@ importers:
         version: 1.0.2
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
-        version: 1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 1.26.0(zod@3.25.76)
       '@neondatabase/serverless':
         specifier: ^1.0.1
         version: 1.0.2
@@ -141,9 +136,12 @@ importers:
       '@openuidev/react-headless':
         specifier: ^0.8.1
         version: 0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))
+      '@openuidev/react-lang':
+        specifier: ^0.2.5
+        version: 0.2.5(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(react@18.3.1)(zod@3.25.76)
       '@openuidev/react-ui':
         specifier: ^0.11.6
-        version: 0.11.6(@openuidev/react-headless@0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)))(@openuidev/react-lang@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))
+        version: 0.11.6(@openuidev/react-headless@0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)))(@openuidev/react-lang@0.2.5(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(react@18.3.1)(zod@3.25.76))(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))
       '@pinecone-database/pinecone':
         specifier: ^7.0.0
         version: 7.0.0
@@ -320,7 +318,7 @@ importers:
         version: 0.5.17
       ai:
         specifier: ^6.0.64
-        version: 6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 6.0.90(zod@3.25.76)
       amqp-connection-manager:
         specifier: latest
         version: 5.0.0(amqplib@2.0.1)
@@ -446,7 +444,7 @@ importers:
         version: 3.38.6
       langsmith:
         specifier: ^0.6.0
-        version: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
+        version: 0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -497,7 +495,7 @@ importers:
         version: 1.0.2(@babel/core@7.28.5)(@babel/template@7.27.2)(@tiptap/extension-code-block@2.27.2(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2))(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(highlight.js@10.7.3)(immer@10.2.0)(lowlight@1.20.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^6.21.0
-        version: 6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
       p-limit:
         specifier: latest
         version: 7.3.0
@@ -625,30 +623,30 @@ importers:
         specifier: ^3.19.0
         version: 3.19.0
       zod:
-        specifier: ^3.24.1
-        version: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@ai-sdk/anthropic':
         specifier: ^3.0.45
-        version: 3.0.45(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.45(zod@3.25.76)
       '@ai-sdk/gateway':
         specifier: ^3.0.49
-        version: 3.0.49(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.49(zod@3.25.76)
       '@ai-sdk/google':
         specifier: ^3.0.29
-        version: 3.0.29(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.29(zod@3.25.76)
       '@ai-sdk/mistral':
         specifier: ^3.0.20
-        version: 3.0.20(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.20(zod@3.25.76)
       '@ai-sdk/openai':
         specifier: ^3.0.28
-        version: 3.0.28(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.28(zod@3.25.76)
       '@ai-sdk/provider':
         specifier: ^3.0.8
         version: 3.0.8
       '@ai-sdk/react':
         specifier: ^3.0.66
-        version: 3.0.92(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.0.92(react@18.3.1)(zod@3.25.76)
       '@jest/globals':
         specifier: ^30.0.5
         version: 30.2.0
@@ -768,7 +766,7 @@ importers:
         version: 7.0.2
       ollama-ai-provider-v2:
         specifier: ^3.3.1
-        version: 3.3.1(ai@6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+        version: 3.3.1(ai@6.0.90(zod@3.25.76))(zod@3.25.76)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -4326,8 +4324,8 @@ packages:
       react: ^18.3.1 || ^19.0.0
       zustand: ^4.5.5
 
-  '@openuidev/react-lang@0.2.4':
-    resolution: {integrity: sha512-DP0NbqI9nhMqK80Ra6kMMtbEdDSh9ZASKsnA/N0FIsO48QZaz4xbHOKXwwAgoFR8kWJcIZ238Hjoqplq9IX/Dw==}
+  '@openuidev/react-lang@0.2.5':
+    resolution: {integrity: sha512-OImhBXUQoIOlHEGc308e0BaJGVHrEA6qWv76xqc71sSQUoaWjn0zhCaGA8qcXGhqYVak4bzIbLikgO+L0Kf3tQ==}
     peerDependencies:
       '@modelcontextprotocol/sdk': '>=1.0.0'
       react: ^18.3.1 || ^19.0.0
@@ -13329,9 +13327,6 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -13387,12 +13382,6 @@ snapshots:
       rxjs: 7.8.1
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@3.0.45(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
-
   '@ai-sdk/anthropic@3.0.45(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -13412,11 +13401,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/deepseek@2.0.20(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/deepseek@2.0.20(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/gateway@2.0.60(zod@3.25.76)':
     dependencies:
@@ -13425,25 +13414,12 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
 
-  '@ai-sdk/gateway@3.0.49(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      '@vercel/oidc': 3.1.0
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
-
   '@ai-sdk/gateway@3.0.49(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       '@vercel/oidc': 3.1.0
       zod: 3.25.76
-
-  '@ai-sdk/google@3.0.29(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
 
   '@ai-sdk/google@3.0.29(zod@3.25.76)':
     dependencies:
@@ -13457,11 +13433,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/mistral@3.0.20(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/mistral@3.0.20(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/openai-compatible@1.0.34(zod@3.25.76)':
     dependencies:
@@ -13469,11 +13445,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai-compatible@2.0.30(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/openai-compatible@2.0.30(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/openai@2.0.100(zod@3.25.76)':
     dependencies:
@@ -13481,11 +13457,11 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@3.0.28(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/openai@3.0.28(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
 
   '@ai-sdk/openai@3.0.47(zod@3.25.76)':
     dependencies:
@@ -13500,26 +13476,12 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
-
   '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 3.25.76
-
-  '@ai-sdk/provider-utils@4.0.21(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
 
   '@ai-sdk/provider-utils@4.0.21(zod@3.25.76)':
     dependencies:
@@ -13536,10 +13498,10 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.92(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/react@3.0.92(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      ai: 6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      ai: 6.0.90(zod@3.25.76)
       react: 18.3.1
       swr: 2.4.0(react@18.3.1)
       throttleit: 2.1.0
@@ -13553,12 +13515,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.22(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/xai@3.0.56(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@ai-sdk/xai@3.0.56(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/openai-compatible': 2.0.30(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@ai-sdk/openai-compatible': 2.0.30(zod@3.25.76)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -13573,11 +13535,11 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@anthropic-ai/sdk@0.74.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@anthropic-ai/sdk@0.74.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -14735,19 +14697,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google/genai@1.42.0(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
-    dependencies:
-      google-auth-library: 10.5.0
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.42.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(bufferutil@4.0.9)(utf-8-validate@6.0.5)':
     dependencies:
       google-auth-library: 10.5.0
@@ -15892,28 +15841,6 @@ snapshots:
 
   '@mixmark-io/domino@2.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.7)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.11.7
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
-      zod-to-json-schema: 3.25.1(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
@@ -17044,11 +16971,11 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
 
-  '@openuidev/lang-core@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@openuidev/lang-core@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      zod: 3.25.76
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
 
   '@openuidev/react-headless@0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))':
     dependencies:
@@ -17056,19 +16983,19 @@ snapshots:
       react: 18.3.1
       zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
 
-  '@openuidev/react-lang@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))':
+  '@openuidev/react-lang@0.2.5(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(react@18.3.1)(zod@3.25.76)':
     dependencies:
-      '@openuidev/lang-core': 0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@openuidev/lang-core': 0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(zod@3.25.76)
       react: 18.3.1
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      zod: 3.25.76
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
 
-  '@openuidev/react-ui@0.11.6(@openuidev/react-headless@0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)))(@openuidev/react-lang@0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))':
+  '@openuidev/react-ui@0.11.6(@openuidev/react-headless@0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)))(@openuidev/react-lang@0.2.5(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(react@18.3.1)(zod@3.25.76))(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@openuidev/react-headless': 0.8.1(react@18.3.1)(zustand@4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1))
-      '@openuidev/react-lang': 0.2.4(@modelcontextprotocol/sdk@1.26.0(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(react@18.3.1)(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@openuidev/react-lang': 0.2.5(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(react@18.3.1)(zod@3.25.76)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-aspect-ratio': 1.1.8(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17099,7 +17026,7 @@ snapshots:
       remark-gfm: 4.0.1
       remark-math: 6.0.0
       tiny-invariant: 1.3.3
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      zod: 3.25.76
       zustand: 4.5.7(@types/react@18.3.26)(immer@10.2.0)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
@@ -19676,13 +19603,13 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
-  ai@6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)):
+  ai@6.0.90(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 3.0.49(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@ai-sdk/gateway': 3.0.49(zod@3.25.76)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.15(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      zod: 3.25.76
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -24014,14 +23941,14 @@ snapshots:
     dependencies:
       langfuse-core: 3.38.6
 
-  langsmith@0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
+  langsmith@0.6.0(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.0))(openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76))(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.217.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      openai: 6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
+      openai: 6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76)
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
 
   language-subtag-registry@0.3.23: {}
@@ -25069,12 +24996,12 @@ snapshots:
       ai: 5.0.156(zod@3.25.76)
       zod: 3.25.76
 
-  ollama-ai-provider-v2@3.3.1(ai@6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)):
+  ollama-ai-provider-v2@3.3.1(ai@6.0.90(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.21(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      ai: 6.0.90(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52))
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
+      '@ai-sdk/provider-utils': 4.0.21(zod@3.25.76)
+      ai: 6.0.90(zod@3.25.76)
+      zod: 3.25.76
 
   on-exit-leak-free@2.1.2: {}
 
@@ -25098,11 +25025,6 @@ snapshots:
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
       zod: 3.25.76
-
-  openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)):
-    optionalDependencies:
-      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
 
   openai@6.21.0(ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@6.0.5))(zod@3.25.76):
     optionalDependencies:
@@ -28142,15 +28064,9 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-to-json-schema@3.25.1(zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)):
-    dependencies:
-      zod: 3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52)
-
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod@3.24.1(patch_hash=99447639c57a97aecf6e33f715d29c14e2e6503bd04dd97ce56ab473d578dc52): {}
 
   zod@3.25.76: {}
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -20,13 +20,15 @@ module.exports = {
     }
   },
   moduleNameMapper: {
+    '^@/lib/(.*)$': '<rootDir>/../lib/$1',
+    '^@/types/(.*)$': '<rootDir>/../types/$1',
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transformIgnorePatterns: [
     'node_modules/(?!uuid)',
   ],
   transform: {
-    '^.+\\.ts$': ['ts-jest', {
+    '^.+\\.(ts|tsx)$': ['ts-jest', {
       tsconfig: {
         esModuleInterop: true,
         allowSyntheticDefaultImports: true,

--- a/server/package.json
+++ b/server/package.json
@@ -69,7 +69,7 @@
     "@types/pdf-parse": "^1.1.5",
     "@types/xml2js": "^0.4.14",
     "adm-zip": "^0.5.16",
-    "ai": "^5.0.116",
+    "ai": "^6.0.64",
     "amqp-connection-manager": "^4.1.5",
     "amqplib": "^0.10.4",
     "archiver": "^7.0.1",

--- a/server/src/__tests__/modules/openuiChat/OpenUIChatController.test.ts
+++ b/server/src/__tests__/modules/openuiChat/OpenUIChatController.test.ts
@@ -20,6 +20,11 @@ jest.mock("../../../lib/project-access", () => ({
   userHasProjectAccess: jest.fn(),
 }))
 
+jest.mock("@/lib/openui/systemPrompt", () => ({
+  buildOpenUISystemPrompt: jest.fn(() => "mock openui system prompt"),
+  buildOpenUIUserMessage: jest.fn((options: { prompt: string }) => options.prompt),
+}))
+
 describe("OpenUIChatController routes", () => {
   const mockedUserHasProjectAccess = jest.mocked(userHasProjectAccess)
 

--- a/server/src/__tests__/modules/openuiChat/OpenUIChatService.test.ts
+++ b/server/src/__tests__/modules/openuiChat/OpenUIChatService.test.ts
@@ -16,6 +16,36 @@ jest.mock("../../../services/aiSearchRAGService", () => ({
   },
 }))
 
+jest.mock("ai", () => ({
+  streamText: jest.fn(),
+}))
+
+jest.mock("@ai-sdk/google", () => ({
+  google: jest.fn(() => "mock-google-model"),
+}))
+
+jest.mock("@/lib/openui/systemPrompt", () => ({
+  buildOpenUISystemPrompt: jest.fn(() => "mock openui system prompt"),
+  buildOpenUIUserMessage: jest.fn((options: { prompt: string; ragContext?: string; projectName?: string }) => {
+    const parts = [options.ragContext, options.projectName ? `Project: ${options.projectName}` : "", options.prompt]
+    return parts.filter(Boolean).join("\n")
+  }),
+}))
+
+import { streamText } from "ai"
+
+const mockedStreamText = jest.mocked(streamText)
+
+function mockLangStream(chunks: string[]) {
+  mockedStreamText.mockResolvedValue({
+    textStream: (async function* () {
+      for (const chunk of chunks) {
+        yield chunk
+      }
+    })(),
+  } as Awaited<ReturnType<typeof streamText>>)
+}
+
 describe("OpenUIChatService", () => {
   const mockedAiSearchRAGService = jest.mocked(aiSearchRAGService)
 
@@ -36,6 +66,7 @@ describe("OpenUIChatService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockLangStream(["<Tabs title=\"Test\" />"])
   })
 
   test("passes the selected project into assisted context assembly", async () => {
@@ -98,7 +129,16 @@ describe("OpenUIChatService", () => {
       }),
       "user-1"
     )
-    await expect(response.text()).resolves.toContain("Scoped project evidence")
+    expect(mockedStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.stringContaining("Scoped project evidence"),
+          }),
+        ],
+      })
+    )
+    await expect(response.text()).resolves.toContain("event: text")
   })
 
   test("rejects blank user content before persisting the thread", async () => {
@@ -168,8 +208,16 @@ describe("OpenUIChatService", () => {
       reportMode: false,
     })
 
-    expect(repository.appendMessage).toHaveBeenCalledTimes(2)
-    await expect(response.text()).resolves.toContain("Project project-1: Fallback prompt")
+    expect(repository.appendMessage).toHaveBeenCalledTimes(1)
+    expect(mockedStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.stringContaining("Fallback prompt"),
+          }),
+        ],
+      })
+    )
   })
 
   test("uses basic project context when report mode has no assisted sources", async () => {
@@ -236,9 +284,17 @@ describe("OpenUIChatService", () => {
     })
 
     expect(projectFallbackLoader).toHaveBeenCalledWith("project-1")
+    expect(mockedStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.stringContaining("Project: Apollo"),
+          }),
+        ],
+      })
+    )
     const payload = await response.text()
-    expect(payload).toContain("Project: Apollo")
-    expect(payload).toContain("Framework: PMBOK 7")
+    expect(payload).toContain("event: text")
     expect(payload).not.toContain("No internal ADPA search context was found")
   })
 

--- a/server/src/__tests__/modules/openuiChat/OpenUIChatService.test.ts
+++ b/server/src/__tests__/modules/openuiChat/OpenUIChatService.test.ts
@@ -21,7 +21,7 @@ jest.mock("ai", () => ({
 }))
 
 jest.mock("@ai-sdk/google", () => ({
-  google: jest.fn(() => "mock-google-model"),
+  createGoogleGenerativeAI: jest.fn(() => jest.fn(() => "mock-google-model")),
 }))
 
 jest.mock("@/lib/openui/systemPrompt", () => ({

--- a/server/src/modules/openuiChat/OpenUIChatController.ts
+++ b/server/src/modules/openuiChat/OpenUIChatController.ts
@@ -26,8 +26,9 @@ export class OpenUIChatController {
       return res.status(401).json({ error: "Unauthorized" })
     }
 
-    const { projectId, threadId, messages } = req.body as {
+    const { projectId, documentId, threadId, messages } = req.body as {
       projectId?: string
+      documentId?: string
       threadId?: string
       messages?: OpenUIChatRequestMessage[]
     }
@@ -50,6 +51,7 @@ export class OpenUIChatController {
     const streamResponse = await this.service.streamReply({
       user,
       projectId,
+      documentId,
       threadId,
       message: submittedMessage,
       reportMode,

--- a/server/src/modules/openuiChat/OpenUIChatService.ts
+++ b/server/src/modules/openuiChat/OpenUIChatService.ts
@@ -5,8 +5,9 @@ import { NotFoundError, ValidationError } from "../../middleware/errorHandler"
 import aiSearchRAGService from "../../services/aiSearchRAGService"
 import { logger } from "../../utils/logger"
 import { OpenUIChatRepository, type OpenUIChatJson, type OpenUIChatThreadSummary, type OpenUIChatThread } from "./OpenUIChatRepository"
-import { google } from "@ai-sdk/google"
+import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { streamText } from "ai"
+import { GOOGLE_PRIMARY_MODEL, normalizeGoogleModelId } from "../../utils/googleModelConfig"
 
 export type OpenUIChatRequestMessage = {
   role: string
@@ -147,10 +148,10 @@ export class OpenUIChatService {
 
     try {
       const result = await streamText({
-        model: google("gemini-2.0-flash"),
+        model: resolveOpenUIGoogleModel(),
         system: systemPrompt,
         messages: [{ role: "user", content: userMessage }],
-        maxTokens: 8192,
+        maxOutputTokens: 16384,
         temperature: 0.1,
       })
 
@@ -261,6 +262,19 @@ export function extractMessageText(content: OpenUIChatJson): string {
   return ""
 }
 
+function resolveOpenUIGoogleModel() {
+  const apiKey =
+    process.env.GOOGLE_AI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY
+  if (!apiKey) {
+    throw new Error("GOOGLE_AI_API_KEY is not configured")
+  }
+
+  const requestedModel = process.env.GEMINI_MODEL_OVERRIDE ?? GOOGLE_PRIMARY_MODEL
+  const modelId = normalizeGoogleModelId(requestedModel)
+  const google = createGoogleGenerativeAI({ apiKey })
+  return google(modelId)
+}
+
 function buildThreadTitle(prompt: string): string {
   const normalized = prompt.replace(/\s+/g, " ").trim()
   if (!normalized) return "New thread"
@@ -302,8 +316,8 @@ async function loadDocumentContext(documentId: string, projectId: string): Promi
         ? JSON.stringify(rawContent)
         : ""
 
-    // Allow up to 24,000 chars (~6,000 tokens) — enough for a full charter
-    const TRUNCATE_AT = 24_000
+    // Large input budget so reports can include full document text (model output capped separately)
+    const TRUNCATE_AT = 48_000
     const truncated = text.length > TRUNCATE_AT
       ? text.slice(0, TRUNCATE_AT) + "\n\n[...content truncated for context window...]"
       : text

--- a/server/src/modules/openuiChat/OpenUIChatService.ts
+++ b/server/src/modules/openuiChat/OpenUIChatService.ts
@@ -1,11 +1,12 @@
 import type { AuthenticatedUser } from "@/lib/auth-utils"
-import { selectComponentType, type ComponentSelectionContext } from "@/lib/openui/componentSelector"
-import type { ComponentPayload } from "@/lib/openui/library"
+import { buildOpenUISystemPrompt, buildOpenUIUserMessage } from "@/lib/openui/systemPrompt"
 import { pool } from "../../database/connection"
 import { NotFoundError, ValidationError } from "../../middleware/errorHandler"
 import aiSearchRAGService from "../../services/aiSearchRAGService"
 import { logger } from "../../utils/logger"
 import { OpenUIChatRepository, type OpenUIChatJson, type OpenUIChatThreadSummary, type OpenUIChatThread } from "./OpenUIChatRepository"
+import { google } from "@ai-sdk/google"
+import { streamText } from "ai"
 
 export type OpenUIChatRequestMessage = {
   role: string
@@ -19,6 +20,7 @@ export type OpenUIChatUserMessage = OpenUIChatRequestMessage & {
 export type StreamReplyInput = {
   user: AuthenticatedUser
   projectId: string
+  documentId?: string
   threadId?: string
   message: OpenUIChatUserMessage
   reportMode: boolean
@@ -51,7 +53,7 @@ export class OpenUIChatService {
       throw new ValidationError("message content is required")
     }
 
-    const title = buildThreadTitle(latestText, input.reportMode)
+    const title = buildThreadTitle(latestText)
 
     if (input.threadId) {
       const existingThread = await this.repository.getThread(input.threadId, input.user.id, input.projectId)
@@ -69,77 +71,152 @@ export class OpenUIChatService {
       content: input.message.content,
     })
 
-    let context = null
-    if (latestText) {
+    // Load document content if a specific document is requested
+    let documentContext: DocumentContext | null = null
+    if (input.documentId) {
+      documentContext = await loadDocumentContext(input.documentId, input.projectId)
+      if (documentContext) {
+        logger.info("[OPENUI-CHAT] Document context loaded", {
+          documentId: input.documentId,
+          documentName: documentContext.name,
+          contentLength: documentContext.content.length,
+        })
+      }
+    }
+
+    // Run RAG if no document is attached
+    let ragContext: string | undefined
+    if (!documentContext && latestText) {
       try {
-        context = await aiSearchRAGService.assembleContext(
+        const context = await aiSearchRAGService.assembleContext(
           {
             query: latestText,
-            limit: input.reportMode ? 12 : 10,
+            limit: 12,
             offset: 0,
             sortBy: "relevance",
             includeRelationships: true,
             relationshipDepth: 2,
             includeKnowledgeBase: true,
-            maxContextItems: input.reportMode ? 10 : 8,
+            maxContextItems: 10,
             projectIds: [input.projectId],
           },
           input.user.id
         )
+        if (context?.contextPrompt && !context.contextPrompt.startsWith("No internal ADPA search context")) {
+          ragContext = context.contextPrompt
+        }
       } catch (error) {
-        logger.warn("[OPENUI-CHAT] Assisted context assembly failed", {
+        logger.warn("[OPENUI-CHAT] RAG context assembly failed", {
           projectId: input.projectId,
-          userId: input.user.id,
-          threadId: input.threadId,
           error: error instanceof Error ? error.message : String(error),
         })
       }
     }
 
-    // Load fallback context if RAG returned nothing
-    const fallbackProjectContext =
-      input.reportMode && (!context || context.sources.length === 0)
-        ? await this.loadProjectContextFallback(input.projectId)
-        : null
-
-    // Determine best component type for this context
-    const selectionContext: ComponentSelectionContext = {
-      prompt: latestText,
-      dataPoints: context?.sources.length || 0,
-      domainContext: fallbackProjectContext?.framework || undefined,
+    // Load project fallback for context when no document/RAG
+    let fallbackProjectContext: ProjectContextFallback | null = null
+    if (!documentContext && !ragContext) {
+      fallbackProjectContext = await this.loadProjectContextFallback(input.projectId)
     }
 
-    const componentType = selectComponentType(selectionContext)
+    const threadId = userEntry?.thread.id ?? input.threadId ?? null
 
-    // Build structured payload
-    const assistantPayload = buildAssistantPayload({
-      projectId: input.projectId,
-      threadId: userEntry?.thread.id ?? input.threadId ?? null,
+    // Build the system prompt and user message
+    const systemPrompt = buildOpenUISystemPrompt({
+      documentName: documentContext?.name,
+      documentType: documentContext?.templateName ?? undefined,
+    })
+
+    const userMessage = buildOpenUIUserMessage({
       prompt: latestText,
-      componentType,
-      reportMode: input.reportMode,
-      contextPrompt: context?.contextPrompt,
-      sourceCount: context?.sources.length ?? 0,
-      fallbackProjectContext,
+      documentContent: documentContext?.content,
+      documentName: documentContext?.name,
+      ragContext,
+      projectName: fallbackProjectContext?.name,
+      projectDescription: fallbackProjectContext?.description ?? undefined,
     })
 
-    await this.appendMessageOrThrowNotFound({
-      threadId: userEntry?.thread.id ?? input.threadId ?? null,
-      userId: input.user.id,
+    // Stream OpenUI Lang from the LLM
+    logger.info("[OPENUI-CHAT] Streaming OpenUI Lang from LLM", {
       projectId: input.projectId,
-      title,
-      role: "assistant",
-      content: assistantPayload,
+      documentId: input.documentId,
+      hasDocumentContext: !!documentContext,
+      hasRagContext: !!ragContext,
+      contentLength: documentContext?.content?.length ?? 0,
     })
 
-    return new Response(createSsePayload(assistantPayload), {
-      status: 200,
-      headers: {
-        "cache-control": "no-cache",
-        connection: "keep-alive",
-        "content-type": "text/event-stream",
-      },
-    })
+    try {
+      const result = await streamText({
+        model: google("gemini-2.0-flash"),
+        system: systemPrompt,
+        messages: [{ role: "user", content: userMessage }],
+        maxTokens: 8192,
+        temperature: 0.1,
+      })
+
+      // Accumulate the full response to save to DB after streaming
+      let fullResponse = ""
+
+      const encoder = new TextEncoder()
+      const stream = new ReadableStream({
+        async start(controller) {
+          try {
+            for await (const chunk of result.textStream) {
+              fullResponse += chunk
+              // Stream each chunk as SSE text event
+              const sseChunk = `event: text\ndata: ${JSON.stringify({ text: chunk, threadId })}\n\n`
+              controller.enqueue(encoder.encode(sseChunk))
+            }
+            // Send done event with final threadId
+            const doneEvent = `event: done\ndata: ${JSON.stringify({ threadId, length: fullResponse.length })}\n\n`
+            controller.enqueue(encoder.encode(doneEvent))
+            controller.close()
+
+            // Persist the full assistant response (OpenUI Lang text) to DB
+            try {
+              await new OpenUIChatRepository().appendMessage({
+                threadId,
+                userId: input.user.id,
+                projectId: input.projectId,
+                title,
+                role: "assistant",
+                content: fullResponse,
+              })
+              logger.info("[OPENUI-CHAT] Saved OpenUI Lang response to DB", {
+                threadId,
+                responseLength: fullResponse.length,
+              })
+            } catch (dbError) {
+              logger.warn("[OPENUI-CHAT] Failed to save assistant response to DB", {
+                error: dbError instanceof Error ? dbError.message : String(dbError),
+              })
+            }
+          } catch (streamError) {
+            logger.error("[OPENUI-CHAT] LLM stream error", {
+              error: streamError instanceof Error ? streamError.message : String(streamError),
+            })
+            const errEvent = `event: error\ndata: ${JSON.stringify({ message: "LLM stream failed" })}\n\n`
+            controller.enqueue(encoder.encode(errEvent))
+            controller.close()
+          }
+        },
+      })
+
+      return new Response(stream, {
+        status: 200,
+        headers: {
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+          "content-type": "text/event-stream",
+          "x-thread-id": threadId ?? "",
+        },
+      })
+    } catch (error) {
+      logger.error("[OPENUI-CHAT] Failed to start LLM stream", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      throw error
+    }
   }
 
   private async appendMessageOrThrowNotFound(
@@ -184,11 +261,9 @@ export function extractMessageText(content: OpenUIChatJson): string {
   return ""
 }
 
-function buildThreadTitle(prompt: string, reportMode: boolean): string {
+function buildThreadTitle(prompt: string): string {
   const normalized = prompt.replace(/\s+/g, " ").trim()
-  if (!normalized) {
-    return reportMode ? "Project report" : "New thread"
-  }
+  if (!normalized) return "New thread"
   return normalized.slice(0, 80)
 }
 
@@ -196,79 +271,57 @@ function isThreadNotFoundError(error: unknown): boolean {
   return error instanceof Error && error.message === "OpenUI chat thread not found"
 }
 
-function buildAssistantPayload(input: {
-  projectId: string
-  threadId: string | null
-  prompt: string
-  componentType: string
-  reportMode: boolean
-  contextPrompt?: string
-  sourceCount: number
-  fallbackProjectContext?: ProjectContextFallback | null
-}): OpenUIChatJson {
-  const synopsis =
-    input.contextPrompt && !input.contextPrompt.startsWith("No internal ADPA search context was found")
-      ? input.contextPrompt.slice(0, 500)
-      : buildFallbackSynopsis(input.fallbackProjectContext, input.prompt, input.reportMode)
+type DocumentContext = {
+  name: string
+  content: string
+  templateName: string | null
+  framework: string | null
+}
 
-  if (input.reportMode) {
+async function loadDocumentContext(documentId: string, projectId: string): Promise<DocumentContext | null> {
+  try {
+    const result = await pool.query<{
+      name: string
+      content: string | null
+      template_name: string | null
+      template_framework: string | null
+    }>(
+      `SELECT d.name, d.content, t.name AS template_name, t.framework AS template_framework
+       FROM documents d
+       LEFT JOIN templates t ON t.id = d.template_id
+       WHERE d.id = $1 AND d.project_id = $2 AND d.deleted_at IS NULL
+       LIMIT 1`,
+      [documentId, projectId]
+    )
+    const row = result.rows[0]
+    if (!row) return null
+    const rawContent = row.content
+    const text = typeof rawContent === "string"
+      ? rawContent
+      : rawContent != null
+        ? JSON.stringify(rawContent)
+        : ""
+
+    // Allow up to 24,000 chars (~6,000 tokens) — enough for a full charter
+    const TRUNCATE_AT = 24_000
+    const truncated = text.length > TRUNCATE_AT
+      ? text.slice(0, TRUNCATE_AT) + "\n\n[...content truncated for context window...]"
+      : text
+
     return {
-      type: "report",
-      component: "ReportOverview",
-      props: {
-        title: "Project charter report",
-        projectId: input.projectId,
-        threadId: input.threadId,
-        prompt: input.prompt,
-        supportingEvidence: input.sourceCount,
-        synopsis,
-      },
+      name: row.name,
+      content: truncated,
+      templateName: row.template_name ?? null,
+      framework: row.template_framework ?? null,
     }
+  } catch (error) {
+    logger.warn("[OPENUI-CHAT] Document context lookup failed", {
+      documentId,
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return null
   }
-
-  const payload: ComponentPayload = {
-    type: "component",
-    component: input.componentType as any,
-    props: {
-      title: `${input.componentType} view`,
-      projectId: input.projectId,
-      threadId: input.threadId,
-      prompt: input.prompt,
-      supportingEvidence: input.sourceCount,
-      synopsis,
-    },
-    metadata: {
-      supportingEvidence: input.sourceCount,
-      prompt: input.prompt,
-      synopsis,
-    },
-  }
-
-  return payload as unknown as OpenUIChatJson
-}
-
-function createSsePayload(payload: OpenUIChatJson): string {
-  return `event: message\ndata: ${JSON.stringify(payload)}\n\n`
-}
-
-function buildFallbackSynopsis(
-  fallbackProjectContext: ProjectContextFallback | null | undefined,
-  prompt: string,
-  reportMode: boolean
-): string {
-  if (!fallbackProjectContext) {
-    return "No supporting context available."
-  }
-
-  const description = fallbackProjectContext.description?.trim() || "No description available."
-  const framework = fallbackProjectContext.framework?.trim() || "Framework not set"
-
-  return [
-    `Project: ${fallbackProjectContext.name}`,
-    `Framework: ${framework}`,
-    `Description: ${description}`,
-    reportMode ? `Requested report: ${prompt}` : `Requested: ${prompt}`,
-  ].join("\n")
 }
 
 async function defaultProjectContextFallbackLoader(projectId: string): Promise<ProjectContextFallback | null> {
@@ -278,24 +331,12 @@ async function defaultProjectContextFallbackLoader(projectId: string): Promise<P
       description: string | null
       framework: string | null
     }>(
-      `
-        SELECT name, description, framework
-        FROM projects
-        WHERE id = $1
-      `,
+      `SELECT name, description, framework FROM projects WHERE id = $1`,
       [projectId]
     )
-
     const row = result.rows[0]
-    if (!row) {
-      return null
-    }
-
-    return {
-      name: row.name,
-      description: row.description,
-      framework: row.framework,
-    }
+    if (!row) return null
+    return { name: row.name, description: row.description, framework: row.framework }
   } catch (error) {
     logger.warn("[OPENUI-CHAT] Project context fallback lookup failed", {
       projectId,


### PR DESCRIPTION
## Summary

- Integrates **`@openuidev/react-lang`** end-to-end: `defineComponent` + `createLibrary`, `library.prompt()` system instructions, and `<Renderer>` on the client.
- **Backend** streams OpenUI Lang text via SSE (`event: text` / `event: done`) using Gemini 2.0 Flash instead of static JSON `buildAssistantPayload` payloads.
- **Frontend** parses the text stream progressively; document dashboard at `/projects/[id]/documents/ui` with auto-visualize; legacy JSON payloads still render for older threads.
- Upgrades **Zod to 3.25.76** and imports from `zod/v4` (required by OpenUI); removes the obsolete `zod@3.24.1` patch.

## Test plan

- [ ] `pnpm install -w` then `cd server && pnpm dev` — server starts without Zod/OpenUI library errors
- [ ] `pnpm dev --port 3000` — open a project document → **UI Chat** → verify streaming tabs/tables/charts from real document content
- [ ] Open `/ai/openui-chat` — send a prompt and confirm components render while streaming
- [ ] `cd server && npx jest --testPathPattern=openuiChat` (requires test DB)
- [ ] Confirm `GOOGLE_GENERATIVE_AI_API_KEY` (or configured Gemini provider) is set for LLM generation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mdresch/adpa/pull/687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->