### PR TITLE
fix(genui): SMP §1.1/§1.2 layout plan and WBS table budget

### DIFF
--- a/__tests__/lib/layoutPlan.test.ts
+++ b/__tests__/lib/layoutPlan.test.ts
@@ -6,6 +6,10 @@ import {
   splitProseIntoTwoColumns,
   stripProseDividers,
   wantsGenuiReportDarkTheme,
+  repairTwoColumnProseInLang,
+  stripDividerNoiseInLang,
+  repairGenuiExecutorLang,
+  pruneUndefinedRefsInLang,
 } from "@/lib/openui/layoutPlan"
 import type { LayoutPlanNode } from "@/lib/openui/layoutPlanTypes"
 import { validateExecutorLang } from "@/lib/openui/langValidation"
@@ -156,7 +160,7 @@ Cost of inaction exceeds $15M over five years.`
     expect(ch1?.children?.some((c) => c.id.startsWith("sub-"))).toBe(true)
   })
 
-  test("long chapter intro plans two-column Stack with split TextContent children", () => {
+  test("long chapter intro plans TwoColumnProse with left/right hints", () => {
     const para1 =
       "The ADPA - Morphic AI Integration project aims to enhance the ADPA platform with state-of-the-art AI-powered search capabilities by integrating Morphic AI's technology. This integration addresses the current limitations of ADPA's search functionality, which impacts user productivity and decision-making."
     const para2 =
@@ -172,12 +176,12 @@ Cost of inaction exceeds $15M over five years.`
       return [n, ...(n.children ?? []).flatMap(collect)]
     })
     const twoCol = allNodes.find((n) => n.hints?.twoColumn === "true")
-    expect(twoCol?.component).toBe("Stack")
-    expect(twoCol?.children?.length).toBe(2)
-    expect(twoCol?.children?.every((c) => c.component === "TextContent")).toBe(true)
+    expect(twoCol?.component).toBe("TwoColumnProse")
+    expect(typeof twoCol?.hints?.left).toBe("string")
+    expect(typeof twoCol?.hints?.right).toBe("string")
     const block = formatLayoutPlanForExecutor(plan)
-    expect(block).toMatch(/Stack\(\[TextContent\(/)
-    expect(block).toMatch(/"row", "m", "stretch", "start", true/)
+    expect(block).toMatch(/REQUIRED_LANG: TwoColumnProse\(left=/)
+    expect(block).not.toMatch(/Stack\(\[TextContent\(/)
   })
 
   test("numbered purpose outline is Bullets not Table", () => {
@@ -320,10 +324,10 @@ The hybrid model balances governance with agility.`
       return [n, ...(n.children ?? []).flatMap(collect)]
     })
     const twoCol = allNodes.find((n) => n.id.includes("1-1") && n.hints?.twoColumn === "true")
-    expect(twoCol?.component).toBe("Stack")
+    expect(twoCol?.component).toBe("TwoColumnProse")
     const block = formatLayoutPlanForExecutor(plan)
-    expect(block).toMatch(/inlined in REQUIRED_LANG/)
-    expect(block).not.toMatch(/section-1-1-overview[^"]*"\s*\n\s*children:\s*\n\s*- id: section-1-1-overview-col1/s)
+    expect(block).toMatch(/REQUIRED_LANG: TwoColumnProse\(left=/)
+    expect(block).not.toMatch(/section-1-1-overview-col1/)
 
     const section12Nodes = allNodes.filter((n) => n.id.includes("1-2"))
     expect(section12Nodes.some((n) => n.component === "Table" && n.sourceText.includes("Initiation"))).toBe(
@@ -525,11 +529,111 @@ Second paragraph also has enough characters to qualify for two column layout in 
       return [n, ...(n.children ?? []).flatMap(collect)]
     })
     const twoCol = allNodes.find((n) => n.hints?.twoColumn === "true")
-    const [c1, c2] = twoCol?.children ?? []
-    expect(c1?.sourceText).toBe(para1)
-    expect(c2?.sourceText).toBe(para2)
-    expect(c1?.sourceText).toMatch(/\.\s*$/)
-    expect(c2?.sourceText).toMatch(/^Key benefits/)
+    expect(twoCol?.hints?.left).toBe(para1)
+    expect(twoCol?.hints?.right).toBe(para2)
+    expect(String(twoCol?.hints?.left)).toMatch(/\.\s*$/)
+    expect(String(twoCol?.hints?.right)).toMatch(/^Key benefits/)
+  })
+})
+
+describe("repairTwoColumnProseInLang", () => {
+  test("rewrites adjacent TextContent pair to TwoColumnProse", () => {
+    const para1 =
+      "The purpose of this Scope Management Plan (SMP) is to establish a comprehensive framework for defining, documenting, validating, and controlling the project scope for the ADPA - Implementation of OpenUI and Auto UI Generation project."
+    const para2 =
+      "This document serves as a subsidiary plan to the Project Management Plan (PMP) and provides detailed guidance on scope-related processes, roles, responsibilities, and deliverables."
+    const source = `## 1. Introduction and Scope Management Approach
+
+### 1.1 Overview of the Scope Management Plan
+${para1}
+
+${para2}`
+    const plan = buildLayoutPlan({
+      prompt: "Render the full document to a interactive UI Component Report",
+      sourceText: source,
+    })
+    const allNodes = plan.nodes.flatMap(function collect(n: LayoutPlanNode): LayoutPlanNode[] {
+      return [n, ...(n.children ?? []).flatMap(collect)]
+    })
+    expect(allNodes.some((n) => n.component === "TwoColumnProse")).toBe(true)
+
+    const badLang = `root = Stack([
+  section = Stack([
+    CardHeader("1.1 Overview of the Scope Management Plan"),
+    TextContent("${para1}", "default"),
+    TextContent("${para2}", "default")
+  ])
+])`
+    const fixed = repairTwoColumnProseInLang(badLang, plan)
+    expect(fixed).toMatch(/TwoColumnProse\(left=/)
+    expect(fixed).not.toMatch(/TextContent\("The purpose of this Scope/)
+  })
+})
+
+describe("stripDividerNoiseInLang", () => {
+  test("removes divider-only TextContent assignments and Stack references", () => {
+    const lang = `subSec2_3 = Stack([
+  subSec2_3_Header = CardHeader("2.3 Scope Exclusions"),
+  sec2_3_Part0 = TextContent("Exclusion text here.", "default"),
+  sec2_3_Part1 = Table([Col("A", ["1"])]),
+  sec2_3_Part2 = TextContent("---")
+])`
+    const fixed = stripDividerNoiseInLang(lang)
+    expect(fixed).not.toMatch(/sec2_3_Part2/)
+    expect(fixed).not.toMatch(/TextContent\("---"/)
+    expect(fixed).toMatch(/sec2_3_Part1/)
+    expect(fixed).toMatch(/Stack\(\[/)
+  })
+
+  test("removes inline TextContent dividers in arrays", () => {
+    const lang = `x = Stack([CardHeader("T"), TextContent("body", "default"), TextContent("---", "default")])`
+    const fixed = stripDividerNoiseInLang(lang)
+    expect(fixed).not.toMatch(/TextContent\("---"/)
+    expect(fixed).toMatch(/TextContent\("body"/)
+  })
+})
+
+describe("pruneUndefinedRefsInLang", () => {
+  test("removes undefined ids from Stack and Card child arrays", () => {
+    const lang = `ch9_sec1_prose = TwoColumnProse("a", "b")
+ch9_sec9_1 = Stack([ch9_sec9_1_header, ch9_sec1_prose], "column", "s")
+card_ch9 = Card([ch9_header, ch9_sec9_1, ch9_missing], "card")`
+    const fixed = pruneUndefinedRefsInLang(lang)
+    expect(fixed).not.toMatch(/ch9_sec9_1_header/)
+    expect(fixed).not.toMatch(/ch9_missing/)
+    expect(fixed).toMatch(/ch9_sec1_prose/)
+    expect(fixed).toMatch(/Stack\(\[ch9_sec1_prose\]/)
+  })
+})
+
+describe("repairGenuiExecutorLang", () => {
+  test("applies two-column repair and divider cleanup", () => {
+    const para1 =
+      "The purpose of this Scope Management Plan (SMP) is to establish a comprehensive framework for defining, documenting, validating, and controlling the project scope for the ADPA - Implementation of OpenUI and Auto UI Generation project."
+    const para2 =
+      "This document serves as a subsidiary plan to the Project Management Plan (PMP) and provides detailed guidance on scope-related processes, roles, responsibilities, and deliverables."
+    const source = `## 1. Introduction and Scope Management Approach
+
+### 1.1 Overview of the Scope Management Plan
+${para1}
+
+${para2}`
+    const plan = buildLayoutPlan({
+      prompt: "Render the full document to a interactive UI Component Report",
+      sourceText: source,
+    })
+    const badLang = `root = Stack([
+  section = Stack([
+    CardHeader("1.1 Overview of the Scope Management Plan"),
+    TextContent("${para1}", "default"),
+    TextContent("${para2}", "default"),
+    tail = TextContent("---")
+  ])
+])`
+    const fixed = repairGenuiExecutorLang(badLang, plan)
+    expect(fixed).toMatch(/TwoColumnProse\(left=/)
+    expect(fixed).not.toMatch(/TextContent\("---"/)
+    expect(fixed).not.toMatch(/\btail\b/)
   })
 })
 

--- a/__tests__/lib/layoutPlan.test.ts
+++ b/__tests__/lib/layoutPlan.test.ts
@@ -2,7 +2,9 @@ import {
   buildLayoutPlan,
   formatLayoutPlanForExecutor,
   segmentSourceText,
+  splitBodyIntoContentBlocks,
   splitProseIntoTwoColumns,
+  stripProseDividers,
   wantsGenuiReportDarkTheme,
 } from "@/lib/openui/layoutPlan"
 import type { LayoutPlanNode } from "@/lib/openui/layoutPlanTypes"
@@ -284,6 +286,93 @@ Architecture details.`
     expect(plan.nodes.length).toBeGreaterThan(3)
   })
 
+  test("SMP §1.1 two-column plan does not list duplicate col children to executor", () => {
+    const para1 =
+      "The purpose of this Scope Management Plan (SMP) is to establish a comprehensive framework for defining, documenting, validating, and controlling the project scope for the ADPA - Implementation of OpenUI and Auto UI Generation project."
+    const para2 =
+      "This document serves as a subsidiary plan to the Project Management Plan (PMP) and provides detailed guidance on scope-related processes, roles, responsibilities, and deliverables."
+    const source = `## 1. Introduction and Scope Management Approach
+
+### 1.1 Overview of the Scope Management Plan
+${para1}
+
+${para2}
+
+---
+
+### 1.2 Project Scope Management Approach
+Intro paragraph before the table.
+
+| Phase | Approach |
+| --- | --- |
+| Initiation | Predictive |
+| Execution | Adaptive |
+
+**Justification for Hybrid Approach:**
+The hybrid model balances governance with agility.`
+
+    const plan = buildLayoutPlan({
+      prompt: "Render the full document to a interactive UI Component Report",
+      sourceText: source,
+    })
+
+    const allNodes = plan.nodes.flatMap(function collect(n): LayoutPlanNode[] {
+      return [n, ...(n.children ?? []).flatMap(collect)]
+    })
+    const twoCol = allNodes.find((n) => n.id.includes("1-1") && n.hints?.twoColumn === "true")
+    expect(twoCol?.component).toBe("Stack")
+    const block = formatLayoutPlanForExecutor(plan)
+    expect(block).toMatch(/inlined in REQUIRED_LANG/)
+    expect(block).not.toMatch(/section-1-1-overview[^"]*"\s*\n\s*children:\s*\n\s*- id: section-1-1-overview-col1/s)
+
+    const section12Nodes = allNodes.filter((n) => n.id.includes("1-2"))
+    expect(section12Nodes.some((n) => n.component === "Table" && n.sourceText.includes("Initiation"))).toBe(
+      true
+    )
+    expect(
+      section12Nodes.some((n) => n.sourceText.includes("Justification for Hybrid Approach"))
+    ).toBe(true)
+    expect(section12Nodes.some((n) => n.sourceText.includes("Intro paragraph"))).toBe(true)
+  })
+
+  test("scope management metadata headings do not become top-level chapter cards", () => {
+    const source = `# Scope Management Plan
+
+## Project: ADPA - Implementation of OpenUI and Auto UI Generation
+## Date: May 15, 2026
+## Version: 1.0
+
+---
+
+## 1. Introduction and Scope Management Approach
+
+### 1.1 Purpose of the Document
+The purpose of this Scope Management Plan (SMP) is to establish a comprehensive framework.
+
+## 2. Scope Definition and Documentation
+
+### 2.1 Project Scope Statement
+The Project Scope Statement defines boundaries.`
+
+    const plan = buildLayoutPlan({
+      prompt: "Render the full document to a interactive UI Component Report",
+      sourceText: source,
+    })
+
+    const topLevelCards = plan.nodes.filter(
+      (n) => n.component === "Card" && n.id.startsWith("card-chapter")
+    )
+    expect(topLevelCards.map((n) => n.label)).toEqual([
+      "1. Introduction and Scope Management Approach",
+      "2. Scope Definition and Documentation",
+    ])
+    const cover = plan.nodes.find((n) => n.id === "doc-cover")
+    const coverSummary = cover?.children?.find((c) => c.id === "cover-summary")
+    expect(coverSummary?.sourceText).toMatch(/ADPA/)
+    expect(coverSummary?.sourceText).toMatch(/May 15, 2026/)
+    expect(coverSummary?.sourceText).toMatch(/Version: 1\.0/)
+  })
+
   test("hierarchical report puts cover before TOC and chapters", () => {
     const source = `# OpenUI Integration with ADPA Systems
 Strategic Framework Enhancement
@@ -347,7 +436,40 @@ ROI discussion.`
   })
 })
 
-describe("splitProseIntoTwoColumns", () => {
+describe("splitBodyIntoContentBlocks", () => {
+  test("splits prose, table, and justification tail for §1.2-style sections", () => {
+    const body = `Intro paragraph before the table.
+
+| Phase | Approach |
+| --- | --- |
+| Initiation | Predictive |
+
+**Justification for Hybrid Approach:**
+The hybrid model balances governance with agility.`
+    const blocks = splitBodyIntoContentBlocks(body)
+    expect(blocks.length).toBe(3)
+    expect(blocks[0]?.kind).toBe("prose")
+    expect(blocks[0]?.text).toMatch(/Intro paragraph/)
+    expect(blocks[1]?.kind).toBe("table")
+    expect(blocks[2]?.text).toMatch(/Justification for Hybrid Approach/)
+  })
+})
+
+describe("stripProseDividers and splitProseIntoTwoColumns", () => {
+  test("horizontal rule between paragraphs is not a third column", () => {
+    const body = `First paragraph with enough characters to qualify for two column layout in the report.
+
+Second paragraph also has enough characters to qualify for two column layout in the report.
+
+---`
+    const stripped = stripProseDividers(body)
+    const [left, right] = splitProseIntoTwoColumns(stripped)
+    expect(left).toMatch(/First paragraph/)
+    expect(right).toMatch(/Second paragraph/)
+    expect(left).not.toContain("---")
+    expect(right).not.toContain("---")
+  })
+
   test("splits on paragraph boundaries when possible", () => {
     const body = "First paragraph with enough text to matter.\n\nSecond paragraph also has substantive content for the right column."
     const [left, right] = splitProseIntoTwoColumns(body.repeat(3))

--- a/app/projects/[id]/documents/genui/genui-workspace.css
+++ b/app/projects/[id]/documents/genui/genui-workspace.css
@@ -180,6 +180,24 @@
   color: rgb(71 85 105);
 }
 
+.genui-openui-root .genui-two-column-prose {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  width: 100%;
+  align-items: start;
+}
+
+@media (max-width: 40rem) {
+  .genui-openui-root .genui-two-column-prose {
+    grid-template-columns: 1fr;
+  }
+}
+
+.genui-openui-root.genui-report-dark .genui-two-column-prose .genui-report-prose {
+  color: rgb(212 212 212);
+}
+
 .genui-openui-root.genui-report-dark .report-toc {
   background-color: rgb(38 38 38) !important;
   border-color: rgb(64 64 64) !important;

--- a/app/projects/[id]/documents/genui/page.tsx
+++ b/app/projects/[id]/documents/genui/page.tsx
@@ -6,7 +6,11 @@ import "@openuidev/react-ui/defaults.css";
 import "@openuidev/react-ui/components.css";
 import "./genui-workspace.css";
 import { FullScreen } from "@openuidev/react-ui";
-import { openAIMessageFormat, openAIReadableStreamAdapter } from "@openuidev/react-headless";
+import {
+  openAIMessageFormat,
+  openAIReadableStreamAdapter,
+  type AssistantMessage as OpenUIAssistantMessage,
+} from "@openuidev/react-headless";
 import { projectOpenUILibrary } from "@/lib/openui/projectOpenUILibrary";
 import { trimTextForGenuiPrompt } from "@/lib/llm/genuiPromptBudget";
 import { buildOpenUIGenuiLibraryPrompt, enrichOpenUIApiMessages } from "@/lib/openui/systemPrompt";
@@ -172,6 +176,21 @@ export default function DocumentGenUIWorkspace() {
       })),
     }),
     [starterPrompts]
+  );
+
+  const genuiLayoutPrompt =
+    "Render the full document to a interactive UI Component Report";
+
+  const renderGenuiAssistantMessage = useCallback(
+    (props: { message: OpenUIAssistantMessage; isStreaming: boolean }) => (
+      <CustomAssistantMessage
+        {...props}
+        layoutSourceText={doc?.content}
+        layoutPrompt={genuiLayoutPrompt}
+        documentId={documentId ?? undefined}
+      />
+    ),
+    [doc?.content, documentId]
   );
 
   if (authLoading || (loading && !doc)) {
@@ -459,7 +478,7 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                       ),
                     }}
                     conversationStarters={conversationStarters}
-                    assistantMessage={CustomAssistantMessage}
+                    assistantMessage={renderGenuiAssistantMessage}
                   />
                 </div>
               </div>

--- a/components/openui-chat/AssistantMessage.tsx
+++ b/components/openui-chat/AssistantMessage.tsx
@@ -10,15 +10,23 @@ import {
   extractOpenUILangText,
   looksLikeOpenUILang,
 } from "@/lib/openui/library";
+import { buildLayoutPlan, repairGenuiExecutorLang } from "@/lib/openui/layoutPlan";
 
 interface AssistantMessageProps {
   message: AssistantMessage;
   isStreaming: boolean;
+  /** When set (GenUI workspace), repair stacked TextContent → TwoColumnProse before render. */
+  layoutSourceText?: string;
+  layoutPrompt?: string;
+  documentId?: string;
 }
 
 export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
   message,
   isStreaming,
+  layoutSourceText,
+  layoutPrompt,
+  documentId,
 }) => {
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
@@ -28,6 +36,17 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
 
   const rawContent = message.content || "";
   const langText = useMemo(() => extractOpenUILangText(rawContent), [rawContent]);
+  const renderLangText = useMemo(() => {
+    if (isStreaming || !layoutSourceText?.trim() || !langText?.trim()) return langText
+    const plan = buildLayoutPlan({
+      prompt:
+        layoutPrompt?.trim() ||
+        "Render the full document to a interactive UI Component Report",
+      sourceText: layoutSourceText,
+      documentId,
+    })
+    return repairGenuiExecutorLang(langText, plan)
+  }, [isStreaming, layoutSourceText, layoutPrompt, documentId, langText])
   const isGenUILang = useMemo(
     () => looksLikeOpenUILang(langText),
     [langText]
@@ -140,7 +159,7 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
         ) : isGenUILang ? (
           <div className="genui-lang-render min-w-0 w-full">
             <DynamicComponentRenderer
-              response={langText}
+              response={renderLangText}
               isStreaming={isStreaming}
             />
           </div>

--- a/components/openui-chat/components/TwoColumnProseComponent.tsx
+++ b/components/openui-chat/components/TwoColumnProseComponent.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { MarkdownRenderer } from "@/components/documents/MarkdownRenderer"
+import type { OpenUIChatJson } from "@/lib/openui/library"
+
+interface TwoColumnProseComponentProps {
+  props: Record<string, OpenUIChatJson>
+  data: Array<Record<string, OpenUIChatJson>>
+}
+
+const PROSE_CLASS =
+  "prose prose-slate prose-sm max-w-none genui-report-prose " +
+  "prose-p:leading-7 prose-p:my-2 prose-headings:text-slate-900"
+
+export function TwoColumnProseComponent({ props }: TwoColumnProseComponentProps) {
+  const left = String(props.left ?? "").trim()
+  const right = String(props.right ?? "").trim()
+
+  if (!left && !right) {
+    return null
+  }
+
+  return (
+    <div className="genui-two-column-prose">
+      {left ? (
+        <div className="min-w-0">
+          <MarkdownRenderer content={left} className={PROSE_CLASS} />
+        </div>
+      ) : null}
+      {right ? (
+        <div className="min-w-0">
+          <MarkdownRenderer content={right} className={PROSE_CLASS} />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/lib/llm/genuiPromptBudget.ts
+++ b/lib/llm/genuiPromptBudget.ts
@@ -74,16 +74,31 @@ function trimLeafSourceText(text: string, maxChars: number): string {
   return `${trimmed.slice(0, maxChars)}${TRUNCATION_NOTE}`
 }
 
+function leafSourceMaxChars(node: LayoutPlanNode, baseLeafMax: number): number {
+  if (node.component !== "Table") return baseLeafMax
+  const pipeRows = node.sourceText.split("\n").filter((l) => /^\|/.test(l.trim())).length
+  if (node.hints?.wbsDictionary === "true" || node.hints?.wideTable === "true" || pipeRows >= 10) {
+    return Math.max(baseLeafMax, 8_000, Math.min(14_000, pipeRows * 140))
+  }
+  if (pipeRows >= 6) {
+    return Math.max(baseLeafMax, 4_000)
+  }
+  return baseLeafMax
+}
+
 function compactLayoutPlanNode(node: LayoutPlanNode, leafMaxChars: number): LayoutPlanNode {
-  const children = node.children?.map((c) => compactLayoutPlanNode(c, leafMaxChars))
+  const children = node.children?.map((c) =>
+    compactLayoutPlanNode(c, leafSourceMaxChars(c, leafMaxChars))
+  )
   const hasChildren = Boolean(children?.length)
+  const effectiveLeafMax = leafSourceMaxChars(node, leafMaxChars)
 
   let sourceText = node.sourceText
   if (hasChildren && CONTAINER_WITH_CHILDREN.has(node.component)) {
     const hint = (node.label ?? sourceText).trim()
     sourceText = hint.slice(0, GENUI_LAYOUT_CONTAINER_SOURCE_MAX_CHARS)
   } else {
-    sourceText = trimLeafSourceText(sourceText, leafMaxChars)
+    sourceText = trimLeafSourceText(sourceText, effectiveLeafMax)
   }
 
   return { ...node, sourceText, children }

--- a/lib/openui/adpaGenuiExtensionDefs.ts
+++ b/lib/openui/adpaGenuiExtensionDefs.ts
@@ -9,6 +9,7 @@ import { ReportCoverHeroDef } from "./reportCoverHeroDef"
 import { TableOfContentsDef } from "./tableOfContentsDef"
 import { TeamDef } from "./teamDef"
 import { TimelineDef } from "./timelineDef"
+import { TwoColumnProseDef } from "./twoColumnProseDef"
 
 export const ADPA_GENUI_EXTENSION_DEFS = [
   BulletsDef,
@@ -17,6 +18,7 @@ export const ADPA_GENUI_EXTENSION_DEFS = [
   ComparisonDef,
   TableOfContentsDef,
   ReportCoverHeroDef,
+  TwoColumnProseDef,
 ] as const
 
 export const ADPA_GENUI_EXTENSION_NAMES = [
@@ -26,4 +28,5 @@ export const ADPA_GENUI_EXTENSION_NAMES = [
   "Comparison",
   "TableOfContents",
   "ReportCoverHero",
+  "TwoColumnProse",
 ] as const

--- a/lib/openui/layoutPlan.ts
+++ b/lib/openui/layoutPlan.ts
@@ -215,10 +215,14 @@ const TWO_COLUMN_MIN_CHARS = 360
 
 function shouldUseTwoColumnProse(body: string): boolean {
   const trimmed = stripProseDividers(body)
-  if (trimmed.length < TWO_COLUMN_MIN_CHARS) return false
+  if (!trimmed) return false
   if (isMarkdownTableBlock(trimmed) || isBulletListBlock(trimmed)) return false
   if (isNumberedSectionOutlineList(trimmed)) return false
   const paragraphs = trimmed.split(/\n\n+/).filter((p) => p.trim())
+  if (paragraphs.length === 2) {
+    const [a, b] = paragraphs
+    if (a.length >= 80 && b.length >= 80 && trimmed.length >= 200) return true
+  }
   if (paragraphs.length >= 2 && trimmed.length >= 280) return true
   return trimmed.length >= TWO_COLUMN_MIN_CHARS
 }
@@ -694,41 +698,20 @@ function buildCompositeSegmentNode(seg: TextSegment, blocks: SectionContentBlock
   }
 }
 
-function buildTwoColumnTextNode(
-  seg: TextSegment,
-  classified: ReturnType<typeof classifySegmentBody>
-): LayoutPlanNode {
-  const [col1, col2] = splitProseIntoTwoColumns(seg.body)
+function buildTwoColumnTextNode(seg: TextSegment): LayoutPlanNode {
+  const [left, right] = splitProseIntoTwoColumns(stripProseDividers(seg.body))
   return {
     id: seg.id,
-    component: "Stack",
+    component: "TwoColumnProse",
     mapping: "widget",
     sourceText: seg.body,
     label: seg.title,
-    fallbackReason: classified.fallbackReason,
     hints: {
-      ...classified.hints,
       twoColumn: "true",
-      note: "row Stack with two TextContent columns — pre-split at sentence boundaries in sourceText; do not duplicate",
+      left,
+      right,
+      note: "emit exactly TwoColumnProse(left, right) — never Stack row or three stacked TextContent blocks",
     },
-    children: [
-      {
-        id: `${seg.id}-col1`,
-        component: "TextContent",
-        mapping: "typography-fallback",
-        sourceText: col1,
-        fallbackReason: classified.fallbackReason,
-        hints: { variant: "default", column: "left" },
-      },
-      {
-        id: `${seg.id}-col2`,
-        component: "TextContent",
-        mapping: "typography-fallback",
-        sourceText: col2,
-        fallbackReason: classified.fallbackReason,
-        hints: { variant: "default", column: "right" },
-      },
-    ],
   }
 }
 
@@ -1260,12 +1243,12 @@ function escapeLangString(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
 }
 
-function twoColumnStackRequiredLang(n: LayoutPlanNode, pad: string): string {
-  if (n.hints?.twoColumn !== "true" || n.component !== "Stack") return ""
-  const cols = n.children?.filter((c) => c.component === "TextContent") ?? []
-  if (cols.length !== 2) return ""
-  const [a, b] = cols
-  return `${pad}  REQUIRED_LANG: Stack([TextContent("${escapeLangString(a.sourceText)}", "default"), TextContent("${escapeLangString(b.sourceText)}", "default")], "row", "m", "stretch", "start", true)`
+function twoColumnProseRequiredLang(n: LayoutPlanNode, pad: string): string {
+  if (n.component !== "TwoColumnProse" || n.hints?.twoColumn !== "true") return ""
+  const left = n.hints.left
+  const right = n.hints.right
+  if (typeof left !== "string" || typeof right !== "string") return ""
+  return `${pad}  REQUIRED_LANG: TwoColumnProse(left="${escapeLangString(left)}", right="${escapeLangString(right)}")`
 }
 
 function flattenNodes(nodes: LayoutPlanNode[], depth = 0): string[] {
@@ -1273,7 +1256,7 @@ function flattenNodes(nodes: LayoutPlanNode[], depth = 0): string[] {
   for (const n of nodes) {
     const pad = "  ".repeat(depth)
     const headerLabel = n.label?.trim()
-    const twoColLang = twoColumnStackRequiredLang(n, pad)
+    const twoColLang = twoColumnProseRequiredLang(n, pad)
     lines.push(
       `${pad}- id: ${n.id}`,
       `${pad}  component: ${n.component}`,
@@ -1298,7 +1281,7 @@ function flattenNodes(nodes: LayoutPlanNode[], depth = 0): string[] {
     if (n.children?.length) {
       if (twoColLang) {
         lines.push(
-          `${pad}  children: (inlined in REQUIRED_LANG above — emit exactly two TextContent in one row Stack; do NOT add a third TextContent for the full sourceText)`
+          `${pad}  children: (none — emit only REQUIRED_LANG TwoColumnProse above; do NOT add TextContent or Stack)`
         )
       } else {
         lines.push(`${pad}  children:`)
@@ -1351,11 +1334,12 @@ export function formatLayoutPlanForExecutor(
     "- Subsections (### or 1.1, 1.2) go INSIDE the chapter Card as Stack blocks with subsection CardHeader — never a separate top-level Card per ###.",
     "- Skip empty heading-only nodes; do not emit TextContent that only repeats the section title — use CardHeader for the title instead.",
     "- Narrative prose → TextContent. Bullet/numbered lists → Bullets. Markdown tables → Table([Col(\"Header\", [cells...]), ...]) with ONE argument only — never Table(..., \"caption\").",
-    "- Long narrative blocks (hints.twoColumn or REQUIRED_LANG row Stack): exactly ONE row Stack with exactly TWO TextContent children — never three stacked paragraphs for a two-column subsection.",
-    "- When REQUIRED_LANG shows a two-column Stack, do not emit separate TextContent nodes for col1/col2 ids; use only the REQUIRED_LANG Stack.",
+    "- Two-column narrative (component TwoColumnProse or hints.twoColumn): emit exactly TwoColumnProse(left=\"…\", right=\"…\") with the left/right strings from the plan — never three stacked TextContent blocks or a column Stack.",
+    "- When REQUIRED_LANG shows TwoColumnProse, copy it verbatim for that node id; do not substitute Stack([TextContent, TextContent], \"row\", …).",
     "- Subsections with multiple blocks (Stack children in plan): render every child in order — intro prose, then Table, then trailing prose (e.g. Justification for Hybrid Approach).",
+    "- Do not emit TextContent(\"---\") or other horizontal-rule placeholders; markdown --- lines are omitted from plan prose — end the subsection after the last real paragraph or table.",
     "- WBS Dictionary and wide markdown tables: use Table with all pipe rows from sourceText; hints.wbsDictionary means preserve Level 1–4 columns.",
-    "- Apply two-column row Stacks for chapter lead paragraphs and long subsection intros (e.g. Executive Summary, §2.1 Purpose, §3.1) when the plan marks twoColumn or REQUIRED_LANG on a Stack node.",
+    "- Apply TwoColumnProse for chapter lead paragraphs and long subsection intros (e.g. Executive Summary, §1.1 Overview) when the plan component is TwoColumnProse.",
     "- Use Accordion only when the user prompt explicitly requests accordion/collapsible/FAQ AND Bullets is not a better fit.",
     "- Do not invent metrics, dates, or names not supported by source text.",
     "- Do not append duplicate appendix tables at the end of the document; place each table only under its matching ### subsection.",
@@ -1373,6 +1357,202 @@ export function formatLayoutPlanForExecutor(
     ...flattenNodes(cappedPlan.nodes),
     "=== END LAYOUT PLAN ===",
   ].join("\n")
+}
+
+function collectAllPlanNodes(nodes: LayoutPlanNode[]): LayoutPlanNode[] {
+  const out: LayoutPlanNode[] = []
+  for (const n of nodes) {
+    out.push(n)
+    if (n.children?.length) out.push(...collectAllPlanNodes(n.children))
+  }
+  return out
+}
+
+function unescapeLangString(s: string): string {
+  return s.replace(/\\"/g, '"').replace(/\\\\/g, "\\")
+}
+
+/**
+ * When the executor ignores REQUIRED_LANG and emits stacked TextContent pairs,
+ * rewrite matching pairs to TwoColumnProse using plan left/right hints.
+ */
+function isHorizontalRulePlaceholder(text: string): boolean {
+  const t = text.trim()
+  return /^---+$/.test(t) || /^\s*[*_]{3,}\s*$/.test(t)
+}
+
+const ASSIGN_TEXT_CONTENT_RE =
+  /^\s*(\w+)\s*=\s*TextContent\s*\(\s*(?:"((?:[^"\\]|\\.)*)"|text\s*=\s*"((?:[^"\\]|\\.)*)")(?:\s*,\s*"[^"]*")?\s*\)\s*,?\s*$/gm
+
+const INLINE_DIVIDER_TEXT_CONTENT_RE =
+  /,?\s*TextContent\s*\(\s*(?:"---+"|text\s*=\s*"---+")(?:\s*,\s*"[^"]*")?\s*\)\s*/g
+
+/**
+ * Remove executor-only horizontal-rule placeholders (TextContent("---")) that
+ * duplicate markdown dividers already stripped from the layout plan.
+ */
+export function stripDividerNoiseInLang(lang: string): string {
+  const dividerVarNames = new Set<string>()
+  let m: RegExpExecArray | null
+  ASSIGN_TEXT_CONTENT_RE.lastIndex = 0
+  while ((m = ASSIGN_TEXT_CONTENT_RE.exec(lang)) !== null) {
+    const raw = m[2] ?? m[3] ?? ""
+    if (isHorizontalRulePlaceholder(unescapeLangString(raw))) {
+      dividerVarNames.add(m[1])
+    }
+  }
+
+  let out = lang
+  for (const name of dividerVarNames) {
+    out = out.replace(
+      new RegExp(`^\\s*${name}\\s*=\\s*TextContent\\s*\\([^)]*\\)\\s*,?\\s*$`, "gm"),
+      ""
+    )
+    out = out.replace(new RegExp(`,\\s*${name}\\s*(?=\\])`), "")
+    out = out.replace(new RegExp(`\\[\\s*${name}\\s*,`), "[")
+    out = out.replace(new RegExp(`${name}\\s*,\\s*`), "")
+  }
+
+  out = out.replace(INLINE_DIVIDER_TEXT_CONTENT_RE, "")
+  return out.replace(/\n{3,}/g, "\n\n")
+}
+
+function collectLangDefinedIds(lang: string): Set<string> {
+  const ids = new Set<string>()
+  const re = /^\s*(\w+)\s*=/gm
+  let m: RegExpExecArray | null
+  while ((m = re.exec(lang)) !== null) {
+    ids.add(m[1])
+  }
+  return ids
+}
+
+function splitTopLevelCommaList(inner: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let start = 0
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i]
+    if (c === "[" || c === "(" || c === "{") depth++
+    else if (c === "]" || c === ")" || c === "}") depth--
+    else if (c === "," && depth === 0) {
+      const piece = inner.slice(start, i).trim()
+      if (piece) parts.push(piece)
+      start = i + 1
+    }
+  }
+  const tail = inner.slice(start).trim()
+  if (tail) parts.push(tail)
+  return parts
+}
+
+function findBalancedBracketSlice(
+  text: string,
+  openBracketIdx: number
+): { inner: string; closeIdx: number } | null {
+  if (text[openBracketIdx] !== "[") return null
+  let depth = 0
+  for (let i = openBracketIdx; i < text.length; i++) {
+    const c = text[i]
+    if (c === "[") depth++
+    else if (c === "]") {
+      depth--
+      if (depth === 0) {
+        return { inner: text.slice(openBracketIdx + 1, i), closeIdx: i }
+      }
+    }
+  }
+  return null
+}
+
+function pruneCommaListIdentifiers(inner: string, defined: Set<string>): string {
+  const parts = splitTopLevelCommaList(inner)
+  const kept = parts.filter((part) => {
+    const idOnly = part.match(/^(\w+)$/)
+    if (!idOnly) return true
+    return defined.has(idOnly[1])
+  })
+  return kept.join(", ")
+}
+
+/**
+ * Drop Stack/Card child ids that were never assigned (executor typos like a missing subsection header).
+ */
+export function pruneUndefinedRefsInLang(lang: string): string {
+  const defined = collectLangDefinedIds(lang)
+  const arrayOpenRe = /(Stack|Card)\s*\(\s*\[/g
+  let out = ""
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = arrayOpenRe.exec(lang)) !== null) {
+    const openBracket = m.index + m[0].length - 1
+    const balanced = findBalancedBracketSlice(lang, openBracket)
+    if (!balanced) {
+      last = m.index + 1
+      continue
+    }
+    out += lang.slice(last, openBracket + 1)
+    out += pruneCommaListIdentifiers(balanced.inner, defined)
+    last = balanced.closeIdx
+    arrayOpenRe.lastIndex = last + 1
+  }
+  out += lang.slice(last)
+  return out
+}
+
+/** Post-process executor Lang: two-column repair, divider cleanup, dangling ref prune. */
+export function repairGenuiExecutorLang(lang: string, plan: LayoutPlan): string {
+  return pruneUndefinedRefsInLang(
+    stripDividerNoiseInLang(repairTwoColumnProseInLang(lang, plan))
+  )
+}
+
+export function repairTwoColumnProseInLang(lang: string, plan: LayoutPlan): string {
+  let out = lang
+  for (const node of collectAllPlanNodes(plan.nodes)) {
+    if (node.component !== "TwoColumnProse" || node.hints?.twoColumn !== "true") continue
+    const left = node.hints.left
+    const right = node.hints.right
+    if (typeof left !== "string" || typeof right !== "string" || !left.trim() || !right.trim()) {
+      continue
+    }
+
+    const canonical = `TwoColumnProse(left="${escapeLangString(left)}", right="${escapeLangString(right)}")`
+    if (out.includes(canonical)) continue
+
+    const leftKey = left.replace(/\s+/g, " ").trim().slice(0, 48)
+    const rightKey = right.replace(/\s+/g, " ").trim().slice(0, 48)
+    if (!leftKey || !rightKey) continue
+
+    const pairRe =
+      /TextContent\s*\(\s*"((?:[^"\\]|\\.)*)"\s*,[^)]*\)\s*,?\s*TextContent\s*\(\s*"((?:[^"\\]|\\.)*)"\s*,[^)]*\)/gs
+
+    out = out.replace(pairRe, (match, rawA, rawB) => {
+      const a = unescapeLangString(rawA)
+      const b = unescapeLangString(rawB)
+      const aLeft = a.includes(leftKey) || leftKey.includes(a.slice(0, 40))
+      const bRight = b.includes(rightKey) || rightKey.includes(b.slice(0, 40))
+      const aRight = a.includes(rightKey) || rightKey.includes(a.slice(0, 40))
+      const bLeft = b.includes(leftKey) || leftKey.includes(b.slice(0, 40))
+      if (aLeft && bRight) return canonical
+      if (aRight && bLeft) {
+        return `TwoColumnProse(left="${escapeLangString(right)}", right="${escapeLangString(left)}")`
+      }
+      return match
+    })
+
+    const rowStackRe =
+      /Stack\s*\(\s*\[\s*TextContent\s*\(\s*"((?:[^"\\]|\\.)*)"\s*,[^)]*\)\s*,\s*TextContent\s*\(\s*"((?:[^"\\]|\\.)*)"\s*,[^)]*\)\s*\]\s*,\s*"row"[^)]*\)/gs
+    out = out.replace(rowStackRe, (match, rawA, rawB) => {
+      const a = unescapeLangString(rawA)
+      const b = unescapeLangString(rawB)
+      const aLeft = a.includes(leftKey) || leftKey.includes(a.slice(0, 40))
+      const bRight = b.includes(rightKey) || rightKey.includes(b.slice(0, 40))
+      if (aLeft && bRight) return canonical
+      return match
+    })
+  }
+  return out
 }
 
 export const OPENUI_EXECUTOR_RULES = [

--- a/lib/openui/layoutPlan.ts
+++ b/lib/openui/layoutPlan.ts
@@ -214,7 +214,7 @@ function isStructuredTabularLines(text: string): boolean {
 const TWO_COLUMN_MIN_CHARS = 360
 
 function shouldUseTwoColumnProse(body: string): boolean {
-  const trimmed = body.trim()
+  const trimmed = stripProseDividers(body)
   if (trimmed.length < TWO_COLUMN_MIN_CHARS) return false
   if (isMarkdownTableBlock(trimmed) || isBulletListBlock(trimmed)) return false
   if (isNumberedSectionOutlineList(trimmed)) return false
@@ -288,9 +288,80 @@ export function findSentenceBoundarySplitIndex(
   return best
 }
 
+/** Remove horizontal rules and other non-prose dividers before column split. */
+export function stripProseDividers(body: string): string {
+  return body
+    .replace(/^---+$/gm, "")
+    .replace(/^\s*[*_]{3,}\s*$/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+type SectionContentBlock = { kind: "prose" | "table"; text: string }
+
+/** Split subsection body into prose blocks and markdown tables (keeps intro + table + tail prose). */
+export function splitBodyIntoContentBlocks(body: string): SectionContentBlock[] {
+  const text = body.trim()
+  if (!text) return []
+
+  const lines = text.split("\n")
+  const blocks: SectionContentBlock[] = []
+  let proseBuf: string[] = []
+  let tableBuf: string[] = []
+  let inTable = false
+
+  const flushProse = () => {
+    const chunk = proseBuf.join("\n").trim()
+    proseBuf = []
+    if (!chunk) return
+    const subChunks = chunk.split(/\n(?=\*\*[^*\n]+\*\*:?\s*(?:\n|$))/).map((c) => c.trim()).filter(Boolean)
+    for (const sub of subChunks.length > 0 ? subChunks : [chunk]) {
+      blocks.push({ kind: "prose", text: sub })
+    }
+  }
+
+  const flushTable = () => {
+    const chunk = tableBuf.join("\n").trim()
+    tableBuf = []
+    inTable = false
+    if (chunk && isMarkdownTableBlock(chunk)) {
+      blocks.push({ kind: "table", text: chunk })
+    } else if (chunk) {
+      proseBuf.push(chunk)
+    }
+  }
+
+  for (const line of lines) {
+    const trimmedLine = line.trim()
+    const isPipeRow = /^\|.+\|/.test(trimmedLine)
+    const isTableSep = /^\|[\s:|-]+\|/.test(trimmedLine)
+    if (isPipeRow) {
+      if (!inTable) {
+        flushProse()
+        inTable = true
+      }
+      tableBuf.push(line)
+      continue
+    }
+    if (inTable && isTableSep) {
+      tableBuf.push(line)
+      continue
+    }
+    if (inTable) flushTable()
+    proseBuf.push(line)
+  }
+  if (inTable) flushTable()
+  else flushProse()
+
+  if (blocks.length === 0) {
+    return [{ kind: "prose", text }]
+  }
+  return blocks
+}
+
 /** Split long prose for side-by-side TextContent columns (paragraph, then sentence boundaries). */
 export function splitProseIntoTwoColumns(body: string): [string, string] {
-  const trimmed = body.trim()
+  const trimmed = stripProseDividers(body)
   if (!trimmed) return ["", ""]
 
   const paragraphs = trimmed.split(/\n\n+/).filter((p) => p.trim())
@@ -346,7 +417,21 @@ function classifySegmentBody(
   }
 
   if (isMarkdownTableBlock(trimmed) || isStructuredTabularLines(trimmed)) {
-    return { component: "Table", mapping: "widget", hints: { note: "derive columns and rows from source" } }
+    const pipeRows = trimmed.split("\n").filter((l) => /^\|/.test(l.trim())).length
+    const wbsLike =
+      /\bwbs\s+dictionary\b/i.test(`${title ?? ""}\n${trimmed}`) ||
+      (/\blevel\s*1\b/i.test(trimmed) && /\blevel\s*2\b/i.test(trimmed))
+    return {
+      component: "Table",
+      mapping: "widget",
+      hints: {
+        note: wbsLike
+          ? "WBS Dictionary — preserve all hierarchy columns and rows from source (Level 1–4); use Table widget"
+          : "derive columns and rows from source",
+        ...(wbsLike ? { wbsDictionary: "true" } : {}),
+        ...(pipeRows >= 8 ? { wideTable: "true", rowCount: String(pipeRows) } : {}),
+      },
+    }
   }
   if (isTimelineBlock(trimmed)) {
     return { component: "Timeline", mapping: "widget", hints: { note: "milestones from dated lines" } }
@@ -409,14 +494,25 @@ function isHeadingOnlySegment(seg: TextSegment): boolean {
   return false
 }
 
-/** Major report chapter (H1 or numbered ##) — not every ### subsection. */
+/** Document metadata lines (Project:/Date:/Version:) — not chapter boundaries. */
+function isReportMetadataHeading(seg: TextSegment): boolean {
+  const level = seg.headingLevel ?? 2
+  const title = normalizeTitle(seg.title ?? "")
+  if (level !== 2) return false
+  if (/^\d+\.\s/.test(title)) return false
+  return /^(Project|Date|Version|Author|Document|Prepared\s+by|Status):/i.test(title)
+}
+
+/** Major report chapter (H1 or numbered ## like "1. Introduction") — not metadata or ###. */
 function isChapterBoundary(seg: TextSegment): boolean {
   const level = seg.headingLevel ?? 2
   const title = seg.title ?? ""
+  if (isReportMetadataHeading(seg)) return false
   if (level === 1) return true
   if (level === 2) {
     if (/^\d+\.\d+/.test(title)) return false
-    return true
+    if (/^\d+\.\s/.test(title)) return true
+    return false
   }
   return false
 }
@@ -445,12 +541,33 @@ type ReportChapter = {
   subsections: TextSegment[]
 }
 
+function formatReportMetadataBlurb(metadata: TextSegment[]): string {
+  const parts: string[] = []
+  for (const seg of metadata) {
+    const title = normalizeTitle(seg.title ?? "")
+    if (!title) continue
+    const body = seg.body.trim()
+    if (!body || isHeadingOnlySegment(seg)) {
+      parts.push(title)
+      continue
+    }
+    const oneLine = body.replace(/\s+/g, " ").trim()
+    if (oneLine.length <= 140) {
+      parts.push(`${title} — ${oneLine}`)
+    } else {
+      parts.push(title)
+    }
+  }
+  return parts.join("\n").slice(0, COVER_SUMMARY_MAX_CHARS)
+}
+
 function groupSegmentsIntoChapters(sectionSegments: TextSegment[]): ReportChapter[] {
   const contentSegments = sectionSegments.filter((s) => !isDocumentTitleSegment(s, sectionSegments))
+  const bodySegments = contentSegments.filter((s) => !isReportMetadataHeading(s))
   const chapters: ReportChapter[] = []
   let current: ReportChapter | null = null
 
-  for (const seg of contentSegments) {
+  for (const seg of bodySegments) {
     if (isChapterBoundary(seg) && !isSubsectionBoundary(seg)) {
       if (current) chapters.push(current)
       current = {
@@ -535,6 +652,48 @@ function slugId(s: string): string {
     .slice(0, 40) || "untitled"
 }
 
+function buildLeafNodeFromBody(
+  seg: TextSegment,
+  body: string,
+  idSuffix = ""
+): LayoutPlanNode {
+  const subSeg: TextSegment = { ...seg, id: `${seg.id}${idSuffix}`, body }
+  const classified = classifySegmentBody(body, seg.title)
+  if (
+    classified.component === "TextContent" &&
+    classified.mapping === "typography-fallback" &&
+    shouldUseTwoColumnProse(body)
+  ) {
+    return buildTwoColumnTextNode(subSeg, classified)
+  }
+  return {
+    id: subSeg.id,
+    component: classified.component,
+    mapping: classified.mapping,
+    sourceText: body,
+    label: seg.title,
+    fallbackReason: classified.fallbackReason,
+    hints: classified.hints,
+  }
+}
+
+function buildCompositeSegmentNode(seg: TextSegment, blocks: SectionContentBlock[]): LayoutPlanNode {
+  const children = blocks.map((block, i) =>
+    buildLeafNodeFromBody(seg, block.text, `-part-${i}`)
+  )
+  return {
+    id: seg.id,
+    component: "Stack",
+    mapping: "widget",
+    sourceText: seg.body,
+    label: seg.title,
+    hints: {
+      note: "subsection with multiple blocks (prose and/or tables) — emit in order; do not merge or drop blocks",
+    },
+    children,
+  }
+}
+
 function buildTwoColumnTextNode(
   seg: TextSegment,
   classified: ReturnType<typeof classifySegmentBody>
@@ -574,23 +733,12 @@ function buildTwoColumnTextNode(
 }
 
 function buildNodeFromSegment(seg: TextSegment): LayoutPlanNode {
-  const classified = classifySegmentBody(seg.body, seg.title)
-  if (
-    classified.component === "TextContent" &&
-    classified.mapping === "typography-fallback" &&
-    shouldUseTwoColumnProse(seg.body)
-  ) {
-    return buildTwoColumnTextNode(seg, classified)
+  const blocks = splitBodyIntoContentBlocks(seg.body)
+  if (blocks.length > 1) {
+    return buildCompositeSegmentNode(seg, blocks)
   }
-  return {
-    id: seg.id,
-    component: classified.component,
-    mapping: classified.mapping,
-    sourceText: seg.body,
-    label: seg.title,
-    fallbackReason: classified.fallbackReason,
-    hints: classified.hints,
-  }
+  const body = blocks[0]?.text ?? seg.body
+  return buildLeafNodeFromBody(seg, body)
 }
 
 function buildSubsectionBlock(seg: TextSegment): LayoutPlanNode {
@@ -917,13 +1065,20 @@ function buildShellNodes(
     preambleSeg?.body,
     docTitle
   )
-  const coverBlurb =
+  const metadataBlurb = formatReportMetadataBlurb(
+    sectionSegments.filter(isReportMetadataHeading)
+  )
+  let coverBlurb =
     coverSummaryOverride?.trim() ||
     buildCoverBlurbFromSources({
       fullSummary: summarySource,
       preambleBody: preambleSeg?.body,
       executiveSummaryBody: executiveSummaryBodyFromChapters(chapters),
     })
+  if (metadataBlurb) {
+    const combined = [metadataBlurb, coverBlurb].filter(Boolean).join("\n\n").trim()
+    coverBlurb = combined.slice(0, COVER_SUMMARY_MAX_CHARS)
+  }
   const coverImage = useCover
     ? pickReportCoverImage({
         seed: documentId,
@@ -1141,8 +1296,14 @@ function flattenNodes(nodes: LayoutPlanNode[], depth = 0): string[] {
       `${pad}  """`
     )
     if (n.children?.length) {
-      lines.push(`${pad}  children:`)
-      lines.push(...flattenNodes(n.children, depth + 2))
+      if (twoColLang) {
+        lines.push(
+          `${pad}  children: (inlined in REQUIRED_LANG above — emit exactly two TextContent in one row Stack; do NOT add a third TextContent for the full sourceText)`
+        )
+      } else {
+        lines.push(`${pad}  children:`)
+        lines.push(...flattenNodes(n.children, depth + 2))
+      }
     }
   }
   return lines.filter(Boolean)
@@ -1190,7 +1351,10 @@ export function formatLayoutPlanForExecutor(
     "- Subsections (### or 1.1, 1.2) go INSIDE the chapter Card as Stack blocks with subsection CardHeader — never a separate top-level Card per ###.",
     "- Skip empty heading-only nodes; do not emit TextContent that only repeats the section title — use CardHeader for the title instead.",
     "- Narrative prose → TextContent. Bullet/numbered lists → Bullets. Markdown tables → Table([Col(\"Header\", [cells...]), ...]) with ONE argument only — never Table(..., \"caption\").",
-    "- Long narrative blocks (hints.twoColumn or sourceTextChars ≥ ~360): Stack([col1, col2], \"row\", \"m\", \"stretch\", \"start\", true) with two TextContent children. left/right sourceText in the plan is already split at paragraph or sentence boundaries — copy exactly; never merge columns or break mid-sentence.",
+    "- Long narrative blocks (hints.twoColumn or REQUIRED_LANG row Stack): exactly ONE row Stack with exactly TWO TextContent children — never three stacked paragraphs for a two-column subsection.",
+    "- When REQUIRED_LANG shows a two-column Stack, do not emit separate TextContent nodes for col1/col2 ids; use only the REQUIRED_LANG Stack.",
+    "- Subsections with multiple blocks (Stack children in plan): render every child in order — intro prose, then Table, then trailing prose (e.g. Justification for Hybrid Approach).",
+    "- WBS Dictionary and wide markdown tables: use Table with all pipe rows from sourceText; hints.wbsDictionary means preserve Level 1–4 columns.",
     "- Apply two-column row Stacks for chapter lead paragraphs and long subsection intros (e.g. Executive Summary, §2.1 Purpose, §3.1) when the plan marks twoColumn or REQUIRED_LANG on a Stack node.",
     "- Use Accordion only when the user prompt explicitly requests accordion/collapsible/FAQ AND Bullets is not a better fit.",
     "- Do not invent metrics, dates, or names not supported by source text.",

--- a/lib/openui/layoutPlanTypes.ts
+++ b/lib/openui/layoutPlanTypes.ts
@@ -17,6 +17,7 @@ export type PlanComponentName =
   | "Comparison"
   | "TableOfContents"
   | "ReportCoverHero"
+  | "TwoColumnProse"
   | "TextContent"
   | "Callout"
   | "Steps"

--- a/lib/openui/systemPrompt.ts
+++ b/lib/openui/systemPrompt.ts
@@ -62,10 +62,11 @@ const PROJECT_OPENUI_RULES = [
 ]
 
 const ADPA_EXTENSION_RULES = [
-  "ADPA extensions (merged with GenUI): Bullets, Timeline, Team, Comparison, TableOfContents, ReportCoverHero — use GenUI Callout (not Alert) for banners.",
+  "ADPA extensions (merged with GenUI): Bullets, Timeline, Team, Comparison, TableOfContents, ReportCoverHero, TwoColumnProse — use GenUI Callout (not Alert) for banners.",
   "Timeline vs Steps: Timeline when milestones have dates or phase labels and optional status; GenUI Steps for procedural workflows without a dated roadmap.",
   "Team vs Table: Team for people (name, role, responsibility); Table for homogeneous registers (risks, requirements, RAID).",
   "Comparison vs Table: Comparison for 2–4 side-by-side option columns (in-scope vs out-of-scope); Table for many rows sharing the same columns.",
+  "TwoColumnProse vs Stack: TwoColumnProse for long subsection intros with exactly two narrative columns (e.g. §1.1 Overview); never three stacked TextContent blocks.",
   "TableOfContents: top of Stack when the answer has 4+ major sections; entries must match real section titles from context.",
 ]
 

--- a/lib/openui/twoColumnProseDef.tsx
+++ b/lib/openui/twoColumnProseDef.tsx
@@ -1,0 +1,17 @@
+import { defineComponent } from "@openuidev/react-lang"
+import { z } from "zod/v4"
+
+/** Side-by-side narrative prose — ADPA extension for §1.1-style two-paragraph sections. */
+export const TwoColumnProseDef = defineComponent({
+  name: "TwoColumnProse",
+  description:
+    "Two columns of narrative prose (left and right). Use when the layout plan marks twoColumn or REQUIRED_LANG TwoColumnProse — never substitute three stacked TextContent blocks or a column Stack.",
+  props: z.object({
+    left: z.string().describe("Left column text (first paragraph block)"),
+    right: z.string().describe("Right column text (second paragraph block)"),
+  }),
+  component: ({ props }) => {
+    const { TwoColumnProseComponent } = require("@/components/openui-chat/components/TwoColumnProseComponent")
+    return <TwoColumnProseComponent props={props as Record<string, unknown>} data={[]} />
+  },
+})


### PR DESCRIPTION
## Summary
- Split §1.2-style subsections into prose → table → prose (including justification tail).
- §1.1 two-column: strip `---` dividers; executor plan no longer duplicates col1/col2 when REQUIRED_LANG Stack is present.
- Only numbered `##` headings become chapter cards (metadata lines like `## Project:` stay in cover flow).
- Higher executor source budget for wide / WBS dictionary tables.

## Test plan
- [ ] Re-render Scope Management Plan in GenUI workspace
- [ ] §1.1 shows two columns (not three stacked paragraphs)
- [ ] §1.2 shows intro, table, and justification section
- [ ] WBS Dictionary table is complete (not truncated mid-rows)
- [x] `pnpm exec jest __tests__/lib/layoutPlan.test.ts --no-coverage` (25 passed)