### PR TITLE
Fix Health Check script path in server README

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -63,7 +63,7 @@ cp .env.example .env
 The server uses Jest for testing. We have implemented a stabilized test harness that isolates top-level side effects.
 
 - **[Testing Guide](docs/TESTING_GUIDE.md)**: Detailed documentation on architecture, mocks, and guards.
-- **Health Check**: Run `.\scripts\verify-test-env.ps1` to verify your test environment.
+- **Health Check**: Run `./scripts/verify-test-env.ps1` to verify your test environment.
 
 ```bash
 # Run all tests


### PR DESCRIPTION
### Motivation
- Correct the Health Check instruction in `server/README.md` to use a POSIX-style path so the command displays correctly and avoids confusion across environments.

### Description
- Replace `.\scripts\verify-test-env.ps1` with `./scripts/verify-test-env.ps1` in the Testing section of `server/README.md`.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02135d2f048326bbbbc77aa84032d7)