### PR TITLE
feat(genui): render OpenUI Lang, workspace UX, and maintenance docs

### DIFF
--- a/.agents/skills/adpa-genui-workspace/SKILL.md
+++ b/.agents/skills/adpa-genui-workspace/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: adpa-genui-workspace
+description: Maintain and extend the ADPA document GenUI workspace (split-pane document + OpenUI advisor). Use when editing genui pages, OpenUI Lang rendering, document chat prompts, Mistral /api/chat, or expanding structured UI from governance documents.
+---
+
+# ADPA Document GenUI Workspace
+
+The **document GenUI workspace** is a split-pane experience: **Step 1** shows extracted document text; **Step 2** is an OpenUI `FullScreen` chat that can render **OpenUI Lang** into interactive UI (cards, tables, charts, tabs, steps).
+
+This is **not** the same as project-scoped **OpenUI Chat** (`/openui-chat`, `/api/v1/openui-chat`). Do not conflate the two stacks when debugging or extending features.
+
+## When to use this skill
+
+- Editing `app/projects/[id]/documents/genui/**`
+- Fixing raw `openui-lang` code showing instead of rendered components
+- Changing layout, theme, conversation starters, or toolbar navigation
+- Wiring new LLM behavior, RAG, or thread persistence for document chat
+- Adding document-type-specific prompts or GenUI output patterns
+
+Also read (design context, different surfaces):
+
+- `docs/codedocs/genui-workspace.md` — human-readable codedoc (mirrors this skill)
+- `docs/superpowers/specs/2026-05-14-openui-chat-design.md` — GenUI strategy for project OpenUI chat
+- `docs/superpowers/specs/2026-05-18-genui-personalized-dashboards-design.md` — future PM dashboards (out of scope for this page v1)
+- `docs/codedocs/openui-chat.md` — backend OpenUI chat module (threads, SSE); **not** the document workspace HTTP path
+
+## Routes and navigation
+
+| Item | Location |
+|------|----------|
+| Canonical URL | `/projects/{projectId}/documents/genui?docId={documentId}` |
+| URL helper | `lib/documents/document-routes.ts` → `getProjectDocumentGenUIPath()` |
+| Legacy nested route | `app/projects/[id]/documents/[docId]/genui/` may exist for old links; IDs resolve via `useProjectDocumentRouteIds()` |
+| Toolbar entry | `components/documents/DocumentPageToolbar.tsx` — mode `genui`, **GenUI** button from view/source/report |
+
+## Architecture (data flow)
+
+```mermaid
+flowchart LR
+  subgraph step1 [Step 1 - Source]
+    API["GET /api/v1/documents/..."]
+    Pane[Source pane - doc.content]
+  end
+  subgraph step2 [Step 2 - Advisor]
+    FS[FullScreen OpenUI]
+    CAM[CustomAssistantMessage]
+    DCR[DynamicComponentRenderer]
+    RL[Renderer + openuiLibrary]
+  end
+  subgraph proxy [Next.js]
+    Chat["POST /api/chat"]
+  end
+  subgraph llm [LLM]
+    Mistral[Mistral stream]
+  end
+  API --> Pane
+  Pane -->|systemPrompt embeds content| FS
+  FS --> Chat
+  Chat -->|systemPrompt set| Mistral
+  Mistral -->|OpenUI Lang text stream| FS
+  FS --> CAM
+  CAM --> DCR --> RL
+```
+
+### Request path (critical)
+
+1. `page.tsx` builds `systemPrompt` from `openuiLibrary.prompt(openuiPromptOptions)` plus **full document body** and metadata.
+2. `FullScreen` calls `POST /api/chat` with `{ systemPrompt, messages }` only (no `projectId` in current implementation).
+3. `app/api/chat/route.ts`: if `systemPrompt` is a non-empty string → **Mistral** streaming (`MISTRAL_API_KEY`, `MISTRAL_MODEL`). Otherwise → proxy to backend `openui-chat`.
+4. Assistant replies should be **OpenUI Lang** (e.g. `root = Stack([...])`), optionally wrapped in ` ```openui-lang ` fences.
+
+### Rendering path (critical)
+
+| Piece | Role |
+|-------|------|
+| `componentLibrary={openuiLibrary}` on `FullScreen` | OpenUI package components (`@openuidev/react-ui/genui-lib`) |
+| `assistantMessage={CustomAssistantMessage}` | **Overrides** default assistant UI — must render Lang itself |
+| `components/openui-chat/AssistantMessage.tsx` | Detects Lang → `DynamicComponentRenderer` with **`openuiLibrary`** |
+| `components/openui-chat/DynamicComponentRenderer.tsx` | `Renderer` from `@openuidev/react-lang`; optional `library` prop (default `adpaLibrary` elsewhere) |
+| `lib/openui/library.ts` | `extractOpenUILangText()`, `looksLikeOpenUILang()` |
+
+**Pitfall:** If `CustomAssistantMessage` only uses `MarkDownRenderer`, users see a fenced code block instead of Cards/Tables/Charts. Always route OpenUI Lang through `Renderer` + `openuiLibrary`.
+
+**Pitfall:** Using `adpaLibrary` in the document workspace renders wrong or empty components. Use `openuiLibrary` from `@openuidev/react-ui/genui-lib`.
+
+## Source map
+
+| Concern | Files |
+|---------|--------|
+| Main page | `app/projects/[id]/documents/genui/page.tsx` |
+| Workspace theme / OpenUI shell CSS | `app/projects/[id]/documents/genui/genui-workspace.css` |
+| Error boundary | `app/projects/[id]/documents/genui/error.tsx` |
+| Chat API (Mistral branch) | `app/api/chat/route.ts` |
+| Re-export for imports | `components/Chat/AssistantMessage.tsx` → `openui-chat/AssistantMessage.tsx` |
+| Lang utilities | `lib/openui/library.ts` |
+| Conversation starters | `lib/documents/document-chat-prompts.ts` |
+| Document toolbar / nav | `components/documents/DocumentPageToolbar.tsx` |
+| Route IDs (query vs path) | `lib/documents/use-project-document-route-ids.ts` |
+
+### Related (different product surface)
+
+| Concern | Files |
+|---------|--------|
+| Project OpenUI chat page | `app/openui-chat/`, `components/openui-chat/openui-chat-shell.tsx` |
+| Backend threads + RAG chat | `server/src/modules/openuiChat/` |
+| ADPA-specific legacy components | `lib/openui/` (e.g. `adpaLibrary` in renderer) |
+
+## Environment variables
+
+Set in **`.env.local`** (see `.env.local.example`):
+
+| Variable | Required for Step 2 | Notes |
+|----------|---------------------|--------|
+| `MISTRAL_API_KEY` | Yes | Without it, `/api/chat` returns 503 for GenUI |
+| `MISTRAL_MODEL` | No | Defaults to `mistral-large-latest` |
+| `BACKEND_URL` | Step 1 + auth | Document fetch uses Express API via Next proxy |
+| Firebase / `auth_token` cookie | Yes | Page requires authenticated user |
+
+GenUI workspace does **not** currently persist threads to `openui_chat_threads`. **New chat** remounts `FullScreen` via `chatSessionKey` (client-only reset).
+
+## UI conventions
+
+- **Theme:** Light workspace (`genui-workspace` root). OpenUI default CSS: `@openuidev/react-ui/defaults.css`, `components.css`.
+- **Layout:** 50/50 split; OpenUI root uses `.genui-openui-root` overrides (hide sidebar, panel-sized viewport, centered chat).
+- **Session:** `chatSessionKey` increments on **New chat**; resets when `documentId` changes.
+- **Copy:** Toolbar copies raw `doc.content` (Step 1 body), not chat transcript.
+
+When changing styles, prefer `genui-workspace.css` and existing Tailwind tokens (`slate-*`, `violet-*`) over editing OpenUI package CSS.
+
+## Extending features (safe patterns)
+
+### Add conversation starters
+
+Edit `lib/documents/document-chat-prompts.ts` — keyword buckets on document name/template. Keep prompts **grounded** (“from this document”, “table”, “timeline”) so the model uses Step 1 content.
+
+### Change system instructions
+
+Edit the `systemPrompt` template in `page.tsx` after `openuiLibrary.prompt(openuiPromptOptions)`. Keep document body injection; do not move secrets to the client.
+
+### Add new OpenUI components
+
+1. Prefer components already in `@openuidev/react-ui/genui-lib` / OpenUI Lang syntax (`Card`, `Table`, `BarChart`, `Tabs`, `Steps`, etc.).
+2. For ADPA-only widgets, extend `lib/openui` and pass a custom `library` into `DynamicComponentRenderer` — only if product requires ADPA components on **this** page.
+3. Consult OpenUI / `@openuidev` docs (context7 MCP) for Lang grammar — do not invent syntax.
+
+### Persist chat threads (future)
+
+Today: ephemeral `FullScreen` state. To persist:
+
+- Either extend `POST /api/chat` to accept `projectId` + `documentId` and store in `openui_chat_messages`, or
+- Add dedicated `document_genui_threads` tables — do not break existing `openui-chat` contract without migration design.
+
+### Add RAG beyond inline document text
+
+Current grounding is **full `doc.content` in system prompt**. For large documents, consider chunk retrieval from existing RAG services (`server` search/RAG modules) and inject a truncated context block — watch token limits on Mistral.
+
+### Second route alias
+
+If adding `documents/[docId]/genui`, re-export the same page component or redirect to `?docId=` so `useProjectDocumentRouteIds()` stays the single ID resolver.
+
+## Manual verification checklist
+
+After any GenUI workspace change:
+
+1. Start backend + frontend (`AGENTS.md`); ensure logged in.
+2. Open `/projects/{id}/documents/genui?docId={uuid}` for a document with body text.
+3. **Step 1:** Title, metrics, extracted text visible.
+4. **Step 2:** Welcome + conversation starters; chat input at bottom, centered in panel.
+5. Send a starter (e.g. “Show all risks as a table”) — response renders **UI components**, not a raw `openui-lang` code fence.
+6. **View source** on assistant message toggles Lang source; **Show rendered** restores UI.
+7. **New chat** clears thread; switching document in toolbar loads new doc + resets chat.
+8. Toolbar: View / Source / Report / GenUI navigation works; Copy copies document text.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|----------------|-----|
+| Raw OpenUI Lang code block | `CustomAssistantMessage` markdown-only path | Ensure `looksLikeOpenUILang` + `DynamicComponentRenderer` + `openuiLibrary` |
+| Empty or broken widgets | Wrong library (`adpaLibrary`) | Pass `openuiLibrary` to renderer |
+| 503 on chat | Missing `MISTRAL_API_KEY` | Set in `.env.local`, restart Next |
+| 401 on chat | No auth cookie | Log in via Firebase/demo |
+| Step 1 empty | Document API / permissions | Check `GET` document by project + id |
+| Chat off-center / sidebar bleed | CSS overrides | `genui-workspace.css` `.genui-openui-root` rules |
+| Model ignores document | Weak prompt or empty `doc.content` | Strengthen CRITICAL CONTEXT block; verify fetch |
+| Stream stalls | Mistral/network | Check server logs for `[FRONTEND-PROXY] OpenUI chat error` |
+
+## Agent workflow
+
+1. Load this skill before editing GenUI workspace files.
+2. Follow `adpa-aev-workflow` for scoped changes (one concern per change when possible).
+3. Do not modify `server/src/modules/openuiChat` for document-only UI unless explicitly wiring persistence or RAG.
+4. After edits, run manual checklist above; do not claim “renders correctly” without user confirmation on a real document.
+
+## Expansion backlog (documented intent)
+
+Track larger work in specs/issues; typical next steps:
+
+- Thread persistence per `projectId` + `documentId`
+- Token-aware context (chunk RAG vs full-body prompt)
+- Export rendered GenUI / report to PDF from workspace
+- Document-type templates mapping to OpenUI Lang patterns
+- Align with `2026-05-18-genui-personalized-dashboards-design.md` when PM dashboards ship (separate route)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,18 @@ The Next.js frontend proxies `/api/*` requests to the backend via `next.config.m
 ### Build Scripts Approval
 
 The `pnpm.onlyBuiltDependencies` field in root `package.json` controls which packages can run postinstall scripts. Key packages that need it: `puppeteer`, `sharp`, `esbuild`.
+
+### Document GenUI workspace
+
+Split-pane page for governance documents: source text (left) + OpenUI advisor (right) at `/projects/{projectId}/documents/genui?docId={documentId}`.
+
+| Topic | Detail |
+| --- | --- |
+| **Agent skill (maintain/extend)** | `.agents/skills/adpa-genui-workspace/SKILL.md` — architecture, file map, env vars, rendering pitfalls, checklist |
+| **Human codedoc** | `docs/codedocs/genui-workspace.md` (linked from `docs/codedocs/index.md` as `/docs/genui-workspace`) |
+| **Not the same as** | Project OpenUI Chat (`/openui-chat`, `server/src/modules/openuiChat`) — different API and persistence |
+| **Step 2 LLM** | `POST /api/chat` with `systemPrompt` → Mistral (`MISTRAL_API_KEY`, `MISTRAL_MODEL` in `.env.local`) |
+| **Rendering** | OpenUI Lang via `CustomAssistantMessage` + `openuiLibrary` (`@openuidev/react-ui/genui-lib`); see skill for `assistantMessage` override pitfall |
+| **Key files** | `app/projects/[id]/documents/genui/page.tsx`, `genui-workspace.css`, `app/api/chat/route.ts`, `components/openui-chat/AssistantMessage.tsx` |
+
+Load the skill before changing GenUI layout, prompts, chat proxy, or structured UI output.

--- a/app/projects/[id]/documents/genui/genui-workspace.css
+++ b/app/projects/[id]/documents/genui/genui-workspace.css
@@ -1,0 +1,99 @@
+/* GenUI workspace: OpenUI chat expects a light surface; isolate from app dark theme tokens. */
+.genui-workspace {
+  background-color: rgb(248 250 252);
+  color: rgb(15 23 42);
+}
+
+.genui-workspace .genui-source-pane {
+  background-color: #fff;
+  color: rgb(15 23 42);
+}
+
+.genui-workspace .genui-muted {
+  color: rgb(71 85 105);
+}
+
+.genui-workspace .genui-body-text {
+  color: rgb(30 41 59);
+}
+
+.genui-openui-root {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  color-scheme: light;
+  background-color: #fff;
+  color: rgb(15 23 42);
+}
+
+/* FullScreen defaults to full viewport; constrain to Step 2 panel */
+.genui-openui-root .openui-shell-container {
+  position: absolute !important;
+  inset: 0;
+  height: 100% !important;
+  width: 100% !important;
+  max-height: 100%;
+  max-width: 100%;
+}
+
+/* Hide thread sidebar in embedded document workspace so chat centers in the pane */
+.genui-openui-root .openui-shell-sidebar-container,
+.genui-openui-root .openui-shell-sidebar-container__overlay {
+  display: none !important;
+}
+
+.genui-openui-root .openui-shell-thread-wrapper,
+.genui-openui-root .openui-shell-thread-container {
+  width: 100%;
+  height: 100%;
+}
+
+.genui-openui-root .openui-shell-thread-chat-panel {
+  flex: 1 1 auto !important;
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100%;
+}
+
+.genui-openui-root .openui-shell-welcome-screen,
+.genui-openui-root .openui-shell-thread-messages,
+.genui-openui-root .openui-shell-conversation-starter,
+.genui-openui-root .openui-shell-thread-composer {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.genui-openui-root .openui-shell-welcome-screen__desktop-starters
+  .openui-shell-conversation-starter--long {
+  align-items: stretch;
+}
+
+/* GenUI Lang layout: use full panel width, center content block */
+.genui-openui-root .genui-lang-render,
+.genui-openui-root .openui-shell-thread-messages {
+  width: 100%;
+  max-width: 100%;
+}
+
+.genui-openui-root .openui-shell-thread-scroll-area {
+  padding-left: var(--openui-space-m);
+  padding-right: var(--openui-space-m);
+}
+
+.dark .genui-workspace,
+.dark .genui-workspace .genui-source-pane,
+.dark .genui-workspace .genui-openui-root {
+  color: rgb(15 23 42);
+}
+
+.dark .genui-workspace .genui-muted {
+  color: rgb(71 85 105);
+}
+
+.dark .genui-workspace .genui-body-text {
+  color: rgb(30 41 59);
+}

--- a/app/projects/[id]/documents/genui/page.tsx
+++ b/app/projects/[id]/documents/genui/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
+import "@openuidev/react-ui/defaults.css";
+import "@openuidev/react-ui/components.css";
+import "./genui-workspace.css";
 import { FullScreen } from "@openuidev/react-ui";
 import { openAIMessageFormat, openAIReadableStreamAdapter } from "@openuidev/react-headless";
 import { openuiLibrary, openuiPromptOptions } from "@openuidev/react-ui/genui-lib";
@@ -12,12 +14,27 @@ import { Header } from "@/components/header";
 import { PageTransition } from "@/components/page-transition";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, ArrowLeft, FileText, AlertCircle, RefreshCw } from "lucide-react";
+import {
+  DocumentPageToolbar,
+  type DocumentSummary,
+} from "@/components/documents/DocumentPageToolbar";
+import {
+  Loader2,
+  ArrowLeft,
+  FileText,
+  AlertCircle,
+  RefreshCw,
+  Copy,
+  Check,
+  Sparkles,
+  MessageSquare,
+  Plus,
+} from "lucide-react";
+import { getDocumentChatPrompts } from "@/lib/documents/document-chat-prompts";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiClient } from "@/lib/api";
 import { toast } from "@/lib/notify";
 import { CustomAssistantMessage } from "@/components/Chat/AssistantMessage";
-import { getProjectDocumentViewPath } from "@/lib/documents/document-routes";
 import { useProjectDocumentRouteIds } from "@/lib/documents/use-project-document-route-ids";
 
 interface DocumentData {
@@ -37,16 +54,42 @@ export default function DocumentGenUIWorkspace() {
   const { isAuthenticated, loading: authLoading } = useAuth();
   const { projectId, documentId } = useProjectDocumentRouteIds();
 
+  const [documents, setDocuments] = useState<DocumentSummary[]>([]);
+  const [docsLoading, setDocsLoading] = useState(true);
   const [doc, setDoc] = useState<DocumentData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [chatSessionKey, setChatSessionKey] = useState(0);
+
+  useEffect(() => {
+    setChatSessionKey(0);
+  }, [documentId]);
 
   useEffect(() => {
     if (!projectId || documentId) return;
     router.replace(`/projects/${projectId}/documents`);
   }, [projectId, documentId, router]);
 
-  const fetchDoc = async () => {
+  useEffect(() => {
+    if (!projectId || !isAuthenticated || authLoading) return;
+    const fetchDocs = async () => {
+      setDocsLoading(true);
+      try {
+        const res = await apiClient.get<{ documents: DocumentSummary[] }>(
+          `/documents/project/${projectId}?limit=100`
+        );
+        setDocuments(res.documents ?? []);
+      } catch (err) {
+        console.error("Failed to fetch project documents", err);
+      } finally {
+        setDocsLoading(false);
+      }
+    };
+    void fetchDocs();
+  }, [projectId, isAuthenticated, authLoading]);
+
+  const fetchDoc = useCallback(async () => {
     if (!documentId) return;
     setLoading(true);
     setError(null);
@@ -84,25 +127,57 @@ export default function DocumentGenUIWorkspace() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [documentId]);
 
   useEffect(() => {
     if (authLoading || !documentId) return;
     if (!isAuthenticated) return;
 
     void fetchDoc();
-  }, [projectId, documentId, isAuthenticated, authLoading]);
+  }, [documentId, isAuthenticated, authLoading, fetchDoc]);
+
+  const handleDocChange = (docId: string) => {
+    router.replace(`/projects/${projectId}/documents/genui?docId=${docId}`);
+  };
+
+  const handleCopy = async () => {
+    if (!doc?.content) return;
+    try {
+      await navigator.clipboard.writeText(doc.content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Could not copy to clipboard");
+    }
+  };
+
+  const selectedSummary = documents.find((d) => d.id === documentId);
+  const starterPrompts = useMemo(
+    () => getDocumentChatPrompts(doc?.title ?? "Document", selectedSummary?.template_name),
+    [doc?.title, selectedSummary?.template_name]
+  );
+
+  const conversationStarters = useMemo(
+    () => ({
+      variant: "short" as const,
+      options: starterPrompts.map((prompt) => ({
+        displayText: prompt,
+        prompt,
+      })),
+    }),
+    [starterPrompts]
+  );
 
   if (authLoading || (loading && !doc)) {
     return (
-      <div className="h-screen bg-background flex overflow-hidden">
+      <div className="genui-workspace h-screen flex overflow-hidden">
         <Sidebar />
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col overflow-hidden bg-slate-50">
           <Header title="OpenUI Document Workspace" />
-          <main className="flex-1 flex items-center justify-center bg-slate-950/20">
+          <main className="flex-1 flex items-center justify-center">
             <div className="flex flex-col items-center gap-3">
               <Loader2 className="h-10 w-10 animate-spin text-primary" />
-              <p className="text-sm text-muted-foreground animate-pulse font-medium">
+              <p className="genui-muted text-sm animate-pulse font-medium">
                 Loading secure workspace environment...
               </p>
             </div>
@@ -114,16 +189,16 @@ export default function DocumentGenUIWorkspace() {
 
   if (error || !doc) {
     return (
-      <div className="h-screen bg-background flex overflow-hidden">
+      <div className="genui-workspace h-screen flex overflow-hidden">
         <Sidebar />
-        <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="flex-1 flex flex-col overflow-hidden bg-slate-50">
           <Header title="Error Loading Workspace" />
-          <main className="flex-1 flex flex-col items-center justify-center p-6 bg-slate-950/10">
+          <main className="flex-1 flex flex-col items-center justify-center p-6">
             <AlertCircle className="h-14 w-14 text-destructive mb-4" />
-            <h2 className="text-2xl font-bold tracking-tight mb-2 text-foreground">
+            <h2 className="text-2xl font-bold tracking-tight mb-2 text-slate-900">
               Failed to load document context
             </h2>
-            <p className="text-sm text-muted-foreground max-w-md text-center mb-6 leading-relaxed">
+            <p className="genui-muted text-sm max-w-md text-center mb-6 leading-relaxed">
               {error || "We encountered an issue fetching the requested governance document from the registry."}
             </p>
             <div className="flex gap-3">
@@ -159,94 +234,160 @@ When generating layout, charts, or tables, use the exact metrics detailed above.
 `;
 
   return (
-    <div className="h-screen bg-background flex overflow-hidden">
+    <div className="genui-workspace h-screen flex overflow-hidden">
       <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <Header title={`${doc.title} — Generative UI Workspace`} />
+      <div className="flex-1 flex flex-col overflow-hidden bg-slate-50">
+        <Header />
+        <DocumentPageToolbar
+          projectId={projectId}
+          mode="genui"
+          documents={documents}
+          docsLoading={docsLoading}
+          selectedDocId={documentId}
+          onDocChange={handleDocChange}
+          docSelectorDisabled={loading}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs"
+            onClick={handleCopy}
+            disabled={!doc?.content || loading}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-600" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {copied ? "Copied" : "Copy"}
+          </Button>
+        </DocumentPageToolbar>
 
         <main className="flex-1 flex overflow-hidden">
           <PageTransition className="flex flex-1 overflow-hidden w-full h-full">
-            <div className="flex w-full h-full divide-x divide-slate-800">
-              <div className="w-1/2 flex flex-col h-full bg-slate-900/10 dark:bg-slate-950/40">
-                <div className="p-6 border-b border-border/60 bg-background/50 backdrop-blur flex justify-between items-center">
-                  <div>
-                    <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-primary">
-                      Active Context
+            <div className="flex w-full h-full divide-x divide-slate-200">
+              <div className="genui-source-pane w-1/2 flex flex-col h-full">
+                <div className="p-6 border-b border-slate-200 bg-white flex justify-between items-start gap-4">
+                  <div className="min-w-0">
+                    <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-indigo-600">
+                      Step 1 — Source document
                     </span>
-                    <h2 className="text-xl font-bold tracking-tight text-foreground mt-0.5">
+                    <h2 className="text-xl font-bold tracking-tight text-slate-900 mt-0.5 truncate">
                       {doc.title}
                     </h2>
+                    <p className="genui-muted text-xs mt-1.5 leading-relaxed max-w-md">
+                      Read and verify the extracted text here. The AI on the right uses only this content when answering.
+                    </p>
                   </div>
                   <div className="flex gap-2 items-center">
-                    <Badge variant="outline" className="text-xs px-2.5 py-0.5">
+                    <Badge variant="outline" className="text-xs px-2.5 py-0.5 border-slate-200 text-slate-700">
                       v{doc.version}
                     </Badge>
-                    <Badge variant="secondary" className="text-xs px-2.5 py-0.5 uppercase font-semibold">
+                    <Badge variant="secondary" className="text-xs px-2.5 py-0.5 uppercase font-semibold bg-slate-100 text-slate-700">
                       {doc.status}
                     </Badge>
                   </div>
                 </div>
 
-                <div className="flex-1 p-6 overflow-y-auto space-y-6">
+                <div className="flex-1 p-6 overflow-y-auto space-y-6 bg-slate-50/50">
                   <div className="grid grid-cols-3 gap-4">
-                    <div className="p-4 rounded-2xl bg-background border border-border/80 shadow-sm">
-                      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Word Count</div>
-                      <div className="text-lg font-bold text-foreground mt-1">{doc.word_count || "N/A"}</div>
+                    <div className="p-4 rounded-2xl bg-white border border-slate-200 shadow-sm">
+                      <div className="genui-muted text-[10px] uppercase tracking-wider">Word Count</div>
+                      <div className="text-lg font-bold text-slate-900 mt-1">{doc.word_count || "N/A"}</div>
                     </div>
-                    <div className="p-4 rounded-2xl bg-background border border-border/80 shadow-sm">
-                      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Document ID</div>
-                      <div className="text-sm font-mono truncate text-foreground mt-1.5" title={doc.id}>
+                    <div className="p-4 rounded-2xl bg-white border border-slate-200 shadow-sm">
+                      <div className="genui-muted text-[10px] uppercase tracking-wider">Document ID</div>
+                      <div className="text-sm font-mono truncate text-slate-900 mt-1.5" title={doc.id}>
                         {doc.id.substring(0, 8)}...
                       </div>
                     </div>
-                    <div className="p-4 rounded-2xl bg-background border border-border/80 shadow-sm">
-                      <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Created At</div>
-                      <div className="text-xs font-medium text-foreground mt-2">
+                    <div className="p-4 rounded-2xl bg-white border border-slate-200 shadow-sm">
+                      <div className="genui-muted text-[10px] uppercase tracking-wider">Created At</div>
+                      <div className="text-xs font-medium text-slate-900 mt-2">
                         {new Date(doc.created_at).toLocaleDateString()}
                       </div>
                     </div>
                   </div>
 
-                  <div className="flex flex-col flex-1 bg-background border border-border/80 rounded-3xl shadow-sm overflow-hidden min-h-[300px]">
-                    <div className="px-5 py-3.5 border-b border-border/60 bg-muted/20 flex items-center gap-2">
-                      <FileText size={16} className="text-primary" />
-                      <span className="text-xs font-semibold text-foreground">Extracted Text Content</span>
+                  <div className="flex flex-col flex-1 bg-white border border-slate-200 rounded-3xl shadow-sm overflow-hidden min-h-[300px]">
+                    <div className="px-5 py-3.5 border-b border-slate-200 bg-slate-50 flex items-center gap-2">
+                      <FileText size={16} className="text-indigo-600" />
+                      <span className="text-xs font-semibold text-slate-900">Extracted Text Content</span>
                     </div>
-                    <div className="p-6 flex-1 overflow-y-auto leading-relaxed text-sm text-foreground/80 font-sans whitespace-pre-wrap selection:bg-primary/20 select-text">
-                      {doc.content || <span className="italic text-muted-foreground">This document has no content body loaded.</span>}
+                    <div className="genui-body-text p-6 flex-1 overflow-y-auto leading-relaxed text-sm font-sans whitespace-pre-wrap selection:bg-indigo-100 select-text">
+                      {doc.content || <span className="genui-muted italic">This document has no content body loaded.</span>}
                     </div>
                   </div>
                 </div>
 
-                <div className="p-4 border-t border-border/60 bg-background/50 flex justify-between items-center text-[10px] text-muted-foreground font-mono">
+                <div className="genui-muted p-4 border-t border-slate-200 bg-white text-[10px] font-mono">
                   <span>Project ID: {projectId}</span>
-                  <Link
-                    href={getProjectDocumentViewPath(projectId, documentId)}
-                    className="text-primary hover:underline flex items-center gap-1 font-semibold"
-                  >
-                    Open Rich Editor &rarr;
-                  </Link>
                 </div>
               </div>
 
-              <div className="w-1/2 h-full flex flex-col relative bg-slate-950">
-                <FullScreen
-                  processMessage={async ({ messages, abortController }) => {
-                    return fetch("/api/chat", {
-                      method: "POST",
-                      headers: { "Content-Type": "application/json" },
-                      body: JSON.stringify({
-                        systemPrompt,
-                        messages: openAIMessageFormat.toApi(messages),
-                      }),
-                      signal: abortController.signal,
-                    });
-                  }}
-                  streamProtocol={openAIReadableStreamAdapter()}
-                  componentLibrary={openuiLibrary}
-                  agentName={`${doc.title} Advisor`}
-                  assistantMessage={CustomAssistantMessage}
-                />
+              <div className="flex w-1/2 min-w-0 h-full flex-col min-h-0 relative bg-white border-l border-slate-200">
+                <div className="shrink-0 px-5 py-3 border-b border-slate-200 bg-slate-50">
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-start gap-3 min-w-0 flex-1">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700">
+                        <MessageSquare className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0">
+                        <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-700">
+                          Step 2 — Ask the AI
+                        </span>
+                        <p className="text-sm text-slate-900 mt-0.5 font-medium">
+                          Document advisor
+                        </p>
+                        <p className="genui-muted text-xs mt-1 leading-relaxed">
+                          Pick a suggested question below or type in the chat box at the bottom. Responses can include tables, charts, and structured summaries grounded in the document on the left.
+                        </p>
+                      </div>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 shrink-0 gap-1.5 text-xs border-slate-200 text-slate-700 hover:bg-white"
+                      onClick={() => setChatSessionKey((k) => k + 1)}
+                      title="Start a new conversation about this document"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      New chat
+                    </Button>
+                  </div>
+                </div>
+                <div className="genui-openui-root flex-1 min-h-0 w-full">
+                  <FullScreen
+                    key={`${documentId}-${chatSessionKey}`}
+                    processMessage={async ({ messages, abortController }) => {
+                      return fetch("/api/chat", {
+                        method: "POST",
+                        headers: { "Content-Type": "application/json" },
+                        body: JSON.stringify({
+                          systemPrompt,
+                          messages: openAIMessageFormat.toApi(messages),
+                        }),
+                        signal: abortController.signal,
+                      });
+                    }}
+                    streamProtocol={openAIReadableStreamAdapter()}
+                    componentLibrary={openuiLibrary}
+                    agentName={`${doc.title} advisor`}
+                    welcomeMessage={{
+                      title: `Explore “${doc.title}”`,
+                      description:
+                        "Ask questions about this document. The advisor can build interactive charts, tables, checklists, and summaries from the source text shown on the left — not from the open web.",
+                      image: (
+                        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-violet-100 text-violet-700">
+                          <Sparkles className="h-7 w-7" />
+                        </div>
+                      ),
+                    }}
+                    conversationStarters={conversationStarters}
+                    assistantMessage={CustomAssistantMessage}
+                  />
+                </div>
               </div>
             </div>
           </PageTransition>

--- a/components/documents/DocumentPageToolbar.tsx
+++ b/components/documents/DocumentPageToolbar.tsx
@@ -19,9 +19,12 @@ import {
   Wand2,
 } from "lucide-react"
 import type { LucideIcon } from "lucide-react"
-import { getProjectDocumentViewPath } from "@/lib/documents/document-routes"
+import {
+  getProjectDocumentGenUIPath,
+  getProjectDocumentViewPath,
+} from "@/lib/documents/document-routes"
 
-export type DocumentPageMode = "view" | "source" | "report"
+export type DocumentPageMode = "view" | "source" | "report" | "genui"
 
 export interface DocumentSummary {
   id: string
@@ -41,6 +44,12 @@ const MODE_CONFIG: Record<
     title: "Document Report",
     badge: "Live",
     iconClassName: "text-indigo-600",
+  },
+  genui: {
+    icon: Wand2,
+    title: "GenUI Workspace",
+    badge: "AI",
+    iconClassName: "text-violet-600",
   },
 }
 
@@ -170,6 +179,23 @@ export function DocumentPageToolbar({
               >
                 <Wand2 className="h-3.5 w-3.5" />
                 Report
+              </Button>
+            ) : null}
+            {mode !== "genui" ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className={`h-8 gap-1.5 text-xs ${
+                  mode === "report"
+                    ? "border-violet-200 text-violet-600"
+                    : ""
+                }`}
+                onClick={() =>
+                  router.push(getProjectDocumentGenUIPath(projectId, selectedDocId))
+                }
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                GenUI
               </Button>
             ) : null}
           </>

--- a/components/openui-chat/AssistantMessage.tsx
+++ b/components/openui-chat/AssistantMessage.tsx
@@ -1,26 +1,42 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { AssistantMessage } from "@openuidev/react-headless";
 import { MarkDownRenderer } from "@openuidev/react-ui";
+import { openuiLibrary } from "@openuidev/react-ui/genui-lib";
 import { Copy, FileText, Code, Volume2, ThumbsUp, ThumbsDown, Check } from "lucide-react";
+
+import { DynamicComponentRenderer } from "./DynamicComponentRenderer";
+import {
+  extractOpenUILangText,
+  looksLikeOpenUILang,
+} from "@/lib/openui/library";
 
 interface AssistantMessageProps {
   message: AssistantMessage;
   isStreaming: boolean;
 }
 
-export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ message, isStreaming }) => {
+export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
+  message,
+  isStreaming,
+}) => {
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [showRaw, setShowRaw] = useState(false);
   const [feedback, setFeedback] = useState<"like" | "dislike" | null>(null);
   const [speaking, setSpeaking] = useState(false);
 
-  // 1. Copy Response Text
+  const rawContent = message.content || "";
+  const langText = useMemo(() => extractOpenUILangText(rawContent), [rawContent]);
+  const isGenUILang = useMemo(
+    () => looksLikeOpenUILang(langText),
+    [langText]
+  );
+
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(message.content || "");
+      await navigator.clipboard.writeText(rawContent);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
@@ -28,12 +44,10 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ messag
     }
   };
 
-  // 2. Export Content as Premium PDF Document
   const handleExportPDF = () => {
-    if (!message.content) return;
+    if (!rawContent) return;
     setExporting(true);
 
-    // Create a temporary hidden iframe for standard styled PDF printing
     const iframe = document.createElement("iframe");
     iframe.style.position = "absolute";
     iframe.style.width = "0";
@@ -47,18 +61,19 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ messag
       return;
     }
 
-    // Process raw markdown text into readable HTML
-    let cleanContent = message.content
-      .replace(/<context>[\s\S]*<\/context>/g, "") // Remove generative context tags
-      .replace(/<content[^>]*>/g, "") // Remove start component wrappers
-      .replace(/<\/content>/g, "") // Remove end component wrappers
-      .replace(/\n/g, "<br/>") // Convert linebreaks
-      .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>") // Bold Markdown
-      .replace(/\*(.*?)\*/g, "<em>$1</em>") // Italic Markdown
-      .replace(/`([^`]+)`/g, "<code>$1</code>") // Inline code blocks
-      .replace(/### (.*?)(<br\/>|$)/g, "<h3>$1</h3>") // H3 Headers
-      .replace(/## (.*?)(<br\/>|$)/g, "<h2>$1</h2>") // H2 Headers
-      .replace(/# (.*?)(<br\/>|$)/g, "<h1>$1</h1>"); // H1 Headers
+    let cleanContent = rawContent
+      .replace(/```(?:openui-lang|openui)\s*\n?/gi, "")
+      .replace(/```\s*$/g, "")
+      .replace(/<context>[\s\S]*<\/context>/g, "")
+      .replace(/<content[^>]*>/g, "")
+      .replace(/<\/content>/g, "")
+      .replace(/\n/g, "<br/>")
+      .replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
+      .replace(/\*(.*?)\*/g, "<em>$1</em>")
+      .replace(/`([^`]+)`/g, "<code>$1</code>")
+      .replace(/### (.*?)(<br\/>|$)/g, "<h3>$1</h3>")
+      .replace(/## (.*?)(<br\/>|$)/g, "<h2>$1</h2>")
+      .replace(/# (.*?)(<br\/>|$)/g, "<h1>$1</h1>");
 
     doc.open();
     doc.write(`
@@ -66,127 +81,23 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ messag
       <html>
         <head>
           <title>ADPA Governance Report</title>
-          <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;700&display=swap" rel="stylesheet">
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
           <style>
-            @page {
-              size: A4;
-              margin: 20mm;
-            }
-            body {
-              font-family: 'Outfit', sans-serif;
-              color: #1e293b;
-              line-height: 1.6;
-              padding: 0;
-              margin: 0;
-              background: #ffffff;
-            }
-            .report-container {
-              max-width: 100%;
-            }
-            .header {
-              border-bottom: 3px solid #6366f1;
-              padding-bottom: 16px;
-              margin-bottom: 24px;
-              display: flex;
-              justify-content: space-between;
-              align-items: flex-end;
-            }
-            .logo-title {
-              font-size: 22px;
-              font-weight: 700;
-              color: #0f172a;
-              letter-spacing: -0.025em;
-            }
-            .logo-title span {
-              color: #6366f1;
-            }
-            .meta {
-              font-size: 11px;
-              color: #64748b;
-              text-align: right;
-            }
-            .content {
-              font-size: 14px;
-              color: #334155;
-            }
-            h1, h2, h3 { 
-              color: #0f172a; 
-              font-weight: 600; 
-              margin-top: 28px;
-              margin-bottom: 12px;
-            }
-            h1 { font-size: 22px; border-bottom: 1px solid #e2e8f0; padding-bottom: 6px; }
-            h2 { font-size: 18px; }
-            h3 { font-size: 15px; }
-            p { margin-bottom: 16px; }
-            code { 
-              font-family: monospace; 
-              background: #f1f5f9; 
-              padding: 2px 4px; 
-              border-radius: 4px; 
-              font-size: 12px; 
-            }
-            pre { 
-              background: #f8fafc; 
-              padding: 16px; 
-              border-radius: 8px; 
-              font-family: monospace; 
-              font-size: 12px; 
-              border: 1px solid #e2e8f0; 
-              margin: 20px 0; 
-              white-space: pre-wrap; 
-            }
-            table { 
-              width: 100%; 
-              border-collapse: collapse; 
-              margin: 24px 0; 
-            }
-            th, td { 
-              border: 1px solid #e2e8f0; 
-              padding: 12px 14px; 
-              text-align: left; 
-              font-size: 13px; 
-            }
-            th { 
-              background: #f8fafc; 
-              color: #475569; 
-              font-weight: 600; 
-            }
-            .footer {
-              border-top: 1px solid #e2e8f0;
-              margin-top: 60px;
-              padding-top: 16px;
-              font-size: 10px;
-              color: #94a3b8;
-              text-align: center;
-            }
+            @page { size: A4; margin: 20mm; }
+            body { font-family: Inter, sans-serif; color: #1e293b; line-height: 1.6; margin: 0; }
+            .header { border-bottom: 3px solid #6366f1; padding-bottom: 16px; margin-bottom: 24px; }
+            .logo-title { font-size: 22px; font-weight: 700; color: #0f172a; }
+            .content { font-size: 14px; color: #334155; white-space: pre-wrap; }
           </style>
         </head>
         <body>
-          <div class="report-container">
-            <div class="header">
-              <div class="logo-title">ADPA<span>.Governance</span></div>
-              <div class="meta">
-                <strong>Generated Report</strong><br/>
-                Date: ${new Date().toLocaleDateString()}<br/>
-                Reference: ${message.id || "N/A"}
-              </div>
-            </div>
-            
-            <div class="content">
-              ${cleanContent}
-            </div>
-            
-            <div class="footer">
-              Confidential — Generated by ADPA AI Assistant Workspace | RPAS-CM Baselines Certified
-            </div>
-          </div>
+          <div class="header"><div class="logo-title">ADPA Document Report</div></div>
+          <div class="content">${cleanContent}</div>
         </body>
       </html>
     `);
     doc.close();
 
-    // Trigger Print after loading styles and fonts
     setTimeout(() => {
       iframe.contentWindow?.focus();
       iframe.contentWindow?.print();
@@ -195,94 +106,97 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ messag
     }, 600);
   };
 
-  // 3. Text-to-Speech (TTS)
   const handleSpeak = () => {
-    if (!message.content) return;
-    
+    if (!rawContent) return;
+
     if (speaking) {
       window.speechSynthesis.cancel();
       setSpeaking(false);
       return;
     }
 
-    const cleanText = message.content.replace(/<[^>]*>/g, ""); // Strip XML component tags
+    const cleanText = rawContent.replace(/```[\s\S]*?```/g, "").replace(/<[^>]*>/g, "");
     const utterance = new SpeechSynthesisUtterance(cleanText);
     utterance.onend = () => setSpeaking(false);
-    
+
     setSpeaking(true);
     window.speechSynthesis.speak(utterance);
   };
 
   return (
-    <div className="flex gap-4 p-4 border-b border-slate-800 bg-slate-900/20">
-      {/* Bot Avatar */}
-      <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-indigo-600/20 border border-indigo-500/30 flex items-center justify-center text-indigo-400 font-bold text-sm">
+    <div className="flex gap-3 px-4 py-4 border-b border-slate-100 bg-white">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 text-sm font-semibold">
         AI
       </div>
 
-      {/* Message Content */}
-      <div className="flex-1 flex flex-col gap-3 min-w-0">
-        <span className="text-xs font-semibold tracking-wide text-slate-400">Advisor Response</span>
-        
-        {/* Toggle between rendered layout and raw components JSON */}
-        {showRaw ? (
-          <pre className="p-4 rounded-lg bg-slate-950 border border-slate-800 font-mono text-xs text-indigo-300 overflow-x-auto whitespace-pre-wrap">
-            {JSON.stringify(message, null, 2)}
-          </pre>
-        ) : (
-          message.content && (
-            <MarkDownRenderer
-              textMarkdown={message.content}
-              className="prose prose-invert prose-slate leading-relaxed text-sm text-slate-200"
-            />
-          )
-        )}
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
+        <span className="text-xs font-semibold tracking-wide text-slate-500">
+          Advisor response
+        </span>
 
-        {/* 🛠️ Utility buttons bar (only show when message is completed) */}
+        {showRaw ? (
+          <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700">
+            {isGenUILang ? langText : JSON.stringify(message, null, 2)}
+          </pre>
+        ) : isGenUILang ? (
+          <div className="genui-lang-render min-w-0 w-full">
+            <DynamicComponentRenderer
+              response={langText}
+              isStreaming={isStreaming}
+              library={openuiLibrary}
+            />
+          </div>
+        ) : rawContent ? (
+          <MarkDownRenderer
+            textMarkdown={rawContent}
+            className="prose prose-slate max-w-none text-sm leading-relaxed text-slate-700"
+          />
+        ) : null}
+
         {!isStreaming && (
-          <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-slate-800/60 pt-3">
-            {/* Copy button */}
+          <div className="mt-1 flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
             <button
+              type="button"
               onClick={handleCopy}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded bg-slate-900 border border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-xs text-slate-300 transition-all active:scale-95"
+              className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50"
               title="Copy response"
             >
-              {copied ? <Check size={13} className="text-green-400" /> : <Copy size={13} />}
-              <span>{copied ? "Copied!" : "Copy"}</span>
+              {copied ? <Check size={13} className="text-green-600" /> : <Copy size={13} />}
+              <span>{copied ? "Copied" : "Copy"}</span>
             </button>
 
-            {/* Export PDF button */}
             <button
+              type="button"
               onClick={handleExportPDF}
               disabled={exporting}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded bg-slate-900 border border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-xs text-slate-300 transition-all active:scale-95 disabled:opacity-50"
-              title="Submit and download PDF report"
+              className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+              title="Export as PDF"
             >
-              <FileText size={13} className="text-indigo-400" />
-              <span>{exporting ? "Submitting..." : "Export PDF"}</span>
+              <FileText size={13} className="text-violet-600" />
+              <span>{exporting ? "Exporting…" : "Export PDF"}</span>
             </button>
 
-            {/* View Source/JSON toggle */}
             <button
+              type="button"
               onClick={() => setShowRaw(!showRaw)}
-              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded border text-xs transition-all active:scale-95 ${
-                showRaw 
-                  ? "bg-indigo-950 border-indigo-800 text-indigo-300"
-                  : "bg-slate-900 border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-slate-300"
+              className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
+                showRaw
+                  ? "border-violet-200 bg-violet-50 text-violet-700"
+                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
               }`}
-              title="Show component JSON structure"
+              title={isGenUILang ? "Show OpenUI Lang source" : "Show raw message JSON"}
             >
               <Code size={13} />
-              <span>{showRaw ? "Show Rendered" : "View JSON"}</span>
+              <span>{showRaw ? "Show rendered" : isGenUILang ? "View source" : "View JSON"}</span>
             </button>
 
-            {/* Text-To-Speech speak toggle */}
             <button
+              type="button"
               onClick={handleSpeak}
-              className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded border text-xs transition-all active:scale-95 ${
-                speaking 
-                  ? "bg-green-950 border-green-800 text-green-300 animate-pulse"
-                  : "bg-slate-900 border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-slate-300"
+              className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
+                speaking
+                  ? "border-green-200 bg-green-50 text-green-700"
+                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
               }`}
               title="Read aloud"
             >
@@ -290,28 +204,27 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({ messag
               <span>{speaking ? "Stop" : "Speak"}</span>
             </button>
 
-            {/* Divider */}
-            <span className="w-px h-4 bg-slate-800 mx-1" />
+            <span className="mx-1 h-4 w-px bg-slate-200" />
 
-            {/* Like Feedback */}
             <button
+              type="button"
               onClick={() => setFeedback(feedback === "like" ? null : "like")}
-              className={`p-1.5 rounded border transition-all active:scale-95 ${
+              className={`rounded-md border p-1.5 transition-colors ${
                 feedback === "like"
-                  ? "bg-blue-950 border-blue-800 text-blue-400"
-                  : "bg-slate-900 border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-slate-400"
+                  ? "border-blue-200 bg-blue-50 text-blue-600"
+                  : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
               }`}
             >
               <ThumbsUp size={13} />
             </button>
 
-            {/* Dislike Feedback */}
             <button
+              type="button"
               onClick={() => setFeedback(feedback === "dislike" ? null : "dislike")}
-              className={`p-1.5 rounded border transition-all active:scale-95 ${
+              className={`rounded-md border p-1.5 transition-colors ${
                 feedback === "dislike"
-                  ? "bg-red-950 border-red-800 text-red-400"
-                  : "bg-slate-900 border-slate-800 hover:bg-slate-800 hover:border-slate-700 text-slate-400"
+                  ? "border-red-200 bg-red-50 text-red-600"
+                  : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
               }`}
             >
               <ThumbsDown size={13} />

--- a/components/openui-chat/DynamicComponentRenderer.tsx
+++ b/components/openui-chat/DynamicComponentRenderer.tsx
@@ -6,7 +6,7 @@
 
 "use client"
 
-import { Renderer } from "@openuidev/react-lang"
+import { Renderer, type Library } from "@openuidev/react-lang"
 import { Sparkles, Telescope } from "lucide-react"
 
 import { MarkdownRenderer } from "@/components/documents/MarkdownRenderer"
@@ -14,7 +14,11 @@ import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { adpaLibrary } from "@/lib/openui/adpaLibrary"
 import type { ComponentPayload, OpenUIChatJson } from "@/lib/openui/library"
-import { isLegacyComponentPayload, looksLikeOpenUILang } from "@/lib/openui/library"
+import {
+  extractOpenUILangText,
+  isLegacyComponentPayload,
+  looksLikeOpenUILang,
+} from "@/lib/openui/library"
 
 import { TableComponent } from "./components/TableComponent"
 import { ChartComponent } from "./components/ChartComponent"
@@ -40,16 +44,21 @@ export interface DynamicComponentRendererProps {
   /** @deprecated Legacy JSON component payload from pre–react-lang threads */
   payload?: ComponentPayload | OpenUIChatJson
   isStreaming?: boolean
+  /** Defaults to ADPA library; pass openuiLibrary from @openuidev/react-ui/genui-lib for GenUI workspace */
+  library?: Library
 }
 
 export function DynamicComponentRenderer({
   response,
   payload,
   isStreaming = false,
+  library = adpaLibrary,
 }: DynamicComponentRendererProps) {
-  const langText =
+  const raw =
     response ??
     (typeof payload === "string" && looksLikeOpenUILang(payload) ? payload : null)
+
+  const langText = raw ? extractOpenUILangText(raw) : null
 
   const trimmed = langText?.trim() ?? ""
   const hasRoot = /^root\s*=/m.test(trimmed)
@@ -67,7 +76,7 @@ export function DynamicComponentRenderer({
   if (hasRoot) {
     return (
       <Renderer
-        library={adpaLibrary}
+        library={library}
         response={trimmed}
         isStreaming={isStreaming}
         onError={(errors) => {

--- a/docs/codedocs/genui-workspace.md
+++ b/docs/codedocs/genui-workspace.md
@@ -1,0 +1,136 @@
+---
+title: "Document GenUI Workspace"
+description: "Split-pane document viewer plus OpenUI advisor: routes, rendering pipeline, environment, and maintenance guide."
+---
+
+The **document GenUI workspace** lets users read an extracted governance document on the left and chat with an AI advisor on the right. The advisor can return **OpenUI Lang**, which the UI renders as interactive components (cards, tables, charts, tabs, steps).
+
+This page is **not** the same as [OpenUI Chat](/docs/openui-chat), which is project-scoped chat backed by `server/src/modules/openuiChat` with thread persistence and RAG. The document workspace uses a separate HTTP path and Mistral streaming.
+
+For agent-driven maintenance, see `.agents/skills/adpa-genui-workspace/SKILL.md` and the **Document GenUI workspace** section in `AGENTS.md`.
+
+## User-facing URL
+
+```txt
+/projects/{projectId}/documents/genui?docId={documentId}
+```
+
+Helper: `getProjectDocumentGenUIPath(projectId, documentId)` in `lib/documents/document-routes.ts`.
+
+Navigation from other document modes (View, Source, Report) uses `DocumentPageToolbar` with mode `genui`.
+
+## Layout
+
+| Pane | Purpose |
+| --- | --- |
+| **Step 1 — Source document** | Title, metadata, word count, full extracted `doc.content` from the documents API |
+| **Step 2 — Ask the AI** | OpenUI `FullScreen` chat: starters, streaming replies, **New chat** (client session reset) |
+
+Styling lives in `app/projects/[id]/documents/genui/genui-workspace.css` (light theme, panel-sized OpenUI shell, sidebar hidden inside the embed).
+
+## Source map
+
+| Concern | Files |
+| --- | --- |
+| Main page | `app/projects/[id]/documents/genui/page.tsx` |
+| Workspace CSS | `app/projects/[id]/documents/genui/genui-workspace.css` |
+| Error UI | `app/projects/[id]/documents/genui/error.tsx` |
+| Chat proxy (Mistral) | `app/api/chat/route.ts` |
+| Assistant rendering | `components/openui-chat/AssistantMessage.tsx` (re-exported from `components/Chat/AssistantMessage.tsx`) |
+| Lang → components | `components/openui-chat/DynamicComponentRenderer.tsx` |
+| Fence stripping / detection | `lib/openui/library.ts` — `extractOpenUILangText()`, `looksLikeOpenUILang()` |
+| Conversation starters | `lib/documents/document-chat-prompts.ts` |
+| Route IDs | `lib/documents/use-project-document-route-ids.ts` |
+| Toolbar / GenUI button | `components/documents/DocumentPageToolbar.tsx` |
+
+## Request and rendering flow
+
+1. The page loads the document via the authenticated documents API (`projectId` + `documentId`).
+2. It builds a **system prompt** from `openuiLibrary.prompt(openuiPromptOptions)` plus the full document body and metadata.
+3. `FullScreen` posts to `POST /api/chat` with `{ systemPrompt, messages }`.
+4. When `systemPrompt` is present, `app/api/chat/route.ts` streams from **Mistral** (`MISTRAL_API_KEY`, optional `MISTRAL_MODEL`). Without `systemPrompt`, the same route proxies to backend OpenUI chat.
+5. The model should reply in **OpenUI Lang** (e.g. `root = Stack([...])`), sometimes wrapped in ` ```openui-lang ` fences.
+6. `CustomAssistantMessage` detects Lang, strips fences, and renders with `@openuidev/react-lang` `Renderer` and **`openuiLibrary`** from `@openuidev/react-ui/genui-lib`.
+
+```mermaid
+flowchart LR
+  DocAPI[Documents API] --> Step1[Step 1 pane]
+  Step1 --> Prompt[systemPrompt + doc content]
+  Prompt --> FullScreen[FullScreen]
+  FullScreen --> ApiChat["POST /api/chat"]
+  ApiChat --> Mistral[Mistral stream]
+  Mistral --> Assistant[CustomAssistantMessage]
+  Assistant --> Renderer[Renderer + openuiLibrary]
+```
+
+### Rendering pitfalls
+
+- **`assistantMessage={CustomAssistantMessage}` overrides** the default `FullScreen` assistant renderer. If the custom component only shows markdown, users see raw Lang in a code block.
+- Use **`openuiLibrary`** for this page, not `adpaLibrary` (used elsewhere in `DynamicComponentRenderer`).
+- Always run model output through **`extractOpenUILangText()`** before `looksLikeOpenUILang()` / `Renderer`.
+
+## Environment variables
+
+Set in `.env.local` (see `.env.local.example`):
+
+| Variable | Required for Step 2 | Notes |
+| --- | --- | --- |
+| `MISTRAL_API_KEY` | Yes | Missing key → 503 from `/api/chat` |
+| `MISTRAL_MODEL` | No | Default `mistral-large-latest` |
+| `BACKEND_URL` | Step 1 | Document fetch via Express proxy |
+| Auth (`auth_token` cookie / Firebase) | Yes | Page requires login |
+
+OpenUI package styles are imported on the page:
+
+```ts
+import "@openuidev/react-ui/defaults.css";
+import "@openuidev/react-ui/components.css";
+```
+
+## Persistence and sessions
+
+- **Threads:** Not stored in `openui_chat_threads` today. Chat state is in-memory in `FullScreen`.
+- **New chat:** Increments `chatSessionKey` to remount `FullScreen`; also resets when `documentId` changes.
+- **Copy toolbar:** Copies raw document text (Step 1), not the chat transcript.
+
+## Extending the workspace
+
+| Goal | Where to change |
+| --- | --- |
+| Suggested questions | `lib/documents/document-chat-prompts.ts` |
+| Grounding / instructions | `systemPrompt` block in `genui/page.tsx` |
+| Layout / contrast / OpenUI embed | `genui-workspace.css` |
+| New OpenUI components | Prefer `@openuidev/react-ui/genui-lib` Lang syntax; consult OpenUI docs for grammar |
+| Thread history per document | New persistence design — do not break `/api/v1/openui-chat` without a migration plan |
+| RAG for large documents | Chunk retrieval from existing server RAG; watch Mistral context limits |
+
+Future PM dashboards are described in `docs/superpowers/specs/2026-05-18-genui-personalized-dashboards-design.md`; that is a separate route from this document workspace.
+
+## Manual test checklist
+
+1. Log in; open `/projects/{id}/documents/genui?docId={uuid}` for a document with body text.
+2. Confirm Step 1 shows title, metrics, and extracted content.
+3. Confirm Step 2 shows welcome text and conversation starters; input is centered in the right panel.
+4. Send a starter (e.g. risks table) — response should be **rendered UI**, not a fenced code block.
+5. Use **View source** / **Show rendered** on an assistant message.
+6. **New chat** clears the thread; changing document in the toolbar loads the new doc and resets chat.
+7. Toolbar links: View, Source, Report, GenUI.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Raw `openui-lang` code block | Assistant path not using `Renderer` + `openuiLibrary` |
+| Broken or empty widgets | Wrong library (`adpaLibrary` instead of `openuiLibrary`) |
+| 503 on send | `MISTRAL_API_KEY` not set |
+| 401 on send | Not logged in |
+| Empty Step 1 | Document API or missing `doc.content` |
+| Chat layout broken | `genui-workspace.css` overrides under `.genui-openui-root` |
+| Model ignores document | Empty content or weak system prompt |
+
+## Related documentation
+
+- [OpenUI Chat](/docs/openui-chat) — backend module, threads, SSE payloads
+- `docs/superpowers/specs/2026-05-14-openui-chat-design.md` — GenUI strategy for project chat
+- `docs/superpowers/specs/2026-05-18-genui-personalized-dashboards-design.md` — future dashboards
+- `.agents/skills/adpa-genui-workspace/SKILL.md` — agent maintenance skill

--- a/docs/codedocs/index.md
+++ b/docs/codedocs/index.md
@@ -127,11 +127,13 @@ After the health check passes, the smallest meaningful ADPA workflow is:
 - Two context systems: a lightweight injector and a newer orchestrator with access-control, freshness, and metrics.
 - Multi-provider AI support spanning OpenAI, Google AI, and local Ollama, plus a generic fallback executor.
 - Project-scoped OpenUI chat threads that return structured UI payloads over SSE.
+- Document GenUI workspace: split-pane document source plus OpenUI advisor with rendered charts, tables, and reports grounded in document text.
 - Knowledge-base workflows for storing reusable improvements, reviews, and application outcomes.
 
 <Cards>
   <Card title="Architecture" href="/docs/architecture">How the frontend, API, modules, data stores, and integrations fit together.</Card>
   <Card title="Core Concepts" href="/docs/document-templates">Start with the abstractions that shape every request: templates, context, providers, and knowledge reuse.</Card>
   <Card title="OpenUI Chat" href="/docs/openui-chat">Project-scoped chat routes, storage, auth modes, and operational constraints.</Card>
+  <Card title="Document GenUI Workspace" href="/docs/genui-workspace">Split-pane document viewer, Mistral chat, OpenUI Lang rendering, and maintenance guide.</Card>
   <Card title="API Reference" href="/docs/api-reference/document-template-service">Method signatures, route surfaces, constructor options, and source-file pointers.</Card>
 </Cards>

--- a/docs/codedocs/openui-chat.md
+++ b/docs/codedocs/openui-chat.md
@@ -5,6 +5,8 @@ description: "Project-scoped chat threads, structured assistant payloads, and th
 
 OpenUI chat is a project-scoped assistant surface that stores chat history in PostgreSQL and returns structured UI payloads over Server-Sent Events (SSE). It is implemented by the Express module in `server/src/modules/openuiChat` and consumed by the Next.js pages under `app/openui-chat` and `app/ai/openui-chat`.
 
+For the **document GenUI workspace** (split-pane document + advisor at `/projects/{id}/documents/genui`), see [Document GenUI Workspace](/docs/genui-workspace). That surface uses `POST /api/chat` with a document-embedded system prompt and Mistral streaming—not the `/api/v1/openui-chat` thread APIs described below.
+
 ## Source Map
 
 | Concern | Source files |

--- a/lib/documents/document-chat-prompts.ts
+++ b/lib/documents/document-chat-prompts.ts
@@ -1,0 +1,64 @@
+const DOCUMENT_PROMPTS: { keywords: string[]; prompts: string[] }[] = [
+  {
+    keywords: ["risk"],
+    prompts: [
+      "Show all risks as a table",
+      "Which risks are critical?",
+      "Visualize risk probability vs impact",
+      "List mitigation strategies",
+    ],
+  },
+  {
+    keywords: ["stakeholder"],
+    prompts: [
+      "Show stakeholder matrix",
+      "List all stakeholders by influence",
+      "Who are the key decision makers?",
+      "Engagement level by stakeholder",
+    ],
+  },
+  {
+    keywords: ["charter", "project"],
+    prompts: [
+      "Render full charter as a numbered report",
+      "Add a milestones timeline section",
+      "Expand the scope section with a table",
+      "Who is the project sponsor?",
+    ],
+  },
+  {
+    keywords: ["quality"],
+    prompts: [
+      "List quality metrics",
+      "Show quality gates",
+      "What are the acceptance criteria?",
+      "Quality KPIs table",
+    ],
+  },
+  {
+    keywords: ["communication", "plan"],
+    prompts: [
+      "Show communication matrix",
+      "List reporting cadence",
+      "Who receives which reports?",
+      "Visualize communication flow",
+    ],
+  },
+]
+
+/** Suggested chat prompts based on document name / template keywords. */
+export function getDocumentChatPrompts(docName: string, templateName?: string): string[] {
+  const haystack = `${docName} ${templateName ?? ""}`.toLowerCase()
+  for (const entry of DOCUMENT_PROMPTS) {
+    if (entry.keywords.some((kw) => haystack.includes(kw))) {
+      return entry.prompts
+    }
+  }
+  return [
+    "Summarize this document in a short executive overview",
+    "Show the main sections as a structured table",
+    "List every action item and owner mentioned",
+    "What are the top risks or gaps in this document?",
+    "Render the full document as an interactive report",
+  ]
+}

--- a/lib/openui/library.ts
+++ b/lib/openui/library.ts
@@ -104,9 +104,21 @@ export function isLegacyComponentPayload(
   return isComponentPayload(payload as OpenUIAssistantPayload)
 }
 
+/** Strip markdown code fences the model sometimes wraps around OpenUI Lang */
+export function extractOpenUILangText(text: string): string {
+  const trimmed = text.trim()
+  const closedFence = trimmed.match(/^```(?:openui-lang|openui)\s*\n([\s\S]*?)\n```$/i)
+  if (closedFence) return closedFence[1].trim()
+
+  const openFence = trimmed.match(/^```(?:openui-lang|openui)\s*\n([\s\S]*)$/i)
+  if (openFence) return openFence[1].trim()
+
+  return trimmed
+}
+
 /** Heuristic: assistant content looks like OpenUI Lang (statement syntax, not XML) */
 export function looksLikeOpenUILang(text: string): boolean {
-  const trimmed = text.trim()
+  const trimmed = extractOpenUILangText(text)
   if (/^root\s*=/m.test(trimmed)) return true
   if (trimmed.startsWith("<") && /<[A-Z][a-zA-Z]*/.test(trimmed)) return false
   return /^[A-Za-z][\w]*\s*=/.test(trimmed)

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express"
 import jwt from "jsonwebtoken"
+import * as admin from "firebase-admin"
 import { pool } from "../database/connection"
 import { logger } from "../utils/logger"
 import { v4 as uuidv4 } from "uuid"
@@ -10,13 +11,6 @@ const DEFAULT_USER_PERMISSIONS = {
   'documents.read': true,
   'templates.read': true,
   'stakeholders.read': true,
-};
-
-// Dynamic import helper to prevent frontend build crashes
-// We use a variable for the module name to hide it from static analysis
-const getAdmin = async () => {
-  const moduleName = "firebase-admin";
-  return await import(moduleName);
 };
 
 interface AuthRequest extends Request {
@@ -63,7 +57,6 @@ export const authenticateToken = async (req: AuthRequest, res: Response, next: N
   try {
     // Attempt Firebase verification first
     try {
-      const admin = await getAdmin();
       const firebaseUser = await admin.auth().verifyIdToken(token)
       // Map Firebase user to our internal format
       decoded = { 
@@ -294,7 +287,6 @@ export const optionalAuth = async (req: AuthRequest, res: Response, next: NextFu
     
     // Attempt Firebase verification first
     try {
-      const admin = await getAdmin();
       const firebaseUser = await admin.auth().verifyIdToken(token)
       decoded = { 
         fromFirebase: true, 


### PR DESCRIPTION
- Render assistant OpenUI Lang via openuiLibrary (strip fenced blocks)
- GenUI workspace: toolbar, starters, light theme CSS, New chat, centered chat
- Add adpa-genui-workspace skill, codedocs, and AGENTS.md pointers

fix(auth): use static firebase-admin import for verifyIdToken

Replaces dynamic import that broke admin.auth() on Render. Production login still needs verification after deploy (Firebase env + token path).