### PR TITLE
feat(genui): report exports, layout follow-up, and kickoff lessons learned

### DIFF
--- a/.agents/skills/adpa-genui-workspace/SKILL.md
+++ b/.agents/skills/adpa-genui-workspace/SKILL.md
@@ -1,28 +1,41 @@
 ---
 name: adpa-genui-workspace
-description: Maintain and extend the ADPA document GenUI workspace (split-pane document + OpenUI advisor). Use when editing genui pages, OpenUI Lang rendering, document chat prompts, Mistral /api/chat, or expanding structured UI from governance documents.
+description: Maintain and extend the ADPA document GenUI workspace (split-pane source document + OpenUI component report). Use when editing genui pages, OpenUI Lang rendering, report prompts, GENUI LLM route (/api/chat), or expanding structured UI from governance documents.
 ---
 
 # ADPA Document GenUI Workspace
 
-The **document GenUI workspace** is a split-pane experience: **Step 1** shows extracted document text; **Step 2** is an OpenUI `FullScreen` chat that can render **OpenUI Lang** into interactive UI (cards, tables, charts, tabs, steps).
+The **document GenUI workspace** is a **split-screen report** experience:
 
-This is **not** the same as project-scoped **OpenUI Chat** (`/openui-chat`, `/api/v1/openui-chat`). Do not conflate the two stacks when debugging or extending features.
+| Pane | User-facing role | What the user sees |
+|------|------------------|-------------------|
+| **Step 1 — Source document** | Read and verify extracted text | Title, metrics, full `doc.content` from the documents API |
+| **Step 2 — Component report** | Build an interactive **OpenUI report** from that source | Rendered OpenUI Lang (cards, tables, timeline, cover, TOC) — **not** a generic chat transcript UI |
+
+Step 2 is **report-first**: `GenuiReportSurfaceProvider` + `reportSurface` on `CustomAssistantMessage` (full-width canvas, no advisor avatar). Toolbar actions are **Render document** and **+ New Report** (`GenuiThreadToolbar`), not “new chat”. CSS hides OpenUI’s built-in “New Chat” control (`.genui-workspace`).
+
+**Implementation (do not confuse with product copy):** Step 2 still embeds OpenUI’s `FullScreen` and streams via `POST /api/chat` with `systemPrompt`. That route name is historical; the **product surface** is a document-scoped **component report**, not project **OpenUI Chat** (`/openui-chat`).
+
+This is **not** the same as project-scoped **OpenUI Chat** (`/openui-chat`, `/api/v1/openui-chat`, persisted threads, Gemini on the server). Do not conflate the two when debugging or extending features.
+
+**Document-agnostic:** Layout and rendering use whatever `docId` is in the URL (`GET /documents/{id}` → `doc.content`). There is **no** allowlist of document UUIDs or hard tie to “Schedule Management Plan” only. Heuristics (markdown headings, prompt keywords) apply to **any** governance-style document in the stack.
+
+**Shared component catalog:** Anything registered in `lib/openui/adpaGenuiExtensionDefs.ts` is merged into `projectOpenUIPromptLibrary` and is available on **both** this page and `/openui-chat` (same `projectOpenUILibrary` renderer). Existing React Kanban/Gantt pages elsewhere in ADPA (`IssueKanbanBoard`, `TaskGanttView`, …) do **not** auto-appear in Lang until you add a `defineComponent` extension (see below).
 
 ## When to use this skill
 
 - Editing `app/projects/[id]/documents/genui/**`
-- Fixing raw `openui-lang` code showing instead of rendered components
-- Changing layout, theme, conversation starters, or toolbar navigation
-- Wiring new LLM behavior, RAG, or thread persistence for document chat
+- Fixing raw `openui-lang` code showing instead of rendered report components
+- Changing layout, theme, **report** starters, or toolbar navigation
+- Wiring new LLM behavior, RAG, or **report session** persistence for the document workspace
 - Adding document-type-specific prompts or GenUI output patterns
 
 Also read (design context, different surfaces):
 
 - `docs/codedocs/genui-workspace.md` — human-readable codedoc (mirrors this skill)
-- `docs/superpowers/specs/2026-05-14-openui-chat-design.md` — GenUI strategy for project OpenUI chat
+- `docs/superpowers/specs/2026-05-14-openui-chat-design.md` — GenUI strategy for **project** OpenUI chat (separate route)
 - `docs/superpowers/specs/2026-05-18-genui-personalized-dashboards-design.md` — future PM dashboards (out of scope for this page v1)
-- `docs/codedocs/openui-chat.md` — backend OpenUI chat module (threads, SSE); **not** the document workspace HTTP path
+- `docs/codedocs/openui-chat.md` — backend OpenUI chat module (threads, SSE); **not** this document report HTTP path
 
 ## Routes and navigation
 
@@ -41,45 +54,69 @@ flowchart LR
     API["GET /api/v1/documents/..."]
     Pane[Source pane - doc.content]
   end
-  subgraph step2 [Step 2 - Advisor]
-    FS[FullScreen OpenUI]
-    CAM[CustomAssistantMessage]
-    DCR[DynamicComponentRenderer]
-    RL[Renderer + openuiLibrary]
+  subgraph step2 [Step 2 - Component report]
+    FS[FullScreen embed]
+    Toolbar[GenuiThreadToolbar - Render / New Report]
+    CAM[CustomAssistantMessage reportSurface]
+    RL[Renderer + projectOpenUILibrary]
   end
   subgraph proxy [Next.js]
-    Chat["POST /api/chat"]
+    LlmRoute["POST /api/chat + systemPrompt"]
   end
   subgraph llm [LLM]
-    Mistral[Mistral stream]
+    Stream[Mistral or Gemini stream]
   end
   API --> Pane
   Pane -->|systemPrompt embeds content| FS
-  FS --> Chat
-  Chat -->|systemPrompt set| Mistral
-  Mistral -->|OpenUI Lang text stream| FS
-  FS --> CAM
-  CAM --> DCR --> RL
+  Toolbar --> FS
+  FS --> LlmRoute
+  LlmRoute --> Stream
+  Stream -->|OpenUI Lang| CAM
+  CAM --> RL
 ```
 
 ### Request path (critical)
 
 1. `page.tsx` builds `systemPrompt` from `buildOpenUIGenuiLibraryPrompt()` plus **full document body** and metadata.
-2. `FullScreen` calls `POST /api/chat` with messages enriched by `enrichOpenUIApiMessages()` — each user turn gets a **REQUIRED LAYOUT PLAN** from `buildLayoutPlan({ prompt, sourceText: doc.content })` (`lib/openui/layoutPlan.ts`). Document text stays in system prompt; plan uses the same content for segment → component mapping.
-3. `app/api/chat/route.ts`: if `systemPrompt` is set → **Mistral** streaming; executor must implement the layout plan; typography only for `typography-fallback` nodes.
-4. Assistant replies should be **OpenUI Lang** (e.g. `root = Stack([...])`), optionally wrapped in ` ```openui-lang ` fences.
+2. User prompts (starters or typed input) go through `FullScreen` → `POST /api/chat` with messages enriched by `enrichOpenUIApiMessages()` — each user turn gets a **REQUIRED LAYOUT PLAN** from `buildLayoutPlan({ prompt, sourceText: doc.content })` (`lib/openui/layoutPlan.ts`). Document text stays in system prompt; plan uses the same content for segment → component mapping.
+3. `app/api/chat/route.ts`: when `systemPrompt` is set → **Mistral** or **Gemini** (`GENUI_LLM_PROVIDER`); executor must implement the layout plan; typography only for `typography-fallback` nodes.
+4. `buildLayoutPlan({ prompt: lastUserMessage, sourceText: doc.content, documentId })` — prompt comes from the **latest user message** (`setLastUserLayoutPrompt` in `page.tsx`); Lang repair in `CustomAssistantMessage` uses the same prompt (not only the default “full document” string).
+5. Model output should be **OpenUI Lang** (e.g. `root = Stack([...])`), optionally wrapped in ` ```openui-lang ` fences, rendered as the **report canvas**.
+
+### Focused vs full document layout (`lib/openui/layoutPlan.ts`)
+
+| Mode | Triggered by (examples) | Planner output | Cover / TOC |
+|------|------------------------|----------------|-------------|
+| **Focused detail** | `wantsGenuiFocusedDetailRender(prompt)` — timeline/gantt/kanban from a section, `no cover`, `only the timeline`, `from this report` + chart type, etc. | Usually **one** widget (`Timeline`, `Table`, …) in `root = Stack([...])` | **Omitted** |
+| **Full report** | `wantsGenuiFullDocumentLayout(prompt)` — “render the full document”, cover + chapters, `GENUI_RENDER_FULL_DOCUMENT_PROMPT` | Cover + optional TOC + **Card per chapter** (when doc has enough `##` sections) | **Included** when structure warrants |
+
+**Exports:** `wantsGenuiFocusedDetailRender`, `wantsGenuiFullDocumentLayout`, `wantsAiCoverSummary` (cover API only for full-document prompts).
+
+**User-facing prompt templates:** `lib/documents/genui-prompts.ts` (full render CTA + focused timeline/gantt/kanban starters). Keyword buckets on document names: `lib/documents/document-chat-prompts.ts` (filename is historical; content is **report** starters for this workspace).
+
+**Current fallbacks (no dedicated Lang widget yet):**
+
+| User asks for | Lang component today | Notes |
+|---------------|---------------------|--------|
+| Timeline / milestones | `Timeline` | ADPA extension |
+| “Gantt chart” | `Table` (activity, start, finish, dependencies) | Planner `shell: "table"` when focused + gantt |
+| Kanban-style board | `Table` (status columns) | Not `KanbanComponent` (legacy JSON path only) |
+
+**Follow-up rule:** Short messages like “from this report, generate a gantt chart” must stay **focused** — do not expand to full charter unless the user asks for full document / cover / all chapters. Tests: `follow-up gantt from this report stays focused` in `__tests__/lib/layoutPlan.test.ts`.
 
 ### Rendering path (critical)
 
 | Piece | Role |
 |-------|------|
-| `componentLibrary={projectOpenUILibrary}` on `FullScreen` | GenUI catalog + ADPA **Bullets, Timeline, Team, Comparison, TableOfContents** |
-| `assistantMessage={CustomAssistantMessage}` | **Overrides** default assistant UI — must render Lang itself |
-| `components/openui-chat/AssistantMessage.tsx` | Detects Lang → `DynamicComponentRenderer` with **`projectOpenUILibrary`** |
-| `components/openui-chat/DynamicComponentRenderer.tsx` | `Renderer` from `@openuidev/react-lang`; default `library` is `projectOpenUILibrary` |
+| `componentLibrary={projectOpenUILibrary}` on `FullScreen` | GenUI catalog + ADPA extensions: **Bullets, Timeline, Team, Comparison, TableOfContents, ReportCoverHero, TwoColumnProse** |
+| `GenuiReportSurfaceProvider` + `reportSurface` on `CustomAssistantMessage` | **Report canvas** — full width, no avatar; distinguishes this pane from conversational OpenUI Chat |
+| `GenuiThreadToolbar` | **Render document** (full report CTA via `GenuiPromptBridge`); **+ New Report** remounts session |
+| `assistantMessage={CustomAssistantMessage}` | **Overrides** default assistant UI — must render Lang as report, not markdown-only |
+| `components/openui-chat/AssistantMessage.tsx` | Shared renderer; detects Lang → `DynamicComponentRenderer` with **`projectOpenUILibrary`** |
+| `components/openui-chat/DynamicComponentRenderer.tsx` | `Renderer` from `@openuidev/react-lang` |
 | `lib/openui/library.ts` | `extractOpenUILangText()`, `looksLikeOpenUILang()` |
-| `lib/openui/systemPrompt.ts` | `buildOpenUIGenuiLibraryPrompt()`, `buildOpenUIUserMessage()`, `enrichOpenUIApiMessages()` |
-| `lib/openui/layoutPlan.ts` | Text → UI plan (strict executor); see `adpa-openui-chat` skill |
+| `lib/openui/systemPrompt.ts` | `buildOpenUIGenuiLibraryPrompt()`, `enrichOpenUIApiMessages()` |
+| `lib/openui/layoutPlan.ts` | Text → UI plan (strict executor); shared with `/openui-chat` |
 
 **Long prose (≈360+ chars):** planner emits a row `Stack` with two `TextContent` columns via `splitProseIntoTwoColumns` (paragraph break first, else nearest sentence boundary — skips `Dr.`, `Ed.`, `3.1`-style decimals); hints `twoColumn` + `REQUIRED_LANG` carry pre-split left/right text. Executor must use `Stack([col1, col2], "row", "m", "stretch", "start", true)` and must not re-split mid-sentence.
 
@@ -87,22 +124,26 @@ flowchart LR
 
 **Pitfall:** Bare `openuiLibrary` without merge → `unknown-component` for **Bullets**. **`adpaLibrary`** → wrong Report-era widgets.
 
-**Pitfall:** Assistant shows only Bullets — usually **model output**, not a missing library. Verify with `getProjectOpenUIComponentNames()`; strengthen prompts in `systemPrompt.ts` / starters.
+**Pitfall:** Report shows only Bullets — usually **model output**, not a missing library. Verify with `getProjectOpenUIComponentNames()`; strengthen prompts in `systemPrompt.ts` / starters.
 
-**Related skill:** Project OpenUI Chat at `/openui-chat` (Gemini, threads) — `.agents/skills/adpa-openui-chat/SKILL.md`.
+**Related skill:** Project **OpenUI Chat** at `/openui-chat` (Gemini, persisted threads, conversational UI) — `.agents/skills/adpa-openui-chat/SKILL.md`.
 
 ## Source map
 
 | Concern | Files |
 |---------|--------|
-| Main page | `app/projects/[id]/documents/genui/page.tsx` |
-| Workspace theme / OpenUI shell CSS | `app/projects/[id]/documents/genui/genui-workspace.css` |
+| Main page (split layout) | `app/projects/[id]/documents/genui/page.tsx` |
+| Workspace theme / report embed CSS | `app/projects/[id]/documents/genui/genui-workspace.css` |
 | Error boundary | `app/projects/[id]/documents/genui/error.tsx` |
-| Chat API (Mistral branch) | `app/api/chat/route.ts` |
+| Report toolbar + prompt bridge | `components/genui/GenuiThreadToolbar.tsx`, `GenuiPromptBridge.tsx`, `GenuiReportSurfaceContext.tsx` |
+| Step 2 export bar | `components/genui/GenuiReportExportBar.tsx`, `lib/genui/reportExport.ts` |
+| **Step 3 reserve (types only)** | `lib/genui/presentationSnapshot.ts`, `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md` |
+| GenUI LLM route (`systemPrompt` branch) | `app/api/chat/route.ts` |
 | Canonical library + prompt | `lib/openui/projectOpenUILibrary.ts`, `lib/openui/adpaGenuiExtensionDefs.ts`, `lib/openui/systemPrompt.ts` |
-| Re-export for imports | `components/Chat/AssistantMessage.tsx` → `openui-chat/AssistantMessage.tsx` |
+| Assistant / report renderer | `components/openui-chat/AssistantMessage.tsx` (re-export: `components/Chat/AssistantMessage.tsx`) |
 | Lang utilities | `lib/openui/library.ts` |
-| Conversation starters | `lib/documents/document-chat-prompts.ts` |
+| Report starters / render CTAs | `lib/documents/genui-prompts.ts`, `lib/documents/document-chat-prompts.ts` |
+| Focused / full layout rules | `lib/openui/layoutPlan.ts`, `lib/openui/layoutPlanTypes.ts` |
 | Document toolbar / nav | `components/documents/DocumentPageToolbar.tsx` |
 | Route IDs (query vs path) | `lib/documents/use-project-document-route-ids.ts` |
 
@@ -110,7 +151,7 @@ flowchart LR
 
 | Concern | Files |
 |---------|--------|
-| Project OpenUI chat | `.agents/skills/adpa-openui-chat/SKILL.md`, `app/openui-chat/`, `components/openui-chat/` |
+| Project OpenUI chat (conversational) | `.agents/skills/adpa-openui-chat/SKILL.md`, `app/openui-chat/`, `components/openui-chat/` |
 | Backend threads + Gemini Lang SSE | `server/src/modules/openuiChat/` |
 | Legacy Report components | `lib/openui/adpaLibrary.tsx` (not default for GenUI or `/openui-chat`) |
 
@@ -118,103 +159,136 @@ flowchart LR
 
 Set in **`.env.local`** (see `.env.local.example`):
 
-| Variable | Required for Step 2 | Notes |
-|----------|---------------------|--------|
-| `GENUI_LLM_PROVIDER` | No | `mistral` (default) or `google` / `gemini` for Gemini (AI Studio–compatible logs) |
+| Variable | Required for Step 2 report | Notes |
+|----------|---------------------------|--------|
+| `GENUI_LLM_PROVIDER` | No | `mistral` (default) or `google` / `gemini` for Gemini |
 | `MISTRAL_API_KEY` | When provider is `mistral` | Without it, `/api/chat` returns 503 |
 | `MISTRAL_MODEL` | No | Defaults to `mistral-large-latest` |
 | `GOOGLE_AI_API_KEY` | When provider is `google` | Also accepts `GOOGLE_GENERATIVE_AI_API_KEY` |
 | `GENUI_GOOGLE_MODEL` / `GEMINI_MODEL_OVERRIDE` | No | Default `gemini-2.5-flash` (see `lib/llm/googleModelConfig.ts`) |
-| `NEXT_PUBLIC_GENUI_LLM_PROVIDER` | No | Optional badge in Step 2 UI; should match `GENUI_LLM_PROVIDER` |
+| `NEXT_PUBLIC_GENUI_LLM_PROVIDER` | No | Optional badge in Step 2 header |
 | `BACKEND_URL` | Step 1 + auth | Document fetch uses Express API via Next proxy |
 | Firebase / `auth_token` cookie | Yes | Page requires authenticated user |
 
-Response headers on GenUI streams: `X-GenUI-Provider`, `X-GenUI-Model` (inspect in DevTools → Network → `/api/chat`).
+Response headers on GenUI streams: `X-GenUI-Provider`, `X-GenUI-Model` (DevTools → Network → `/api/chat`).
 
-GenUI workspace does **not** currently persist threads to `openui_chat_threads`. **New chat** remounts `FullScreen` via `chatSessionKey` (client-only reset).
+**Report session:** Not stored in `openui_chat_threads`. **+ New Report** remounts `FullScreen` via `chatSessionKey` (internal state name only — user-facing label is **New Report**). Resets when `documentId` changes.
 
 ## UI conventions
 
-- **Theme:** Light workspace (`genui-workspace` root). OpenUI default CSS: `@openuidev/react-ui/defaults.css`, `components.css`.
-- **Layout:** 50/50 split; OpenUI root uses `.genui-openui-root` overrides (hide sidebar, panel-sized viewport, centered chat).
-- **Session:** `chatSessionKey` increments on **New chat**; resets when `documentId` changes.
-- **Copy:** Toolbar copies raw `doc.content` (Step 1 body), not chat transcript.
+- **Layout:** ~38% source / ~62% report (`genui-source-pane`, `genui-advisor-pane` in CSS — class names are legacy; treat pane as **report** in copy and specs).
+- **Theme:** Light workspace by default; optional dark report via `GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT` → `genui-report-dark` on `.genui-openui-root`.
+- **OpenUI embed:** `.genui-openui-root` constrains `FullScreen` to the Step 2 panel; sidebar hidden; built-in “New Chat” hidden in favor of **+ New Report**.
+- **Copy toolbar:** Copies raw `doc.content` (Step 1), not the OpenUI Lang source of the report.
 
-When changing styles, prefer `genui-workspace.css` and existing Tailwind tokens (`slate-*`, `violet-*`) over editing OpenUI package CSS.
+When changing styles, prefer `genui-workspace.css` and existing Tailwind tokens over editing OpenUI package CSS.
 
 ## Extending features (safe patterns)
 
-### Add conversation starters
+### Add report starters (suggested prompts)
 
-Edit `lib/documents/document-chat-prompts.ts` — keyword buckets on document name/template. Keep prompts **grounded** (“from this document”, “table”, “timeline”) so the model uses Step 1 content.
+Edit `lib/documents/document-chat-prompts.ts` and/or `lib/documents/genui-prompts.ts`. Keep prompts **grounded** in the source document. Use **focused** phrasing (`no cover`, named section) for a single widget — not the full report unless intended.
 
 ### Change system instructions
 
-Edit `buildOpenUISystemPrompt()` in `lib/openui/systemPrompt.ts` (uses `projectOpenUILibrary.prompt()`). Keep document body injection in `page.tsx`; do not move secrets to the client.
+Edit `buildOpenUISystemPrompt()` in `lib/openui/systemPrompt.ts`. Keep document body injection in `page.tsx`; do not move secrets to the client.
 
-### Add new OpenUI components
+### Add a new OpenUI Lang component (stack-wide)
 
-1. Prefer components already in `projectOpenUILibrary` / `@openuidev/react-ui/genui-lib` (`Card`, `Table`, `BarChart`, `Tabs`, `Steps`, etc.).
-2. For ADPA-only widgets: add a `defineComponent` (see `bulletsDef.tsx`), append to `components` in `projectOpenUILibrary.ts` — **never** replace the full `Object.values(openuiLibrary.components)` spread.
-3. Consult OpenUI / `@openuidev` docs (context7 MCP) for Lang grammar — do not invent syntax.
-4. Run `__tests__/lib/projectOpenUILibrary.test.ts` after library changes.
+Register once in the **ADPA extension layer**; both this **report workspace** and `/openui-chat` pick it up automatically. **Do not** only wire `DynamicComponentRenderer` JSON cases — legacy path, not OpenUI Lang reports.
 
-### Persist chat threads (future)
+**Checklist (mirror `lib/openui/timelineDef.tsx`):**
 
-Today: ephemeral `FullScreen` state. To persist:
+1. **Prefer existing GenUI** — `getProjectOpenUIComponentNames()` from `lib/openui/projectOpenUILibrary.ts`.
+2. **Define extension** — `lib/openui/<name>Def.tsx` with `defineComponent`.
+3. **Register** — `ADPA_GENUI_EXTENSION_DEFS` / `ADPA_GENUI_EXTENSION_NAMES` in `adpaGenuiExtensionDefs.ts`.
+4. **Planner intent** — `componentSelector.ts`, `layoutPlan.ts` (`toGenUIComponentName`, `resolveShellId`, `buildShellNodes`).
+5. **Executor guidance** — `systemPrompt.ts`, `formatLayoutPlanForExecutor`.
+6. **Tests** — `layoutPlan.test.ts`, `projectOpenUILibrary.test.ts` when applicable.
+7. **Prompts** — optional entries in `genui-prompts.ts` / `document-chat-prompts.ts`.
 
-- Either extend `POST /api/chat` to accept `projectId` + `documentId` and store in `openui_chat_messages`, or
-- Add dedicated `document_genui_threads` tables — do not break existing `openui-chat` contract without migration design.
+**Do not change** document fetch, route IDs, or `docId` wiring when adding components.
+
+### Step 2 export (shipped — client)
+
+Bottom bar on Step 2: PDF (print), Word (.doc HTML), HTML, plus **More** (plain text, OpenUI Lang, Step 1 markdown). Implementation: `lib/genui/reportExport.ts`, `lib/genui/reportExportPrepare.ts`, portal in `GenuiReportExportBar.tsx`.
+
+**Export preparation (`prepareGenuiReportExportHtml`):** clones the report DOM, expands paginated `Table` rows from `data-genui-table-export`, strips pagination/scroll controls, resolves `/images/…` to absolute URLs for print/Word. Step 3 server publish should reuse the same semantics for `html_snapshot`.
+
+**Wide tables:** `hints.attributeTable` / `wideTable` in `layoutPlan.ts` + higher leaf budgets in `genuiPromptBudget.ts` reduce executor truncation in Activity Attributes–style tables.
+
+Distinct from server `GET /api/v1/documents/:id/export/pdf` which exports **markdown** via `unifiedPdfService`, not the GenUI render tree.
+
+### Step 3 — Publish snapshot + integrations (reserved, not built)
+
+**Product intent:** Living truth stays `documents.content` (markdown). Beautiful OpenUI reports that must be **reproduced for stakeholders** become **named presentation snapshots** with artifacts in **blob storage** (PDF, DOCX, HTML snapshot, optional Lang replay). **Same Step 3 publish** can push those artifacts to **Confluence, Jira, SharePoint, ProjectWise** using existing project integration settings (not a separate “integration step”).
+
+| Layer | Today | Step 3 (future) |
+|-------|--------|------------------|
+| Step 1 | Source markdown pane | Unchanged |
+| Step 2 | Explore + client export | Unchanged |
+| Step 3 | — | Snapshot + blobs + optional **direct publish** to enterprise systems |
+
+**Do not implement Step 3 in Step 2 files without the spec.** Use reserved contracts:
+
+- Design: `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md` (blob checklist + **Direct publish to integrations**)
+- Types: `lib/genui/presentationSnapshot.ts` — `CreateGenuiPresentationRequest.publishIntegrations`, `GenuiPresentationExternalPublishRef`, `GENUI_PRESENTATION_INTEGRATION_ADAPTERS`
+- Feature flag: `NEXT_PUBLIC_GENUI_STEP3_PUBLISH=true` — gates **Publish presentation** (+ integration targets)
+
+**vs document view today:** View page **Publish to Confluence/Jira** sends **markdown** / issue metadata. Step 3 sends **GenUI PDF/HTML snapshot** and records links on the presentation row.
+
+**Invariants:** Never write OpenUI Lang into `documents.content`. Snapshot rows reference `document_id` + fingerprint. Blobs are derivatives only.
+
+### Persist report sessions (explore only)
+
+Today: in-memory `FullScreen` state only. Step 3 publish is separate from ephemeral exploration. Do not use `/openui-chat` threads for document reports without a migration plan.
 
 ### Add RAG beyond inline document text
 
-Current grounding is **full `doc.content` in system prompt**. For large documents, consider chunk retrieval from existing RAG services (`server` search/RAG modules) and inject a truncated context block — watch token limits on Mistral.
-
-### Second route alias
-
-If adding `documents/[docId]/genui`, re-export the same page component or redirect to `?docId=` so `useProjectDocumentRouteIds()` stays the single ID resolver.
+Current grounding is **full `doc.content` in system prompt**. For large documents, chunk retrieval from server RAG modules — watch token limits.
 
 ## Manual verification checklist
 
 After any GenUI workspace change:
 
-1. Start backend + frontend (`AGENTS.md`); ensure logged in.
+1. Start backend + frontend (`AGENTS.md`); log in.
 2. Open `/projects/{id}/documents/genui?docId={uuid}` for a document with body text.
 3. **Step 1:** Title, metrics, extracted text visible.
-4. **Step 2:** Welcome + conversation starters; chat input at bottom, centered in panel.
-5. Send a starter (e.g. “Show all risks as a table”) — response renders **UI components**, not a raw `openui-lang` code fence.
-6. **View source** on assistant message toggles Lang source; **Show rendered** restores UI.
-7. **New chat** clears thread; switching document in toolbar loads new doc + resets chat.
-8. Toolbar: View / Source / Report / GenUI navigation works; Copy copies document text.
+4. **Step 2:** Report header, starters, prompt input; **Render document** / **+ New Report** in toolbar.
+5. Send a starter (e.g. risks table) — response is **rendered OpenUI components** on the report canvas, not a raw `openui-lang` fence.
+6. **View source** / **Show rendered** on an assistant turn toggles Lang vs report UI.
+7. **+ New Report** clears the in-pane session; changing document resets Step 2.
+8. Toolbar: View / Source / Report / GenUI; Copy copies Step 1 text.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---------|----------------|-----|
-| Raw OpenUI Lang code block | `CustomAssistantMessage` markdown-only path | Ensure `looksLikeOpenUILang` + `DynamicComponentRenderer` + `projectOpenUILibrary` |
-| Empty or broken widgets | Wrong library (`adpaLibrary` or bare `openuiLibrary`) | Pass `projectOpenUILibrary` to FullScreen + renderer |
-| `unknown-component` Bullets | Renderer missing BulletsDef | Use `projectOpenUILibrary` |
-| Only Bullets in UI | Model chose minimal layout | Prompt rules in `systemPrompt.ts`; ask for Card + Table layout |
-| 503 on chat | Missing key for active provider | `MISTRAL_API_KEY` or `GOOGLE_AI_API_KEY`; set `GENUI_LLM_PROVIDER`, restart Next |
-| 401 on chat | No auth cookie | Log in via Firebase/demo |
-| Step 1 empty | Document API / permissions | Check `GET` document by project + id |
-| Chat off-center / sidebar bleed | CSS overrides | `genui-workspace.css` `.genui-openui-root` rules |
-| Model ignores document | Weak prompt or empty `doc.content` | Strengthen CRITICAL CONTEXT block; verify fetch |
-| Stream stalls | Mistral/network | Check server logs for `[FRONTEND-PROXY] OpenUI chat error` |
+| Raw OpenUI Lang code block | Markdown-only assistant path | `looksLikeOpenUILang` + `Renderer` + `projectOpenUILibrary` |
+| Empty or broken widgets | Wrong library | `projectOpenUILibrary` on FullScreen + renderer |
+| `unknown-component` Bullets | Missing extension merge | `projectOpenUILibrary` |
+| Report is only Bullets | Model layout | `systemPrompt.ts` / starters; request Card + Table |
+| 503 on send | Missing LLM key | `MISTRAL_API_KEY` or `GOOGLE_AI_API_KEY`; `GENUI_LLM_PROVIDER` |
+| 401 on send | No auth | Log in |
+| Step 1 empty | Document API | Check GET document by project + id |
+| Report layout broken | CSS | `genui-workspace.css` `.genui-openui-root` |
+| Model ignores document | Empty `doc.content` / weak system prompt | CRITICAL CONTEXT in `page.tsx` |
+| Full report after gantt follow-up | Not focused | `wantsGenuiFocusedDetailRender` |
+| “Gantt” is a table | No Gantt Lang widget yet | Add `GanttDef` per checklist |
+| Stream stalls | LLM/network | Logs: `[FRONTEND-PROXY] OpenUI chat error` (log label is historical) |
 
 ## Agent workflow
 
 1. Load this skill before editing GenUI workspace files.
-2. Follow `adpa-aev-workflow` for scoped changes (one concern per change when possible).
-3. Do not modify `server/src/modules/openuiChat` for document-only UI unless explicitly wiring persistence or RAG.
-4. After edits, run manual checklist above; do not claim “renders correctly” without user confirmation on a real document.
+2. Describe the UI as **source + component report**, not “document chat”, unless referring to the `/api/chat` route or OpenUI `FullScreen` internals.
+3. Follow `adpa-aev-workflow` for scoped changes.
+4. Do not modify `server/src/modules/openuiChat` for report-only UI unless wiring persistence or RAG by design.
+5. Run the manual checklist; do not claim the report renders correctly without user confirmation on a real document.
 
 ## Expansion backlog (documented intent)
 
-Track larger work in specs/issues; typical next steps:
-
-- Thread persistence per `projectId` + `documentId`
+- **Step 3 publish** — DB row + blob artifacts; see `2026-05-21-genui-step3-presentations-design.md`
+- Server PDF/DOCX from GenUI HTML snapshot (`unifiedPdfService.generateFromHtml`)
 - Token-aware context (chunk RAG vs full-body prompt)
-- Export rendered GenUI / report to PDF from workspace
-- Document-type templates mapping to OpenUI Lang patterns
-- Align with `2026-05-18-genui-personalized-dashboards-design.md` when PM dashboards ship (separate route)
+- Document-type templates → OpenUI Lang patterns
+- PM dashboards per `2026-05-18-genui-personalized-dashboards-design.md` (separate route)

--- a/.agents/skills/adpa-openui-chat/SKILL.md
+++ b/.agents/skills/adpa-openui-chat/SKILL.md
@@ -14,7 +14,7 @@ Project-scoped advisor at **`/openui-chat`**: pick a project, chat with persiste
 | Rule | Detail |
 |------|--------|
 | **Single library** | `projectOpenUILibrary` from `lib/openui/projectOpenUILibrary.ts` |
-| **What it is** | GenUI catalog (`openuiLibrary`) **+** ADPA extensions: `Bullets`, `Timeline`, `Team`, `Comparison`, `TableOfContents` (`lib/openui/adpaGenuiExtensionDefs.ts`) |
+| **What it is** | GenUI catalog (`openuiLibrary`) **+** ADPA extensions in `lib/openui/adpaGenuiExtensionDefs.ts` (`Bullets`, `Timeline`, `Team`, `Comparison`, `TableOfContents`, `ReportCoverHero`, `TwoColumnProse`, …) |
 | **Prompt** | `projectOpenUILibrary.prompt(openuiPromptOptions)` via `buildOpenUISystemPrompt()` in `lib/openui/systemPrompt.ts` |
 | **Renderer** | Same library on `FullScreen` `componentLibrary` **and** `CustomAssistantMessage` → `DynamicComponentRenderer` |
 | **Never** | Replace with Bullets-only defs, bare `openuiLibrary` while prompts mention Bullets, or `adpaLibrary` (legacy Report grammar) on this surface |
@@ -23,7 +23,8 @@ Module init **throws** if base component count &lt; 40 or Card/Accordion/Table/B
 
 ```ts
 import { projectOpenUILibrary, openuiPromptOptions, ADPA_GENUI_EXTENSION_NAMES } from "@/lib/openui/projectOpenUILibrary"
-// New ADPA-only widgets: add defineComponent in lib/openui/*.tsx, append to adpaGenuiExtensionDefs.ts (never duplicate GenUI names)
+// New ADPA-only widgets: defineComponent in lib/openui/<name>Def.tsx → ADPA_GENUI_EXTENSION_DEFS in adpaGenuiExtensionDefs.ts
+// Planner hooks (optional): layoutPlan.ts, componentSelector.ts — same as document GenUI workspace
 ```
 
 ### When to use `adpaLibrary`
@@ -90,6 +91,10 @@ ADPA **chooses** widgets; the model **fills** the plan (does not redesign layout
 
 Tests: `__tests__/lib/layoutPlan.test.ts`
 
+### Focused vs full layout (shared with document GenUI)
+
+`buildLayoutPlan()` is **document-agnostic** (any `sourceText` + user `prompt`). **Focused detail** (`wantsGenuiFocusedDetailRender`) omits cover/TOC and often emits one `Timeline` or `Table` (user “gantt” → table shell until a Gantt Lang component exists). **Full report** (`wantsGenuiFullDocumentLayout`) adds cover + chapter Cards. Document workspace uses the same planner with `doc.content`; this chat can pass RAG or pasted text as `layoutSourceText`. Details: `.agents/skills/adpa-genui-workspace/SKILL.md`.
+
 ## Prompt / layout rules (avoid “Bullets-only” UI)
 
 `lib/openui/systemPrompt.ts` enforces:
@@ -140,11 +145,15 @@ Frontend panel calls `/api/v1/openui-chat/...` with Bearer token (Next rewrite t
 1. Load **this skill** for `/openui-chat` and `server/src/modules/openuiChat`.
 2. Load **genui-workspace** skill only when editing document GenUI page.
 3. Follow `adpa-aev-workflow` for scoped edits.
-4. Any library change: update `projectOpenUILibrary.ts`, `systemPrompt.ts`, **both** render sites, and add/extend `projectOpenUILibrary.test.ts`.
+4. Any library change: update `adpaGenuiExtensionDefs.ts`, `systemPrompt.ts`, **both** render sites (`openui-chat-fullscreen-panel`, `genui/page.tsx`), and extend `projectOpenUILibrary.test.ts` + `layoutPlan.test.ts` if planner-related.
 
 ## Extending components
 
+Use the **same checklist** as document GenUI (`.agents/skills/adpa-genui-workspace/SKILL.md` → “Add a new OpenUI Lang component”). Summary:
+
 1. Prefer existing GenUI names from `getProjectOpenUIComponentNames()`.
-2. For ADPA-only widgets: add `defineComponent` in `lib/openui/` (e.g. `bulletsDef.tsx`), append to `components` array in `projectOpenUILibrary.ts`.
-3. Re-run library test; confirm prompt still lists new component.
-4. Do **not** register only one component — always preserve full `openuiLibrary.components` spread.
+2. `defineComponent` in `lib/openui/<name>Def.tsx` → append to **`ADPA_GENUI_EXTENSION_DEFS`** / **`ADPA_GENUI_EXTENSION_NAMES`** in `adpaGenuiExtensionDefs.ts` (merged by `projectOpenUIPromptLibrary.ts` — **do not** hand-edit a duplicate `components` array in `projectOpenUILibrary.ts`).
+3. Optional: `layoutPlan.ts`, `componentSelector.ts`, `systemPrompt.ts` so prompts pick the new widget.
+4. Re-run `projectOpenUILibrary.test.ts`; add `layoutPlan.test.ts` cases when behavior is planner-specific.
+5. Preserve full `openuiLibrary.components` spread — never replace the catalog with a single custom widget.
+6. `DynamicComponentRenderer` JSON branches are **legacy**; new surfaces should use Lang + `Renderer`.

--- a/.env.local.example
+++ b/.env.local.example
@@ -94,6 +94,9 @@ GENUI_LLM_PROVIDER=mistral
 # Optional UI label in Step 2 header (should match GENUI_LLM_PROVIDER)
 # NEXT_PUBLIC_GENUI_LLM_PROVIDER=google
 
+# Step 3 — Save presentation snapshot (publish to blob storage). Not implemented; leave unset.
+# NEXT_PUBLIC_GENUI_STEP3_PUBLISH=true
+
 MISTRAL_API_KEY=your_mistral_api_key_here
 MISTRAL_MODEL=mistral-large-latest
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,12 @@ Split-pane page for governance documents: source text (left) + OpenUI advisor (r
 | **Human codedoc** | `docs/codedocs/genui-workspace.md`, `docs/codedocs/openui-chat.md` |
 | **Not the same as** | Project OpenUI Chat (`/openui-chat`, `server/src/modules/openuiChat`, `GOOGLE_AI_API_KEY` in `server/.env`) |
 | **Step 2 LLM (document)** | `POST /api/chat` with `systemPrompt` → Mistral or Google Gemini (`GENUI_LLM_PROVIDER`, `MISTRAL_*` or `GOOGLE_AI_API_KEY` in `.env.local`) |
-| **Rendering (both surfaces)** | `projectOpenUILibrary` = full `@openuidev/react-ui/genui-lib` catalog + **Bullets** (`lib/openui/projectOpenUILibrary.ts`); same on `FullScreen` + `Renderer`; prompts via `buildOpenUISystemPrompt()` |
-| **Key files** | `app/projects/[id]/documents/genui/page.tsx`, `app/openui-chat/`, `lib/openui/systemPrompt.ts`, `components/openui-chat/AssistantMessage.tsx` |
+| **Step 2 export** | Client PDF/Word/HTML — `lib/genui/reportExport.ts`, `GenuiReportExportBar.tsx` |
+| **Step 3 (reserved)** | Presentation snapshots + blob artifacts — `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md`, `lib/genui/presentationSnapshot.ts` |
+| **Layout modes** | **Focused** (timeline/gantt/kanban, no cover) vs **full report** — `lib/openui/layoutPlan.ts`; starter prompts in `lib/documents/genui-prompts.ts` |
+| **Rendering (both surfaces)** | `projectOpenUILibrary` = genui-lib + ADPA extensions (`lib/openui/adpaGenuiExtensionDefs.ts`); same on `FullScreen` + `Renderer`; `buildOpenUISystemPrompt()` |
+| **Add Lang components** | `defineComponent` → `adpaGenuiExtensionDefs.ts` (+ optional `layoutPlan.ts`); stack-wide — see genui skill checklist (do not change doc fetch/`docId` wiring) |
+| **Key files** | `app/projects/[id]/documents/genui/page.tsx`, `app/openui-chat/`, `lib/openui/layoutPlan.ts`, `lib/openui/systemPrompt.ts`, `components/openui-chat/AssistantMessage.tsx` |
 
 Load the matching skill before changing GenUI layout, OpenUI chat, prompts, or structured UI output. Do not use bare `openuiLibrary` when prompts mention Bullets.
 

--- a/__tests__/lib/genuiPresentationSnapshot.test.ts
+++ b/__tests__/lib/genuiPresentationSnapshot.test.ts
@@ -1,0 +1,98 @@
+import {
+  buildPresentationSnapshotDraft,
+  buildRenderRecipe,
+  defaultIntegrationArtifactPreference,
+  fingerprintSourceMarkdown,
+  isGenuiPresentationIntegrationPlatform,
+  isPresentationStale,
+  resolveGenuiLayoutModeFromPrompt,
+} from "@/lib/genui/presentationSnapshot";
+
+describe("fingerprintSourceMarkdown", () => {
+  it("is stable for the same content", () => {
+    const a = fingerprintSourceMarkdown("# Title\n\nBody");
+    const b = fingerprintSourceMarkdown("# Title\n\nBody");
+    expect(a).toBe(b);
+  });
+
+  it("changes when markdown changes", () => {
+    const a = fingerprintSourceMarkdown("version one");
+    const b = fingerprintSourceMarkdown("version two");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildRenderRecipe", () => {
+  it("marks focused layout from prompt", () => {
+    const recipe = buildRenderRecipe("from this report, generate a gantt chart, no cover");
+    expect(recipe.layoutMode).toBe("focused");
+    expect(recipe.specVersion).toBe("1");
+  });
+});
+
+describe("resolveGenuiLayoutModeFromPrompt", () => {
+  it("detects full document render intent", () => {
+    expect(
+      resolveGenuiLayoutModeFromPrompt("render the full document with cover and table of contents")
+    ).toBe("full");
+  });
+});
+
+describe("buildPresentationSnapshotDraft", () => {
+  it("returns null without source markdown", () => {
+    expect(
+      buildPresentationSnapshotDraft({
+        projectId: "p1",
+        documentId: "d1",
+        documentVersion: 1,
+        documentTitle: "Doc",
+        sourceMarkdown: "   ",
+        lastUserLayoutPrompt: "timeline",
+      })
+    ).toBeNull();
+  });
+
+  it("includes fingerprint and recipe", () => {
+    const draft = buildPresentationSnapshotDraft(
+      {
+        projectId: "p1",
+        documentId: "d1",
+        documentVersion: 2,
+        documentTitle: "Schedule Plan",
+        sourceMarkdown: "## Intro\n\nText",
+        lastUserLayoutPrompt: "show timeline only",
+      },
+      { openuiLang: "root = Stack([])" }
+    );
+    expect(draft).not.toBeNull();
+    expect(draft!.documentVersion).toBe(2);
+    expect(draft!.sourceContentFingerprint).toMatch(/^djb2-/);
+    expect(draft!.renderRecipe.layoutMode).toBe("focused");
+    expect(draft!.payloads.openuiLang).toContain("Stack");
+  });
+});
+
+describe("isPresentationStale", () => {
+  it("detects content drift", () => {
+    const fp = fingerprintSourceMarkdown("original");
+    expect(isPresentationStale(fp, "original")).toBe(false);
+    expect(isPresentationStale(fp, "updated")).toBe(true);
+  });
+});
+
+describe("presentation integrations (Step 3 reserve)", () => {
+  it("recognizes integration platform ids", () => {
+    expect(isGenuiPresentationIntegrationPlatform("confluence")).toBe(true);
+    expect(isGenuiPresentationIntegrationPlatform("jira")).toBe(true);
+    expect(isGenuiPresentationIntegrationPlatform("slack")).toBe(false);
+  });
+
+  it("defaults integration artifacts to presentation deliverables", () => {
+    expect(defaultIntegrationArtifactPreference()).toEqual({
+      confluence: "html_snapshot",
+      jira: "pdf",
+      sharepoint: "pdf",
+      projectwise: "pdf",
+    });
+  });
+});

--- a/__tests__/lib/genuiReportExport.test.ts
+++ b/__tests__/lib/genuiReportExport.test.ts
@@ -2,9 +2,9 @@
  * @jest-environment jsdom
  */
 import {
-  buildTableBodyRowsHtml,
   formatExportTableCellText,
   parseTableExportPayload,
+  populateTableBodyRows,
   resolveExportUrl,
   tableExportRowCount,
 } from "@/lib/genui/reportExportPrepare";
@@ -61,12 +61,13 @@ describe("reportExportPrepare", () => {
   });
 
   it("builds all table body rows for export", () => {
-    const html = buildTableBodyRowsHtml([
+    const tbody = document.createElement("tbody");
+    populateTableBodyRows(tbody, [
       { label: "ID", data: ["1", "2", "3"] },
       { label: "Name", data: ["Alpha", "Beta", "Gamma"] },
     ]);
-    expect(html.match(/<tr>/g)?.length).toBe(3);
-    expect(html).toContain("Gamma");
+    expect(tbody.querySelectorAll("tr").length).toBe(3);
+    expect(tbody.textContent).toContain("Gamma");
   });
 
   it("strips simple markdown emphasis in cells", () => {

--- a/__tests__/lib/genuiReportExport.test.ts
+++ b/__tests__/lib/genuiReportExport.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  buildTableBodyRowsHtml,
+  formatExportTableCellText,
+  parseTableExportPayload,
+  resolveExportUrl,
+  tableExportRowCount,
+} from "@/lib/genui/reportExportPrepare";
+import {
+  getLatestGenuiReportRenderElement,
+  sanitizeExportFilename,
+} from "@/lib/genui/reportExport";
+
+describe("getLatestGenuiReportRenderElement", () => {
+  it("finds the latest render when a toolbar div follows the lang canvas", () => {
+    document.body.innerHTML = `
+      <div class="genui-advisor-pane">
+        <div class="genui-report-surface">
+          <div class="genui-lang-render"><p>First report</p></div>
+          <div class="genui-report-toolbar"><button type="button">Copy</button></div>
+        </div>
+        <div class="genui-report-surface">
+          <div class="genui-lang-render"><p>Latest report</p></div>
+          <div class="genui-report-toolbar"><button type="button">Copy</button></div>
+        </div>
+      </div>
+    `;
+
+    const el = getLatestGenuiReportRenderElement();
+    expect(el?.textContent).toContain("Latest report");
+    expect(el?.textContent).not.toContain("First report");
+  });
+});
+
+describe("sanitizeExportFilename", () => {
+  it("slugifies document titles for download names", () => {
+    expect(sanitizeExportFilename("Schedule Management Plan v2")).toBe(
+      "Schedule-Management-Plan-v2"
+    );
+  });
+
+  it("falls back when title is empty", () => {
+    expect(sanitizeExportFilename("   ")).toBe("genui-report");
+  });
+});
+
+describe("reportExportPrepare", () => {
+  it("parses table export payload JSON", () => {
+    const payload = parseTableExportPayload(
+      JSON.stringify({
+        columns: [
+          { label: "ID", data: ["1", "2"] },
+          { label: "Name", data: ["A", "B"] },
+        ],
+      })
+    );
+    expect(payload?.columns).toHaveLength(2);
+    expect(tableExportRowCount(payload!.columns)).toBe(2);
+  });
+
+  it("builds all table body rows for export", () => {
+    const html = buildTableBodyRowsHtml([
+      { label: "ID", data: ["1", "2", "3"] },
+      { label: "Name", data: ["Alpha", "Beta", "Gamma"] },
+    ]);
+    expect(html.match(/<tr>/g)?.length).toBe(3);
+    expect(html).toContain("Gamma");
+  });
+
+  it("strips simple markdown emphasis in cells", () => {
+    expect(formatExportTableCellText("**Critical** path")).toBe("Critical path");
+  });
+
+  it("resolves root-relative image URLs", () => {
+    expect(resolveExportUrl("/images/cover.jpeg", "http://localhost:3000")).toBe(
+      "http://localhost:3000/images/cover.jpeg"
+    );
+  });
+});

--- a/__tests__/lib/layoutPlan.test.ts
+++ b/__tests__/lib/layoutPlan.test.ts
@@ -5,6 +5,7 @@ import {
   splitBodyIntoContentBlocks,
   splitProseIntoTwoColumns,
   stripProseDividers,
+  wantsGenuiFocusedDetailRender,
   wantsGenuiReportDarkTheme,
   repairTwoColumnProseInLang,
   stripDividerNoiseInLang,
@@ -105,6 +106,91 @@ Paragraph two with more narrative.`
     expect(plan.shell).toBe("risk")
     const serialized = JSON.stringify(plan.nodes)
     expect(serialized).toMatch(/Table/)
+  })
+
+  test("focused timeline from a section omits cover and table of contents", () => {
+    const source = `# Schedule Management Plan
+
+## Executive Summary
+Project overview paragraph.
+
+## Schedule Management Plan
+| Milestone | Date | Status |
+| --- | --- | --- |
+| Kickoff | 2026-05-01 | completed |
+| OpenUI integration | 2026-05-10 | completed |
+| Auto UI module | 2026-05-18 | in-progress |
+| UAT | 2026-05-25 | upcoming |
+| Launch | 2026-05-31 | upcoming |`
+
+    const prompt = "Render a timeline from the Schedule Management Plan section"
+    expect(wantsGenuiFocusedDetailRender(prompt)).toBe(true)
+
+    const plan = buildLayoutPlan({
+      prompt,
+      sourceText: source,
+      documentId: "82efd3d4-1482-4de6-859e-a940202cb0f1",
+    })
+
+    expect(plan.focusedDetail).toBe(true)
+    expect(plan.shell).toBe("timeline")
+    const serialized = JSON.stringify(plan.nodes)
+    expect(serialized).toMatch(/Timeline/)
+    expect(serialized).not.toMatch(/doc-cover/)
+    expect(serialized).not.toMatch(/ReportCoverHero/)
+    expect(serialized).not.toMatch(/TableOfContents/)
+
+    const block = formatLayoutPlanForExecutor(plan)
+    expect(block).toContain("focusedDetail: true")
+    expect(block).toContain("FOCUSED DETAIL MODE")
+    expect(block).toContain("no cover Card")
+  })
+
+  test("follow-up gantt from this report stays focused with table shell, no cover", () => {
+    const source = `## 1. Executive Summary
+Summary.
+
+## 6. Schedule Development
+### 6.4 Milestone Schedule
+| Milestone | Date |
+| --- | --- |
+| Kickoff | 2026-05-01 |
+
+## 12. Approval
+Sign-off.`
+
+    const prompt = "from this report could you generate a gantt chart?"
+    expect(wantsGenuiFocusedDetailRender(prompt)).toBe(true)
+
+    const plan = buildLayoutPlan({
+      prompt,
+      sourceText: source,
+      documentId: "doc-1",
+    })
+
+    expect(plan.focusedDetail).toBe(true)
+    expect(plan.shell).toBe("table")
+    const serialized = JSON.stringify(plan.nodes)
+    expect(serialized).not.toMatch(/doc-cover/)
+    expect(serialized).not.toMatch(/TableOfContents/)
+    expect(serialized).not.toMatch(/card_ch1/)
+  })
+
+  test("full document render still includes cover when governance doc has chapters", () => {
+    const source = `## 1. Executive Summary
+Summary text.
+
+## 2. Schedule Management Plan
+Milestone table here.`
+
+    const plan = buildLayoutPlan({
+      prompt: "Render the full document with cover page and table of contents",
+      sourceText: source,
+      documentId: "doc-1",
+    })
+
+    expect(plan.focusedDetail).toBeFalsy()
+    expect(JSON.stringify(plan.nodes)).toMatch(/doc-cover/)
   })
 
   test("formatLayoutPlanForExecutor includes strict rules and source text", () => {

--- a/app/projects/[id]/documents/genui/genui-workspace.css
+++ b/app/projects/[id]/documents/genui/genui-workspace.css
@@ -7,6 +7,24 @@
 .genui-workspace .genui-source-pane {
   background-color: #fff;
   color: rgb(15 23 42);
+  flex: 0 0 38%;
+  max-width: 38%;
+  min-width: 0;
+}
+
+.genui-workspace .genui-advisor-pane {
+  flex: 1 1 62%;
+  min-width: 0;
+}
+
+/* Bottom export bar (portaled from FullScreen thread context) */
+.genui-report-export-anchor {
+  flex: 0 0 auto;
+  z-index: 5;
+}
+
+.genui-workspace .genui-advisor-pane:has(.genui-report-export-bar) .genui-openui-root .openui-shell-thread-composer {
+  margin-bottom: 0;
 }
 
 .genui-workspace .genui-muted {
@@ -46,6 +64,26 @@
   display: none !important;
 }
 
+/* Workspace toolbar has "+ New Report"; hide OpenUI's built-in "New Chat" */
+.genui-workspace .openui-shell-new-chat-button,
+.genui-workspace .openui-shell-new-chat-button_collapsed,
+.genui-workspace .openui-bottom-tray-header-new-chat-button,
+.genui-workspace [aria-label="New chat"],
+.genui-workspace [aria-label="New Chat"] {
+  display: none !important;
+}
+
+/* Custom Step 2 header replaces OpenUI mobile chrome */
+.genui-openui-root .openui-shell-mobile-header {
+  display: none !important;
+}
+
+/* Safety net: never show chat-style assistant chrome inside GenUI */
+.genui-openui-root .genui-advisor-message > div:first-child,
+.genui-openui-root .genui-advisor-message > div > span:first-child {
+  display: none !important;
+}
+
 .genui-openui-root .openui-shell-thread-wrapper,
 .genui-openui-root .openui-shell-thread-container {
   width: 100%;
@@ -80,8 +118,28 @@
 }
 
 .genui-openui-root .openui-shell-thread-scroll-area {
-  padding-left: var(--openui-space-m);
-  padding-right: var(--openui-space-m);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+/* Report surface: full-width component canvas inside the message list */
+.genui-openui-root .genui-report-surface {
+  width: 100%;
+  max-width: none;
+}
+
+.genui-openui-root .genui-report-surface .genui-lang-render {
+  width: 100%;
+  max-width: none;
+}
+
+.genui-openui-root .openui-shell-thread-messages {
+  max-width: none !important;
+  width: 100%;
+}
+
+.genui-openui-root .genui-advisor-message {
+  max-width: none;
 }
 
 .dark .genui-workspace,

--- a/app/projects/[id]/documents/genui/page.tsx
+++ b/app/projects/[id]/documents/genui/page.tsx
@@ -36,10 +36,17 @@ import {
   Copy,
   Check,
   Sparkles,
-  MessageSquare,
-  Plus,
+  LayoutTemplate,
 } from "lucide-react";
+import { GenuiReportExportBarPortal } from "@/components/genui/GenuiReportExportBar";
 import { getDocumentChatPrompts } from "@/lib/documents/document-chat-prompts";
+import {
+  GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT,
+  GENUI_RENDER_FULL_DOCUMENT_PROMPT,
+} from "@/lib/documents/genui-prompts";
+import { GenuiPromptBridge } from "@/components/genui/GenuiPromptBridge";
+import { GenuiReportSurfaceProvider } from "@/components/genui/GenuiReportSurfaceContext";
+import { GenuiThreadToolbar } from "@/components/genui/GenuiThreadToolbar";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiClient } from "@/lib/api";
 import { toast } from "@/lib/notify";
@@ -71,6 +78,8 @@ export default function DocumentGenUIWorkspace() {
   const [copied, setCopied] = useState(false);
   const [chatSessionKey, setChatSessionKey] = useState(0);
   const [reportDarkTheme, setReportDarkTheme] = useState(false);
+  const [pendingRenderPrompt, setPendingRenderPrompt] = useState<string | null>(null);
+  const clearPendingRenderPrompt = useCallback(() => setPendingRenderPrompt(null), []);
 
   useEffect(() => {
     setChatSessionKey(0);
@@ -162,10 +171,17 @@ export default function DocumentGenUIWorkspace() {
   };
 
   const selectedSummary = documents.find((d) => d.id === documentId);
-  const starterPrompts = useMemo(
-    () => getDocumentChatPrompts(doc?.title ?? "Document", selectedSummary?.template_name),
-    [doc?.title, selectedSummary?.template_name]
-  );
+  const starterPrompts = useMemo(() => {
+    const prompts = getDocumentChatPrompts(
+      doc?.title ?? "Document",
+      selectedSummary?.template_name
+    );
+    return prompts.filter(
+      (p) =>
+        p !== GENUI_RENDER_FULL_DOCUMENT_PROMPT &&
+        p !== GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT
+    );
+  }, [doc?.title, selectedSummary?.template_name]);
 
   const conversationStarters = useMemo(
     () => ({
@@ -180,17 +196,19 @@ export default function DocumentGenUIWorkspace() {
 
   const genuiLayoutPrompt =
     "Render the full document to a interactive UI Component Report";
+  const [lastUserLayoutPrompt, setLastUserLayoutPrompt] = useState(genuiLayoutPrompt);
 
   const renderGenuiAssistantMessage = useCallback(
     (props: { message: OpenUIAssistantMessage; isStreaming: boolean }) => (
       <CustomAssistantMessage
         {...props}
         layoutSourceText={doc?.content}
-        layoutPrompt={genuiLayoutPrompt}
+        layoutPrompt={lastUserLayoutPrompt || genuiLayoutPrompt}
         documentId={documentId ?? undefined}
+        reportSurface
       />
     ),
-    [doc?.content, documentId]
+    [doc?.content, documentId, lastUserLayoutPrompt]
   );
 
   if (authLoading || (loading && !doc)) {
@@ -301,7 +319,7 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
         <main className="flex-1 flex overflow-hidden">
           <PageTransition className="flex flex-1 overflow-hidden w-full h-full">
             <div className="flex w-full h-full divide-x divide-slate-200">
-              <div className="genui-source-pane w-1/2 flex flex-col h-full">
+              <div className="genui-source-pane flex flex-col h-full">
                 <div className="p-6 border-b border-slate-200 bg-white flex justify-between items-start gap-4">
                   <div className="min-w-0">
                     <span className="text-[10px] font-semibold uppercase tracking-[0.24em] text-indigo-600">
@@ -360,22 +378,22 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                 </div>
               </div>
 
-              <div className="flex w-1/2 min-w-0 h-full flex-col min-h-0 relative bg-white border-l border-slate-200">
+              <div className="genui-advisor-pane flex min-w-0 h-full flex-col min-h-0 relative bg-white border-l border-slate-200">
                 <div className="shrink-0 px-5 py-3 border-b border-slate-200 bg-slate-50">
                   <div className="flex items-start justify-between gap-4">
                     <div className="flex items-start gap-3 min-w-0 flex-1">
                       <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700">
-                        <MessageSquare className="h-4 w-4" />
+                        <LayoutTemplate className="h-4 w-4" />
                       </div>
                       <div className="min-w-0">
                         <span className="text-[10px] font-semibold uppercase tracking-[0.2em] text-violet-700">
-                          Step 2 — Ask the AI
+                          Step 2 — Component report
                         </span>
                         <p className="text-sm text-slate-900 mt-0.5 font-medium">
-                          Document advisor
+                          OpenUI interactive report
                         </p>
                         <p className="genui-muted text-xs mt-1 leading-relaxed">
-                          Pick a suggested question below or type in the chat box at the bottom. Responses can include tables, charts, and structured summaries grounded in the document on the left.
+                          Use a suggested prompt or type below to build cards, tables, timelines, and summaries from the source document. Export PDF, Word, or HTML when the report is ready.
                         </p>
                         {process.env.NEXT_PUBLIC_GENUI_LLM_PROVIDER ? (
                           <p className="text-[10px] text-slate-500 mt-1.5 font-mono">
@@ -386,22 +404,12 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                         ) : null}
                       </div>
                     </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="h-8 shrink-0 gap-1.5 text-xs border-slate-200 text-slate-700 hover:bg-white"
-                      onClick={() => setChatSessionKey((k) => k + 1)}
-                      title="Start a new conversation about this document"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      New chat
-                    </Button>
                   </div>
                 </div>
                 <div
                   className={`genui-openui-root flex-1 min-h-0 w-full${reportDarkTheme ? " genui-report-dark" : ""}`}
                 >
+                  <GenuiReportSurfaceProvider>
                   <FullScreen
                     key={`${documentId}-${chatSessionKey}`}
                     processMessage={async ({ messages, abortController }) => {
@@ -411,6 +419,7 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                         typeof lastUser?.content === "string"
                           ? lastUser.content
                           : String(lastUser?.content ?? "");
+                      setLastUserLayoutPrompt(lastPrompt.trim() || genuiLayoutPrompt);
                       setReportDarkTheme(wantsGenuiReportDarkTheme(lastPrompt));
 
                       let coverSummary: string | undefined
@@ -468,9 +477,9 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                     componentLibrary={projectOpenUILibrary}
                     agentName={`${doc.title} advisor`}
                     welcomeMessage={{
-                      title: `Explore “${doc.title}”`,
+                      title: `Build a report from “${doc.title}”`,
                       description:
-                        "Ask questions about this document. The advisor can build interactive charts, tables, checklists, and summaries from the source text shown on the left — not from the open web.",
+                        "Choose a starter or describe the view you need. The report is generated from the source text on the left — not from the open web.",
                       image: (
                         <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-violet-100 text-violet-700">
                           <Sparkles className="h-7 w-7" />
@@ -479,8 +488,48 @@ When generating layout, charts, or tables, use metrics from the excerpt and layo
                     }}
                     conversationStarters={conversationStarters}
                     assistantMessage={renderGenuiAssistantMessage}
+                    threadHeader={
+                      <>
+                        <GenuiThreadToolbar
+                          renderDisabled={!doc.content?.trim() || loading}
+                          onRenderDocument={() =>
+                            setPendingRenderPrompt(GENUI_RENDER_FULL_DOCUMENT_PROMPT)
+                          }
+                          onNewReport={() => setChatSessionKey((k) => k + 1)}
+                        />
+                        <GenuiPromptBridge
+                          prompt={pendingRenderPrompt}
+                          onSent={clearPendingRenderPrompt}
+                        />
+                        <GenuiReportExportBarPortal
+                          documentTitle={doc.title}
+                          sourceMarkdown={doc.content}
+                          presentationContext={
+                            projectId && documentId
+                              ? {
+                                  projectId,
+                                  documentId,
+                                  documentVersion: doc.version,
+                                  documentTitle: doc.title,
+                                  sourceMarkdown: doc.content,
+                                  lastUserLayoutPrompt,
+                                }
+                              : undefined
+                          }
+                        />
+                      </>
+                    }
                   />
+                  </GenuiReportSurfaceProvider>
                 </div>
+                <div
+                  className="genui-report-export-anchor shrink-0"
+                  data-genui-step="2-export"
+                  data-genui-project-id={projectId ?? undefined}
+                  data-genui-document-id={documentId ?? undefined}
+                  data-genui-document-version={doc?.version}
+                  aria-hidden={false}
+                />
               </div>
             </div>
           </PageTransition>

--- a/components/genui/GenuiPromptBridge.tsx
+++ b/components/genui/GenuiPromptBridge.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useThread } from "@openuidev/react-headless"
+
+/**
+ * Sends a user prompt into the OpenUI FullScreen thread (must render inside ChatProvider).
+ */
+export function GenuiPromptBridge({
+  prompt,
+  onSent,
+}: {
+  prompt: string | null
+  onSent: () => void
+}) {
+  const processMessage = useThread((s) => s.processMessage)
+  const isRunning = useThread((s) => s.isRunning)
+  const consumedPromptRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const text = prompt?.trim()
+    if (!text || isRunning) return
+    if (consumedPromptRef.current === text) return
+
+    consumedPromptRef.current = text
+    onSent()
+
+    void processMessage({ role: "user", content: text }).finally(() => {
+      if (consumedPromptRef.current === text) {
+        consumedPromptRef.current = null
+      }
+    })
+  }, [prompt, isRunning, processMessage, onSent])
+
+  return null
+}

--- a/components/genui/GenuiReportExportBar.tsx
+++ b/components/genui/GenuiReportExportBar.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useThread } from "@openuidev/react-headless";
+import {
+  ChevronDown,
+  FileCode2,
+  FileDown,
+  FileText,
+  FileType2,
+  Globe,
+  Loader2,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  extractMessageText,
+  extractOpenUILangText,
+  looksLikeOpenUILang,
+  type OpenUIChatJson,
+} from "@/lib/openui/library";
+import {
+  buildPresentationSnapshotDraft,
+  isGenuiStep3PublishEnabled,
+  type GenuiPresentationContext,
+} from "@/lib/genui/presentationSnapshot";
+import {
+  downloadTextFile,
+  exportGenuiReportHtml,
+  exportGenuiReportPdf,
+  exportGenuiReportWord,
+  getLatestGenuiReportRenderElement,
+  sanitizeExportFilename,
+} from "@/lib/genui/reportExport";
+import { toast } from "@/lib/notify";
+
+type ExportKind = "pdf" | "word" | "html" | null;
+
+type GenuiReportExportBarProps = {
+  documentTitle: string;
+  /** Step 1 source text — optional exports from the left pane */
+  sourceMarkdown?: string;
+  /** Reserved for Step 3 publish — builds snapshot draft without persisting */
+  presentationContext?: GenuiPresentationContext;
+};
+
+function threadHasRenderedReport(
+  messages: { role: string; content?: unknown }[]
+): boolean {
+  return messages.some((m) => {
+    if (m.role !== "assistant") return false;
+    const text = extractMessageText(m.content as OpenUIChatJson);
+    return looksLikeOpenUILang(extractOpenUILangText(text));
+  });
+}
+
+function getLatestAssistantLang(
+  messages: { role: string; content?: unknown }[]
+): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role !== "assistant") continue;
+    const text = extractMessageText(m.content as OpenUIChatJson);
+    const lang = extractOpenUILangText(text);
+    if (looksLikeOpenUILang(lang)) return lang;
+  }
+  return null;
+}
+
+const EXPORT_ANCHOR_SELECTOR = ".genui-report-export-anchor";
+
+/**
+ * Renders inside FullScreen (for useThread) and portals the bar to the bottom of Step 2.
+ */
+export function GenuiReportExportBarPortal(props: GenuiReportExportBarProps) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setAnchor(document.querySelector(EXPORT_ANCHOR_SELECTOR));
+  }, []);
+
+  if (!anchor) return null;
+  return createPortal(<GenuiReportExportBar {...props} />, anchor);
+}
+
+function GenuiReportExportBar({
+  documentTitle,
+  sourceMarkdown,
+  presentationContext,
+}: GenuiReportExportBarProps) {
+  const messages = useThread((s) => s.messages);
+  const hasReport = useMemo(() => threadHasRenderedReport(messages), [messages]);
+  const [exporting, setExporting] = useState<ExportKind>(null);
+  const step3PublishEnabled = isGenuiStep3PublishEnabled();
+
+  const baseName = useMemo(() => sanitizeExportFilename(documentTitle), [documentTitle]);
+
+  const snapshotDraft = useMemo(() => {
+    if (!presentationContext) return null;
+    return buildPresentationSnapshotDraft(presentationContext, {
+      openuiLang: getLatestAssistantLang(messages),
+    });
+  }, [messages, presentationContext]);
+
+  const runExport = useCallback(
+    async (kind: ExportKind) => {
+      if (!kind) return;
+      setExporting(kind);
+      try {
+        let result: { ok: boolean; reason?: string };
+        if (kind === "pdf") {
+          result = await exportGenuiReportPdf(documentTitle);
+        } else if (kind === "word") {
+          result = exportGenuiReportWord(documentTitle);
+        } else {
+          result = exportGenuiReportHtml(documentTitle);
+        }
+        if (!result.ok) {
+          toast.error(result.reason ?? "Export failed");
+        } else if (kind === "pdf") {
+          toast.success("Use “Save as PDF” in the print dialog");
+        } else {
+          toast.success(`Downloaded ${kind.toUpperCase()} export`);
+        }
+      } finally {
+        setExporting(null);
+      }
+    },
+    [documentTitle]
+  );
+
+  const exportSourceMarkdown = useCallback(() => {
+    if (!sourceMarkdown?.trim()) {
+      toast.error("No source document text to export");
+      return;
+    }
+    downloadTextFile(sourceMarkdown, `${baseName}-source.md`, "text/markdown;charset=utf-8");
+    toast.success("Downloaded source Markdown");
+  }, [baseName, sourceMarkdown]);
+
+  const exportOpenUILang = useCallback(() => {
+    const lang = getLatestAssistantLang(messages);
+    if (!lang) {
+      toast.error("No OpenUI Lang report to export");
+      return;
+    }
+    downloadTextFile(lang, `${baseName}.openui-lang`, "text/plain;charset=utf-8");
+    toast.success("Downloaded OpenUI Lang source");
+  }, [baseName, messages]);
+
+  const savePresentationSnapshot = useCallback(() => {
+    if (!step3PublishEnabled) return;
+    if (!snapshotDraft) {
+      toast.error("Cannot build presentation snapshot — render a report first");
+      return;
+    }
+    // Wire to POST getGenuiPresentationApiPaths(documentId).create when Step 3 ships.
+    toast.info("Save presentation (Step 3) is not enabled in this environment yet");
+  }, [snapshotDraft, step3PublishEnabled]);
+
+  const exportPlainText = useCallback(() => {
+    const renderRoot = getLatestGenuiReportRenderElement();
+    const text =
+      renderRoot?.innerText?.trim() || renderRoot?.textContent?.trim() || "";
+    if (!text) {
+      toast.error("Render a report first");
+      return;
+    }
+    downloadTextFile(text, `${baseName}.txt`, "text/plain;charset=utf-8");
+    toast.success("Downloaded plain text");
+  }, [baseName]);
+
+  const disabled = !hasReport || exporting !== null;
+
+  return (
+    <div
+      className="genui-report-export-bar shrink-0 border-t border-slate-200 bg-white px-4 py-3"
+      role="region"
+      aria-label="Export report"
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold text-slate-900">Export report</p>
+          <p className="text-[11px] text-slate-500 leading-snug mt-0.5">
+            {hasReport
+              ? "PDF uses your browser print dialog. Word and HTML include the rendered layout."
+              : "Render a report first, then export."}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs border-slate-200"
+            disabled={disabled}
+            onClick={() => runExport("pdf")}
+            title="Print / Save as PDF"
+          >
+            {exporting === "pdf" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <FileText className="h-3.5 w-3.5 text-violet-600" />
+            )}
+            PDF
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs border-slate-200"
+            disabled={disabled}
+            onClick={() => runExport("word")}
+            title="Download as Word (.doc)"
+          >
+            {exporting === "word" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <FileType2 className="h-3.5 w-3.5 text-violet-600" />
+            )}
+            Word
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 text-xs border-slate-200"
+            disabled={disabled}
+            onClick={() => runExport("html")}
+            title="Download standalone HTML"
+          >
+            {exporting === "html" ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Globe className="h-3.5 w-3.5 text-violet-600" />
+            )}
+            HTML
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1 text-xs border-slate-200"
+                disabled={exporting !== null}
+              >
+                <FileDown className="h-3.5 w-3.5 text-slate-600" />
+                More
+                <ChevronDown className="h-3 w-3 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-52">
+              <DropdownMenuLabel className="text-xs">Other formats</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={!hasReport}
+                onClick={exportPlainText}
+                className="text-xs gap-2"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Plain text (.txt)
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!hasReport}
+                onClick={exportOpenUILang}
+                className="text-xs gap-2"
+              >
+                <FileCode2 className="h-3.5 w-3.5" />
+                OpenUI Lang source
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={!sourceMarkdown?.trim()}
+                onClick={exportSourceMarkdown}
+                className="text-xs gap-2"
+              >
+                <FileText className="h-3.5 w-3.5" />
+                Source Markdown (Step 1)
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={!step3PublishEnabled || !snapshotDraft}
+                onClick={savePresentationSnapshot}
+                className="text-xs gap-2"
+                title="Step 3 — snapshot, blobs, and optional Confluence/Jira/SharePoint publish (planned). See docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md"
+              >
+                <FileDown className="h-3.5 w-3.5" />
+                Publish presentation (Step 3)
+                {!step3PublishEnabled ? " (planned)" : ""}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/genui/GenuiReportSurfaceContext.tsx
+++ b/components/genui/GenuiReportSurfaceContext.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+/** When true, assistant messages render as full-width report canvas (GenUI workspace). */
+const GenuiReportSurfaceContext = createContext(false);
+
+export function GenuiReportSurfaceProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <GenuiReportSurfaceContext.Provider value={true}>
+      {children}
+    </GenuiReportSurfaceContext.Provider>
+  );
+}
+
+export function useGenuiReportSurface(): boolean {
+  return useContext(GenuiReportSurfaceContext);
+}

--- a/components/genui/GenuiThreadToolbar.tsx
+++ b/components/genui/GenuiThreadToolbar.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useThread } from "@openuidev/react-headless";
+import { LayoutTemplate, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  extractMessageText,
+  extractOpenUILangText,
+  looksLikeOpenUILang,
+  type OpenUIChatJson,
+} from "@/lib/openui/library";
+
+type GenuiThreadToolbarProps = {
+  renderDisabled: boolean;
+  onRenderDocument: () => void;
+  onNewReport: () => void;
+};
+
+function threadHasRenderedReport(
+  messages: { role: string; content?: unknown }[]
+): boolean {
+  return messages.some((m) => {
+    if (m.role !== "assistant") return false;
+    const text = extractMessageText(m.content as OpenUIChatJson);
+    return looksLikeOpenUILang(extractOpenUILangText(text));
+  });
+}
+
+/** Toolbar inside OpenUI thread — hides "Render document" once a report exists. */
+export function GenuiThreadToolbar({
+  renderDisabled,
+  onRenderDocument,
+  onNewReport,
+}: GenuiThreadToolbarProps) {
+  const messages = useThread((s) => s.messages);
+  const hasReport = threadHasRenderedReport(messages);
+
+  return (
+    <div className="flex w-full flex-wrap items-center justify-end gap-2 border-b border-slate-200 bg-slate-50 px-4 py-2">
+      {!hasReport ? (
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 gap-1.5 text-xs bg-violet-600 hover:bg-violet-700 text-white shadow-sm"
+          disabled={renderDisabled}
+          onClick={onRenderDocument}
+          title="Build a full interactive report from this document (light theme)"
+        >
+          <LayoutTemplate className="h-3.5 w-3.5" />
+          Render document
+        </Button>
+      ) : null}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 shrink-0 gap-1.5 text-xs border-slate-200 text-slate-700 hover:bg-white"
+        onClick={onNewReport}
+        title="Start a new report for this document"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        + New Report
+      </Button>
+    </div>
+  );
+}

--- a/components/openui-chat/AssistantMessage.tsx
+++ b/components/openui-chat/AssistantMessage.tsx
@@ -7,10 +7,13 @@ import { Copy, FileText, Code, Volume2, ThumbsUp, ThumbsDown, Check } from "luci
 
 import { DynamicComponentRenderer } from "./DynamicComponentRenderer";
 import {
+  extractMessageText,
   extractOpenUILangText,
   looksLikeOpenUILang,
+  type OpenUIChatJson,
 } from "@/lib/openui/library";
 import { buildLayoutPlan, repairGenuiExecutorLang } from "@/lib/openui/layoutPlan";
+import { useGenuiReportSurface } from "@/components/genui/GenuiReportSurfaceContext";
 
 interface AssistantMessageProps {
   message: AssistantMessage;
@@ -19,6 +22,8 @@ interface AssistantMessageProps {
   layoutSourceText?: string;
   layoutPrompt?: string;
   documentId?: string;
+  /** GenUI workspace: OpenUI Lang renders as full-width report surface (no chat chrome). */
+  reportSurface?: boolean;
 }
 
 export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
@@ -27,14 +32,19 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
   layoutSourceText,
   layoutPrompt,
   documentId,
+  reportSurface = false,
 }) => {
+  const genuiReportSurface = useGenuiReportSurface();
   const [copied, setCopied] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [showRaw, setShowRaw] = useState(false);
   const [feedback, setFeedback] = useState<"like" | "dislike" | null>(null);
   const [speaking, setSpeaking] = useState(false);
 
-  const rawContent = message.content || "";
+  const rawContent = useMemo(
+    () => extractMessageText(message.content as OpenUIChatJson),
+    [message.content]
+  );
   const langText = useMemo(() => extractOpenUILangText(rawContent), [rawContent]);
   const renderLangText = useMemo(() => {
     if (isStreaming || !layoutSourceText?.trim() || !langText?.trim()) return langText
@@ -51,6 +61,8 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
     () => looksLikeOpenUILang(langText),
     [langText]
   );
+  /** GenUI workspace: full-width report canvas (no AI avatar / "Advisor response" chrome). */
+  const isReportSurface = (reportSurface || genuiReportSurface) && !showRaw;
 
   const handleCopy = async () => {
     try {
@@ -62,6 +74,7 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
     }
   };
 
+  /** TODO(genui-pdf): clone `.genui-lang-render` DOM (or html2canvas) — not raw Lang. See genui PDF plan in docs/codedocs/genui-workspace.md */
   const handleExportPDF = () => {
     if (!rawContent) return;
     setExporting(true);
@@ -141,6 +154,121 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
     window.speechSynthesis.speak(utterance);
   };
 
+  const contentBlock = showRaw ? (
+    <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700">
+      {isGenUILang ? langText : JSON.stringify(message, null, 2)}
+    </pre>
+  ) : isGenUILang ? (
+    <div className="genui-lang-render min-w-0 w-full">
+      <DynamicComponentRenderer response={renderLangText} isStreaming={isStreaming} />
+    </div>
+  ) : rawContent ? (
+    <MarkDownRenderer
+      textMarkdown={rawContent}
+      className="prose prose-slate max-w-none text-sm leading-relaxed text-slate-700"
+    />
+  ) : null;
+
+  const compactToolbar = !isStreaming && (
+    <div
+      className={
+        isReportSurface
+          ? "genui-report-toolbar flex flex-wrap items-center gap-2 pt-2"
+          : "mt-1 flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3"
+      }
+    >
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50"
+        title="Copy response"
+      >
+        {copied ? <Check size={13} className="text-green-600" /> : <Copy size={13} />}
+        <span>{copied ? "Copied" : "Copy"}</span>
+      </button>
+
+      {!isReportSurface ? (
+        <button
+          type="button"
+          onClick={handleExportPDF}
+          disabled={exporting}
+          className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
+          title="Export as PDF"
+        >
+          <FileText size={13} className="text-violet-600" />
+          <span>{exporting ? "Exporting…" : "Export PDF"}</span>
+        </button>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={() => setShowRaw(!showRaw)}
+        className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
+          showRaw
+            ? "border-violet-200 bg-violet-50 text-violet-700"
+            : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+        }`}
+        title={isGenUILang ? "Show OpenUI Lang source" : "Show raw message JSON"}
+      >
+        <Code size={13} />
+        <span>{showRaw ? "Show rendered" : isGenUILang ? "View source" : "View JSON"}</span>
+      </button>
+
+      {!isReportSurface ? (
+        <>
+          <button
+            type="button"
+            onClick={handleSpeak}
+            className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
+              speaking
+                ? "border-green-200 bg-green-50 text-green-700"
+                : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+            }`}
+            title="Read aloud"
+          >
+            <Volume2 size={13} />
+            <span>{speaking ? "Stop" : "Speak"}</span>
+          </button>
+
+          <span className="mx-1 h-4 w-px bg-slate-200" />
+
+          <button
+            type="button"
+            onClick={() => setFeedback(feedback === "like" ? null : "like")}
+            className={`rounded-md border p-1.5 transition-colors ${
+              feedback === "like"
+                ? "border-blue-200 bg-blue-50 text-blue-600"
+                : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
+            }`}
+          >
+            <ThumbsUp size={13} />
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setFeedback(feedback === "dislike" ? null : "dislike")}
+            className={`rounded-md border p-1.5 transition-colors ${
+              feedback === "dislike"
+                ? "border-red-200 bg-red-50 text-red-600"
+                : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
+            }`}
+          >
+            <ThumbsDown size={13} />
+          </button>
+        </>
+      ) : null}
+    </div>
+  );
+
+  if (isReportSurface) {
+    return (
+      <div className="genui-report-surface w-full px-2 py-3 sm:px-4">
+        {contentBlock}
+        {compactToolbar}
+      </div>
+    );
+  }
+
   return (
     <div className="genui-advisor-message flex gap-3 px-4 py-4 border-b border-slate-100 bg-white">
       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-700 text-sm font-semibold">
@@ -148,106 +276,9 @@ export const CustomAssistantMessage: React.FC<AssistantMessageProps> = ({
       </div>
 
       <div className="flex min-w-0 flex-1 flex-col gap-3">
-        <span className="text-xs font-semibold tracking-wide text-slate-500">
-          Advisor response
-        </span>
-
-        {showRaw ? (
-          <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-slate-50 p-4 font-mono text-xs text-slate-700">
-            {isGenUILang ? langText : JSON.stringify(message, null, 2)}
-          </pre>
-        ) : isGenUILang ? (
-          <div className="genui-lang-render min-w-0 w-full">
-            <DynamicComponentRenderer
-              response={renderLangText}
-              isStreaming={isStreaming}
-            />
-          </div>
-        ) : rawContent ? (
-          <MarkDownRenderer
-            textMarkdown={rawContent}
-            className="prose prose-slate max-w-none text-sm leading-relaxed text-slate-700"
-          />
-        ) : null}
-
-        {!isStreaming && (
-          <div className="mt-1 flex flex-wrap items-center gap-2 border-t border-slate-100 pt-3">
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50"
-              title="Copy response"
-            >
-              {copied ? <Check size={13} className="text-green-600" /> : <Copy size={13} />}
-              <span>{copied ? "Copied" : "Copy"}</span>
-            </button>
-
-            <button
-              type="button"
-              onClick={handleExportPDF}
-              disabled={exporting}
-              className="flex items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-50 disabled:opacity-50"
-              title="Export as PDF"
-            >
-              <FileText size={13} className="text-violet-600" />
-              <span>{exporting ? "Exporting…" : "Export PDF"}</span>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setShowRaw(!showRaw)}
-              className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
-                showRaw
-                  ? "border-violet-200 bg-violet-50 text-violet-700"
-                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
-              }`}
-              title={isGenUILang ? "Show OpenUI Lang source" : "Show raw message JSON"}
-            >
-              <Code size={13} />
-              <span>{showRaw ? "Show rendered" : isGenUILang ? "View source" : "View JSON"}</span>
-            </button>
-
-            <button
-              type="button"
-              onClick={handleSpeak}
-              className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors ${
-                speaking
-                  ? "border-green-200 bg-green-50 text-green-700"
-                  : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
-              }`}
-              title="Read aloud"
-            >
-              <Volume2 size={13} />
-              <span>{speaking ? "Stop" : "Speak"}</span>
-            </button>
-
-            <span className="mx-1 h-4 w-px bg-slate-200" />
-
-            <button
-              type="button"
-              onClick={() => setFeedback(feedback === "like" ? null : "like")}
-              className={`rounded-md border p-1.5 transition-colors ${
-                feedback === "like"
-                  ? "border-blue-200 bg-blue-50 text-blue-600"
-                  : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
-              }`}
-            >
-              <ThumbsUp size={13} />
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setFeedback(feedback === "dislike" ? null : "dislike")}
-              className={`rounded-md border p-1.5 transition-colors ${
-                feedback === "dislike"
-                  ? "border-red-200 bg-red-50 text-red-600"
-                  : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50"
-              }`}
-            >
-              <ThumbsDown size={13} />
-            </button>
-          </div>
-        )}
+        <span className="text-xs font-semibold tracking-wide text-slate-500">Advisor response</span>
+        {contentBlock}
+        {compactToolbar}
       </div>
     </div>
   );

--- a/docs/codedocs/genui-workspace.md
+++ b/docs/codedocs/genui-workspace.md
@@ -5,7 +5,9 @@ description: "Split-pane document viewer plus OpenUI advisor: routes, rendering 
 
 The **document GenUI workspace** lets users read an extracted governance document on the left and chat with an AI advisor on the right. The advisor can return **OpenUI Lang**, which the UI renders as interactive components (cards, tables, charts, tabs, steps).
 
-This page is **not** the same as [OpenUI Chat](/docs/openui-chat), which is project-scoped chat backed by `server/src/modules/openuiChat` with thread persistence and RAG. The document workspace uses a separate HTTP path and Mistral streaming.
+This page is **not** the same as [OpenUI Chat](/docs/openui-chat), which is project-scoped chat backed by `server/src/modules/openuiChat` with thread persistence and RAG. The document workspace uses `POST /api/chat` with `systemPrompt` (Mistral or Gemini via `GENUI_LLM_PROVIDER`).
+
+**Any document** in the project stack can use this route (`docId` in the query string). Layout rules are driven by the **user’s message** and markdown structure, not by a fixed document type.
 
 For agent-driven maintenance, see `.agents/skills/adpa-genui-workspace/SKILL.md` and the **Document GenUI workspace** section in `AGENTS.md`.
 
@@ -24,7 +26,10 @@ Navigation from other document modes (View, Source, Report) uses `DocumentPageTo
 | Pane | Purpose |
 | --- | --- |
 | **Step 1 — Source document** | Title, metadata, word count, full extracted `doc.content` from the documents API |
-| **Step 2 — Ask the AI** | OpenUI `FullScreen` chat: starters, streaming replies, **New chat** (client session reset) |
+| **Step 2 — Component report** | OpenUI `FullScreen`: **Render document** CTA, starters, streaming OpenUI Lang in **report surface**, **Export report** bar (PDF / Word / HTML) |
+| **Step 3 — Published presentations** | *Planned* — snapshot + blob artifacts + optional publish to **Confluence / Jira / SharePoint / ProjectWise**; see [design spec](../superpowers/specs/2026-05-21-genui-step3-presentations-design.md) |
+
+Right pane uses ~62% width. Light theme is default; dark report is an explicit conversation starter (`GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT`), not automatic.
 
 Styling lives in `app/projects/[id]/documents/genui/genui-workspace.css` (light theme, panel-sized OpenUI shell, sidebar hidden inside the embed).
 
@@ -38,9 +43,12 @@ Styling lives in `app/projects/[id]/documents/genui/genui-workspace.css` (light 
 | Chat proxy (Mistral) | `app/api/chat/route.ts` |
 | Assistant rendering | `components/openui-chat/AssistantMessage.tsx` (re-exported from `components/Chat/AssistantMessage.tsx`) |
 | Lang → components | `components/openui-chat/DynamicComponentRenderer.tsx` |
-| Canonical library | `lib/openui/projectOpenUILibrary.ts`, `lib/openui/bulletsDef.tsx`, `lib/openui/systemPrompt.ts` |
+| Canonical library | `lib/openui/projectOpenUILibrary.ts`, `lib/openui/adpaGenuiExtensionDefs.ts`, `lib/openui/systemPrompt.ts` |
+| Layout planner | `lib/openui/layoutPlan.ts` (focused vs full report, shell selection) |
+| Report surface | `components/genui/GenuiReportSurfaceContext.tsx` |
 | Fence stripping / detection | `lib/openui/library.ts` — `extractOpenUILangText()`, `looksLikeOpenUILang()` |
-| Conversation starters | `lib/documents/document-chat-prompts.ts` |
+| Conversation starters | `lib/documents/document-chat-prompts.ts`, `lib/documents/genui-prompts.ts` |
+| Render CTA bridge | `components/genui/GenuiPromptBridge.tsx` (`useThread().processMessage`) |
 | Route IDs | `lib/documents/use-project-document-route-ids.ts` |
 | Toolbar / GenUI button | `components/documents/DocumentPageToolbar.tsx` |
 
@@ -48,10 +56,11 @@ Styling lives in `app/projects/[id]/documents/genui/genui-workspace.css` (light 
 
 1. The page loads the document via the authenticated documents API (`projectId` + `documentId`).
 2. It builds a **system prompt** from `buildOpenUISystemPrompt()` (`projectOpenUILibrary.prompt()` + layout rules in `lib/openui/systemPrompt.ts`) plus the full document body and metadata.
-3. `FullScreen` posts to `POST /api/chat` with `{ systemPrompt, messages }`.
-4. When `systemPrompt` is present, `app/api/chat/route.ts` streams from **Mistral** or **Google Gemini** (`GENUI_LLM_PROVIDER`: `mistral` default, `google` for Gemini via OpenAI-compatible API). Without `systemPrompt`, the same route proxies to backend OpenUI chat (Gemini in `server`).
-5. The model should reply in **OpenUI Lang** (e.g. `root = Stack([...])`), sometimes wrapped in ` ```openui-lang ` fences.
-6. `CustomAssistantMessage` detects Lang, strips fences, and renders with `@openuidev/react-lang` `Renderer` and **`projectOpenUILibrary`** (full GenUI catalog + Bullets).
+3. `FullScreen` posts to `POST /api/chat` with `{ systemPrompt, messages }`. The page passes **`lastUserLayoutPrompt`** (latest user text) into `CustomAssistantMessage` for layout repair — not only the default full-document string.
+4. `buildLayoutPlan({ prompt, sourceText: doc.content, documentId })` runs before the executor LLM; output is injected as `=== REQUIRED LAYOUT PLAN ===` via `enrichOpenUIApiMessages()`.
+5. When `systemPrompt` is present, `app/api/chat/route.ts` streams from **Mistral** or **Google Gemini** (`GENUI_LLM_PROVIDER`). Without `systemPrompt`, the route proxies to backend OpenUI chat.
+6. The model should reply in **OpenUI Lang** (e.g. `root = Stack([...])`), sometimes wrapped in ` ```openui-lang ` fences.
+7. `CustomAssistantMessage` detects Lang, strips fences, and renders with `@openuidev/react-lang` `Renderer` and **`projectOpenUILibrary`** (GenUI catalog + ADPA extensions).
 
 ```mermaid
 flowchart LR
@@ -71,14 +80,35 @@ flowchart LR
 - Prompts should request **Card / Stack / Accordion / Table** layouts, not a single top-level `Bullets` (see `systemPrompt.ts`).
 - Always run model output through **`extractOpenUILangText()`** before `looksLikeOpenUILang()` / `Renderer`.
 
+## Focused vs full document layout
+
+| Mode | Typical user prompt | Result |
+| --- | --- | --- |
+| **Focused detail** | Timeline/gantt/kanban from a section; `no cover`, `no table of contents`; follow-ups like “from this report, gantt chart” | Single **Timeline** or **Table** in `root = Stack([...])` — **no** cover or TOC |
+| **Full report** | `GENUI_RENDER_FULL_DOCUMENT_PROMPT`, “render the full document”, cover + chapters | Cover + optional TOC + **Card per chapter** when the doc has enough `##` headings |
+
+Prompt constants: `lib/documents/genui-prompts.ts`. Schedule-related starters: keyword bucket in `document-chat-prompts.ts`.
+
+**Current mapping (until dedicated Lang widgets exist):**
+
+| User intent | Lang output |
+| --- | --- |
+| Timeline / milestones | `Timeline` |
+| “Gantt chart” | `Table` (activities, dates, dependencies) |
+| Kanban-style | `Table` with status columns |
+
+Planner helpers: `wantsGenuiFocusedDetailRender()`, `wantsGenuiFullDocumentLayout()` in `layoutPlan.ts`. Tests: `__tests__/lib/layoutPlan.test.ts`.
+
 ## Environment variables
 
 Set in `.env.local` (see `.env.local.example`):
 
 | Variable | Required for Step 2 | Notes |
 | --- | --- | --- |
-| `MISTRAL_API_KEY` | Yes | Missing key → 503 from `/api/chat` |
+| `GENUI_LLM_PROVIDER` | No | `mistral` (default) or `google` for Gemini |
+| `MISTRAL_API_KEY` | When provider is Mistral | Missing key → 503 from `/api/chat` |
 | `MISTRAL_MODEL` | No | Default `mistral-large-latest` |
+| `GOOGLE_AI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY` | When provider is `google` | Same keys as server Gemini |
 | `BACKEND_URL` | Step 1 | Document fetch via Express proxy |
 | Auth (`auth_token` cookie / Firebase) | Yes | Page requires login |
 
@@ -88,6 +118,27 @@ OpenUI package styles are imported on the page:
 import "@openuidev/react-ui/defaults.css";
 import "@openuidev/react-ui/components.css";
 ```
+
+## Export and Step 3 (publish)
+
+### Step 2 — client export (shipped)
+
+Rendered `.genui-lang-render` DOM — not raw Lang. See `lib/genui/reportExport.ts` and `components/genui/GenuiReportExportBar.tsx`.
+
+| Format | Mechanism |
+| --- | --- |
+| PDF | Browser print dialog |
+| Word | HTML wrapped as `.doc` |
+| HTML | Standalone download |
+| More | Plain text, OpenUI Lang source, Step 1 markdown |
+
+Server `GET /api/v1/documents/:id/export/pdf` still exports **markdown** only — different audience.
+
+### Step 3 — reserved (not implemented)
+
+**Canonical document:** `documents.content` (markdown). **Published report:** snapshot row + blobs (PDF, optional Lang replay). Full design: [2026-05-21-genui-step3-presentations-design.md](../superpowers/specs/2026-05-21-genui-step3-presentations-design.md).
+
+Code reserve: `lib/genui/presentationSnapshot.ts` (`buildPresentationSnapshotDraft`, API path helpers). Enable future UI with `NEXT_PUBLIC_GENUI_STEP3_PUBLISH=true`.
 
 ## Persistence and sessions
 
@@ -99,12 +150,15 @@ import "@openuidev/react-ui/components.css";
 
 | Goal | Where to change |
 | --- | --- |
-| Suggested questions | `lib/documents/document-chat-prompts.ts` |
-| Grounding / instructions | `systemPrompt` block in `genui/page.tsx` |
+| Suggested questions | `lib/documents/document-chat-prompts.ts`, `lib/documents/genui-prompts.ts` |
+| Focused vs full planner rules | `lib/openui/layoutPlan.ts`, `lib/openui/componentSelector.ts` |
+| Grounding / executor instructions | `lib/openui/systemPrompt.ts` |
 | Layout / contrast / OpenUI embed | `genui-workspace.css` |
-| New OpenUI components | Prefer `@openuidev/react-ui/genui-lib` Lang syntax; consult OpenUI docs for grammar |
+| **New Lang component (stack-wide)** | See checklist in `.agents/skills/adpa-genui-workspace/SKILL.md` — register in `adpaGenuiExtensionDefs.ts` (not only `DynamicComponentRenderer` JSON) |
 | Thread history per document | New persistence design — do not break `/api/v1/openui-chat` without a migration plan |
-| RAG for large documents | Chunk retrieval from existing server RAG; watch Mistral context limits |
+| RAG for large documents | Chunk retrieval from existing server RAG; watch context limits |
+
+Adding a component does **not** require changing `docId` routing or document fetch — only the shared OpenUI library, planner, prompts, and tests.
 
 Future PM dashboards are described in `docs/superpowers/specs/2026-05-18-genui-personalized-dashboards-design.md`; that is a separate route from this document workspace.
 
@@ -131,6 +185,8 @@ Future PM dashboards are described in `docs/superpowers/specs/2026-05-18-genui-p
 | Empty Step 1 | Document API or missing `doc.content` |
 | Chat layout broken | `genui-workspace.css` overrides under `.genui-openui-root` |
 | Model ignores document | Empty content or weak system prompt |
+| Full SMP after “gantt from report” | Follow-up not treated as focused — avoid “full document” on chart follow-ups; see `wantsGenuiFocusedDetailRender` |
+| Gantt shows as table | Expected until a Gantt Lang extension is registered |
 
 ## Related documentation
 

--- a/docs/implementation/LESSONS_LEARNED_OPENUI_GENUI_KICKOFF.md
+++ b/docs/implementation/LESSONS_LEARNED_OPENUI_GENUI_KICKOFF.md
@@ -1,0 +1,117 @@
+# Lessons learned — OpenUI / GenUI implementation kickoff
+
+**Project:** ADPA — Implementation of OpenUI and Auto UI Generation  
+**Window:** May 1–31, 2026 (per charter / Schedule Management Plan)  
+**Captured:** 2026-05-21  
+**Status:** Living document for ACT-CLS-001 and future kickoffs
+
+---
+
+## 1. Requirements & kickoff — avoid vague deliverable nouns
+
+### Lesson
+
+Terms such as **engine**, **platform**, **integration**, and **automation** let planning, duration estimates, DRACO governance, and implementation each assume a different scope. By the time the **document GenUI pipeline** was working in production-like dev, planning artifacts could still read as if core development had not started.
+
+### Rule for future kickoffs
+
+For every named deliverable, require **observable outcomes** in the same sentence — not a metaphor.
+
+| Instead of | Specify |
+|------------|---------|
+| Auto UI **generation engine** | **Document GenUI pipeline:** source markdown → layout plan → OpenUI Lang → rendered report at `/projects/{id}/documents/genui?docId=…` |
+| **Integration** with Thesys/OpenUI | **Component grammar:** `projectOpenUILibrary` + executor rules; list routes/APIs (`POST /api/chat`, etc.) |
+| **LLM hook** | Provider env (`GENUI_LLM_PROVIDER`, `MISTRAL_*`), thread + `enrichOpenUIApiMessages` |
+| **Complete** | Checklist: demo path, tests, deploy target, and explicit **deferred** items (e.g. Step 3 publish) |
+
+**Retro one-liner:** *If we cannot demo it in one sentence, we do not name it in the charter.*
+
+### Recommended WBS split (replacing a single “DEV-002 engine” row)
+
+| ID | Name | Intent |
+|----|------|--------|
+| **DEV-002a** | Layout plan + Lang generation + render loop | **Complete (foundation)** — repeatable auto-UI path |
+| **DEV-002b** | Hardening, exports, provider tuning, template breadth | **In progress** |
+| **DEV-002c** | Published presentation snapshots (Step 3) | **Deferred** — see `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md` |
+
+---
+
+## 2. Definition — what “Auto UI generation engine” means in ADPA
+
+### Layer A — Engine (delivered at foundation tier)
+
+An **auto UI generation engine** in ADPA is a **repeatable pipeline**:
+
+1. **Input** — Source text + user intent (document body, prompt, optional thread).
+2. **Plan** — Heuristic/deterministic mapping to a component graph (`buildLayoutPlan`, segments, shells, focused follow-ups).
+3. **Generate** — LLM emits **OpenUI Lang** under executor rules + `projectOpenUIPromptLibrary`.
+4. **Render** — Client executes Lang → interactive UI (`CustomAssistantMessage` + `projectOpenUILibrary`, GenUI report surface).
+5. **Refine** — Follow-up turns (e.g. gantt/timeline from an existing report) without re-chartering the full document.
+
+**Acceptance criteria (Layer A):**
+
+- UI produced without hand-authored React per report (Lang + renderer).
+- Grounded in project/document source (`doc.content` + layout plan).
+- Repeatable across prompts and governance documents (document-agnostic `docId`).
+- Iteration via thread + focused planner paths (`wantsGenuiFocusedDetailRender`).
+- Traceable rules (layout plan + executor rules + `repairGenuiExecutorLang`), not unconstrained prose.
+
+### Layer B — Program completion (not required to claim “engine exists”)
+
+- Thesys/vendor edge cases and every template variant.
+- **Step 3** immutable publish + blob artifacts (design reserve only).
+- Production deploy, full UAT, formal closure (ACT-DEP / ACT-CLS).
+- DRACO PASS on every generated report.
+
+**Schedule implication:** ~35 expected person-days in a ~22 working-day month only works with parallelism. With foundation in place, **31 May** is realistic for **MVP / demo-ready GenUI** if scope is Layer A + agreed polish; it is tight if every ACT row including UAT/closure must be 100% done.
+
+---
+
+## 3. DRACO / council review — grade the right artifact
+
+DRACO reviews **documents**, not the running app. Adjust expectations by document type:
+
+| Document type | Board should judge |
+|---------------|-------------------|
+| Planning (duration estimates, SMP) | Internal consistency; scope clarity — not proof of production deploy |
+| Implementation status / attestation | ACT-ID → observable capabilities; Complete / In progress / Deferred |
+| Generated GenUI report | Evidence, governance tone, no invented dates — not “is DEV-002 done?” |
+
+**Governance footnote for attestation docs:**
+
+> **Auto UI generation engine (delivered):** ADPA pipeline from governance document text → layout plan → OpenUI Lang → rendered interactive report (GenUI workspace), with LLM hook and component library integration.  
+> **Out of scope for “engine delivered”:** presentation publish (Step 3), all templates, production sign-off.
+
+---
+
+## 4. Implementation tweaks delivered (this effort)
+
+| Area | Change | Files / notes |
+|------|--------|----------------|
+| **Plain text export** | Use `getLatestGenuiReportRenderElement()` so export works when `.genui-report-toolbar` follows `.genui-lang-render` (fixes false “Render a report first”) | `components/genui/GenuiReportExportBar.tsx`, `lib/genui/reportExport.ts`, `lib/genui/presentationSnapshot.ts`, `__tests__/lib/genuiReportExport.test.ts` |
+| **Double “Render document”** | Consume prompt before `processMessage`; `consumedPromptRef` guard; stable `clearPendingRenderPrompt` | `components/genui/GenuiPromptBridge.tsx`, `app/projects/[id]/documents/genui/page.tsx` |
+| **GenUI LLM provider** | Document Mistral in `.env.local.example`; local override must use `GENUI_LLM_PROVIDER=mistral` (root `.env` alone is insufficient if `.env.local` sets `google`) | `.env.local.example`, `lib/llm/genuiLlmProvider.ts` |
+| **Report surface & exports** | Report-first toolbar, export bar (PDF/Word/HTML/plain text), Step 3 draft types (flag-gated) | `components/genui/*`, `lib/genui/reportExportPrepare.ts`, `lib/genui/presentationSnapshot.ts` |
+| **Layout / follow-ups** | Focused renders from prior report; layout plan tests | `lib/openui/layoutPlan.ts`, `__tests__/lib/layoutPlan.test.ts` |
+| **Docs & skills** | GenUI workspace skill, codedoc, Step 3 design reserve, AGENTS.md pointer | `.agents/skills/adpa-genui-workspace/SKILL.md`, `docs/codedocs/genui-workspace.md`, `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md` |
+
+---
+
+## 5. Copy-paste — charter / closure bullet list
+
+Use in **Lessons learned** section of project closure or next charter appendix:
+
+1. **Define deliverables by demo path and acceptance criteria**, not by nouns like “engine.”
+2. **Split DEV-002** into core pipeline (done), hardening (in progress), and Step 3 publish (deferred).
+3. **Align DRACO inputs** — run governance on **implementation status** docs that reference Layer A criteria, not only duration tables with outdated status.
+4. **Environment:** GenUI provider is controlled by `.env.local` `GENUI_LLM_PROVIDER`; document in onboarding checklist.
+5. **Exports:** Report DOM structure must share one “latest render” helper across PDF, Word, HTML, and plain text.
+
+---
+
+## References
+
+- GenUI workspace skill: `.agents/skills/adpa-genui-workspace/SKILL.md`
+- Human codedoc: `docs/codedocs/genui-workspace.md`
+- Step 3 design reserve: `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md`
+- DRACO overview: `docs/07-architecture/ADR-004-DRACO-AI-GOVERNANCE.md`

--- a/docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md
+++ b/docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md
@@ -1,0 +1,286 @@
+# GenUI Step 3 — Published presentation snapshots (design reserve)
+
+**Status:** Design reserve — not implemented (no API, no DB table, no blob upload).  
+**Related:** Document GenUI workspace Step 2 (`/projects/{id}/documents/genui?docId=…`), `.agents/skills/adpa-genui-workspace/SKILL.md`.
+
+## Problem
+
+1. **Markdown** in `documents.content` is the canonical, living document (including future autonomous template refresh and versioned collaboration).
+2. **Step 2** produces beautiful **OpenUI Lang** interactive reports — valuable for presentation but **not reproducible** from markdown alone (LLM, planner, and component catalog drift).
+3. Stakeholders need a **fixed** report for a point in time while the source document may keep changing.
+
+Step 3 is **Publish**: save an immutable **presentation snapshot** and **artifacts** without making OpenUI Lang or PDF the source of truth for the document.
+
+## Separation of concerns
+
+| Layer | Storage | Role |
+| --- | --- | --- |
+| Document truth | Postgres `documents.content` (markdown) | Search, extraction, quality, autonomous updates |
+| Step 1 | — | Read verified source |
+| Step 2 | In-memory session | Explore, render, refine OpenUI report |
+| **Step 3 (future)** | Postgres row + **blob container** | Named snapshot + PDF/DOCX/HTML/Lang replay files |
+
+**Never** write OpenUI Lang into `documents.content`.  
+**Never** treat blob artifacts as editable source — they are derivatives of a snapshot.
+
+## When Step 3 becomes necessary
+
+As markdown versioning runs autonomously (template optimization, change triggers), the contrast is obvious:
+
+- **Living document** = latest markdown in DB.
+- **Published report** = what we showed on date X (audit, board, external share).
+
+Step 2 client export (print / download) is sufficient for ad-hoc use. Step 3 is required when the organization needs **reproducible, named, stored** presentations.
+
+## Snapshot model
+
+### `document_presentations` (future table — name TBD)
+
+Thin metadata in Postgres; bytes in blob storage.
+
+| Field | Purpose |
+| --- | --- |
+| `id` | UUID |
+| `project_id`, `document_id` | Tenant scope |
+| `document_version` | `documents.version` at publish time |
+| `source_content_fingerprint` | Hash of `documents.content` at publish (staleness detection) |
+| `title` / `label` | User-facing name (“Q2 steering deck”) |
+| `render_recipe` | JSON — prompt, layout mode, spec version (audit / approximate replay) |
+| `status` | `draft` \| `published` \| `stale` (source changed) |
+| `created_by`, `created_at` | Audit |
+| `artifacts` | JSON array of `{ kind, blob_path, mime_type, byte_size }` |
+
+### Artifact kinds (blob container)
+
+Align with `GenuiPresentationArtifactKind` in `lib/genui/presentationSnapshot.ts`:
+
+| Kind | Typical use |
+| --- | --- |
+| `pdf` | Final deliverable (server: `unifiedPdfService.generateFromHtml`) |
+| `docx` | Word deliverable |
+| `html` | Standalone HTML |
+| `html_snapshot` | Frozen DOM for stable server PDF |
+| `openui_lang` | Replay interactive report in GenUI (derivative, not document truth) |
+| `plain_text` | Accessibility / search within snapshot |
+
+**Blob layout (proposed):**
+
+```txt
+presentations/{projectId}/{documentId}/{presentationId}/{kind}.{ext}
+```
+
+Use existing ADPA blob/storage patterns when implementing (Azure, S3, or local dev container).
+
+## Blob storage requirements (implementation checklist)
+
+Use this when implementing Step 3 publish — ADPA does not yet have a dedicated presentation blob adapter; align with whichever object store the platform standardizes on (Azure Blob, S3-compatible, or local dev).
+
+### Functional
+
+| # | Requirement |
+| --- | --- |
+| B1 | **Upload** one or more artifacts per publish (`pdf`, `docx`, `html`, `html_snapshot`, `openui_lang`, `plain_text`). |
+| B2 | **Path convention** — `presentations/{projectId}/{documentId}/{presentationId}/{kind}.{ext}` (`buildPresentationBlobPath()`). |
+| B3 | **Content types** — correct `Content-Type` per kind (`application/pdf`, `text/html`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `text/plain`, etc.). |
+| B4 | **Download** — signed URL or authenticated stream; tenant scope via `project_id` + `document_id`. |
+| B5 | **Delete** — when a presentation row is deleted, remove all blobs under that `presentationId` prefix (or soft-delete + lifecycle policy). |
+| B6 | **Idempotent publish** — re-publish same label creates new `presentationId` (new prefix); optional overwrite only if product explicitly supports “replace snapshot”. |
+
+### Non-functional
+
+| # | Requirement |
+| --- | --- |
+| B7 | **Max size** — define per-artifact limit (e.g. PDF ≤ 25 MB, `html_snapshot` ≤ 5 MB); reject with 413 + clear error. |
+| B8 | **Encryption** — at-rest encryption per cloud account defaults; no public containers. |
+| B9 | **Access** — private blobs only; no anonymous read; URLs time-limited (e.g. 15–60 min) if using SAS/presign. |
+| B10 | **Retention** — optional TTL / archival policy TBD; not required for v1. |
+| B11 | **Dev/local** — env-driven container name + connection string (mirror `server/.env` patterns); document in `server/.env.example`. |
+
+### Metadata (Postgres `artifacts` JSON)
+
+Each entry:
+
+```json
+{
+  "kind": "pdf",
+  "blob_path": "presentations/{projectId}/{documentId}/{presentationId}/pdf.pdf",
+  "mime_type": "application/pdf",
+  "byte_size": 123456
+}
+```
+
+Server computes `byte_size` after upload; never trust client-reported sizes for billing/audit.
+
+### Publish pipeline (server)
+
+1. Authenticate + `checkProjectAccess` on `document_id`.
+2. Verify `source_content_fingerprint` and `document_version` against `documents` row.
+3. Build **export-ready HTML** using the same rules as Step 2 client export (`prepareGenuiReportExportHtml` semantics): all table rows, no pagination chrome, absolute image URLs.
+4. Generate artifacts:
+   - `html_snapshot` — cleaned HTML (required for reproducible PDF).
+   - `pdf` — `unifiedPdfService.generateFromHtml(html_snapshot, …)`.
+   - `docx` — v1: HTML-as-doc or dedicated converter (TBD).
+   - `openui_lang` — optional, from client draft payload.
+5. Upload blobs in parallel; insert `document_presentations` row only after all required uploads succeed (or mark `status: draft` until complete).
+6. Return presentation id + download links.
+
+### Environment variables (proposed — add to `server/.env.example` when implementing)
+
+| Variable | Purpose |
+| --- | --- |
+| `GENUI_PRESENTATIONS_CONTAINER` | Blob container / bucket name |
+| `GENUI_PRESENTATIONS_STORAGE_CONNECTION` | Connection string or key (or reuse global `AZURE_STORAGE_*` if shared) |
+| `GENUI_PRESENTATIONS_SIGNED_URL_TTL_SECONDS` | Download link lifetime (default 3600) |
+
+### Out of scope for blob v1
+
+- Storing blobs in Postgres (`bytea`).
+- Writing presentation artifacts into `documents.content`.
+- Using Morphic `morphic_uploads` Supabase bucket (different product surface).
+
+### Related code today
+
+| Piece | Role |
+| --- | --- |
+| `lib/genui/reportExport.ts` | Client export; `prepareGenuiReportExportHtml()` = reference for server snapshot HTML |
+| `lib/genui/presentationSnapshot.ts` | Draft builder + `buildPresentationBlobPath()` |
+| `server/src/services/pdfService.ts` | `generateFromHtml` for server PDF |
+| `app/api/upload/route.ts` | Supabase upload pattern (not presentations) |
+| `server/src/integrations/confluence.ts` | Document publish (markdown today) |
+| `server/src/services/jiraLinkageService.ts` | Jira issue linkage |
+| `server/src/services/sharepointService.ts` | File upload to SharePoint drive |
+| `server/src/services/storageArchivalService.ts` | SharePoint + ProjectWise orchestration |
+| `app/projects/[id]/documents/view/page.tsx` | **Publish to Confluence / Jira** (markdown document) |
+
+## Direct publish to integrations (Step 3 — in scope)
+
+Enterprise publishing stays **inside Step 3**, not a separate product surface. Flow:
+
+1. User finishes Step 2 report → **Publish** (snapshot).
+2. Server creates blobs (`pdf`, `html_snapshot`, …).
+3. **Optionally** pushes selected platforms in the **same job** (or `POST …/presentations/:id/integrations` to retry).
+4. Results stored on the presentation row as `external_publish[]` (and mirrored on `documents.metadata` / `confluence_page_url` where applicable).
+
+**Important:** Document View today publishes **living markdown** to Confluence and creates a **Jira issue** with a text description. Step 3 publishes the **frozen GenUI presentation** (PDF/HTML), while still linking back to `document_id` and `presentation_id`.
+
+### Supported platforms (v1 target)
+
+| Platform | Project setting | Default artifact | Existing ADPA module |
+| --- | --- | --- | --- |
+| **Confluence** | `confluence_enabled`, space/parent overrides | `html_snapshot` or `pdf` | `ConfluenceIntegration`, `POST /api/integrations/confluence/:id/export` |
+| **Jira** | `jira_enabled`, project key / issue type | `pdf` (attach or link in description) | `JiraLinkageService`, `POST /api/jira-linkage/create-issue` |
+| **SharePoint** | `sharepoint_auto_archive` or explicit publish | `pdf` or `docx` | `sharepointService.uploadDocument`, `StorageArchivalService` |
+| **ProjectWise** | `projectwise_auto_archive` | `pdf` or `docx` | `projectWiseService.uploadDocument` |
+
+Types: `GenuiPresentationIntegrationPlatform`, `PublishPresentationIntegrationsRequest` in `lib/genui/presentationSnapshot.ts`. Adapter map: `GENUI_PRESENTATION_INTEGRATION_ADAPTERS`.
+
+### Integration requirements
+
+| # | Requirement |
+| --- | --- |
+| I1 | Publish only after snapshot artifacts exist (or atomically: blobs first, then integrations). |
+| I2 | Respect **project_integrations** toggles — skip disabled platforms with `status: skipped`, not hard error. |
+| I3 | **Confluence** — support update when `documents.confluence_page_url` exists (`confluenceUpdateExisting`); store returned URL on document + presentation ref. |
+| I4 | **Jira** — create or link issue; include ADPA deep link to GenUI presentation + document view; optional PDF attachment when API allows. |
+| I5 | **SharePoint / ProjectWise** — upload binary from blob path; store `webUrl` on `external_publish` and `documents.metadata.archival`. |
+| I6 | **Idempotency** — `POST …/presentations/:id/integrations` retries failed platforms without re-uploading blobs. |
+| I7 | **Audit** — each ref records `platform`, `status`, `artifactKind`, `url`, `error`, `publishedAt`. |
+| I8 | Do **not** replace `documents.content` with Confluence HTML or presentation HTML. |
+
+### Confluence modes (Step 3 extension)
+
+| Mode | Input | Use when |
+| --- | --- | --- |
+| `markdown_source` | `documents.content` | Parity with today’s document view (living doc sync) |
+| `html_snapshot` | Prepared GenUI HTML | Stakeholder-facing page matches Step 2 report |
+| `attachment_pdf` | Snapshot `pdf` blob | PDF in Confluence attachments (TBD API) |
+
+Default for GenUI **Publish**: `html_snapshot` or `pdf`, not markdown alone.
+
+### API extensions (Step 3)
+
+| Method | Path | Body |
+| --- | --- | --- |
+| `POST` | `/api/v1/documents/:documentId/presentations` | `CreateGenuiPresentationRequest` including optional `publishIntegrations` |
+| `POST` | `/api/v1/documents/:documentId/presentations/:presentationId/integrations` | `{ platforms: [...] }` — retry / add platforms |
+
+### UI (GenUI workspace Step 3)
+
+When `NEXT_PUBLIC_GENUI_STEP3_PUBLISH=true`:
+
+- **Publish presentation** dialog: label, artifact checkboxes (PDF, HTML snapshot, Lang).
+- **Also publish to** (multi-select): Confluence, Jira, SharePoint, ProjectWise — enabled only if project integration settings allow.
+- After success: list snapshots with download links + external links (View in Confluence, Open in Jira).
+
+Document View can later call the same `POST …/presentations` with `publishIntegrations` for markdown-only snapshots, or keep separate buttons until unified.
+
+### Reproducibility strategy
+
+On **Publish**, capture **one or more** of:
+
+1. **Artifacts** (PDF + optional HTML snapshot) — **pixel-faithful** for external audience.
+2. **OpenUI Lang** — **interactive replay** in-app (cache; invalidate when renderer catalog changes).
+3. **Render recipe** — audit trail and best-effort regeneration (not guaranteed identical).
+
+Recommended default on publish: **html_snapshot + pdf + optional openui_lang**.
+
+## API sketch (future — not implemented)
+
+Reserved paths (see `getGenuiPresentationApiPaths` in `lib/genui/presentationSnapshot.ts`):
+
+| Method | Path | Body |
+| --- | --- | --- |
+| `POST` | `/api/v1/documents/:documentId/presentations` | `CreateGenuiPresentationRequest` |
+| `GET` | `/api/v1/documents/:documentId/presentations` | List snapshots |
+| `GET` | `/api/v1/documents/:documentId/presentations/:presentationId` | Metadata + signed blob URLs |
+
+Client draft builder today: `buildPresentationSnapshotDraft()` — same shape as future POST body prep.
+
+## UI sketch (future)
+
+| Step | User-facing |
+| --- | --- |
+| 1 | Source document (unchanged) |
+| 2 | Component report + export bar (current) |
+| **3** | **Published presentations** — list snapshots, download PDF, “Open in GenUI”, **Publish to Confluence / Jira / SharePoint** |
+
+Until Step 3 ships, Step 2 **Export report** bar remains the delivery path. Optional env `NEXT_PUBLIC_GENUI_STEP3_PUBLISH=true` will gate **Publish presentation** and integration targets when implemented.
+
+## Distinction from existing document export
+
+| Path | Input | Output |
+| --- | --- | --- |
+| `GET /api/v1/documents/:id/export/pdf` | **Markdown** `documents.content` | PDF (governance template) |
+| Step 2 client export | **Rendered GenUI DOM** | PDF / HTML / .doc |
+| **Step 3 (future)** | GenUI session at publish time | Stored snapshot + blobs |
+| **Step 3 + Confluence** | `html_snapshot` or `pdf` from snapshot | Confluence page (not markdown-only) |
+| Document view → Confluence (today) | `documents.content` markdown | Living doc sync |
+
+All paths are valid; they serve different audiences.
+
+## Implementation phases
+
+| Phase | Deliverable |
+| --- | --- |
+| **Now (reserve)** | Spec (this file), `lib/genui/presentationSnapshot.ts`, docs/skill updates, client draft types |
+| **2a** | Server `POST` publish: HTML snapshot → PDF to blob; DB row |
+| **2b** | Step 3 UI: list/download presentations |
+| **2c** | Staleness when `source_content_fingerprint` ≠ current content |
+| **2d** | **Integration publish** — Confluence / Jira / SharePoint / ProjectWise from snapshot blobs |
+| **3** | Policy hooks (auto-publish on milestone), integration with autonomous markdown pipeline |
+
+## Invariants for implementers
+
+1. `documents.content` stays markdown-only canonical.
+2. Presentation rows reference `document_id` + version/fingerprint; do not fork document rows.
+3. GenUI workspace `POST /api/chat` and `openui_chat_threads` remain separate products unless explicitly unified.
+4. Step 2 exploratory sessions stay ephemeral until user (or policy) calls **Publish**.
+
+## Code references (today)
+
+| File | Role |
+| --- | --- |
+| `lib/genui/presentationSnapshot.ts` | Types, fingerprint, draft builder, API path helpers |
+| `lib/genui/reportExport.ts` | Step 2 client export (DOM) |
+| `components/genui/GenuiReportExportBar.tsx` | Export UI; reserved “Save presentation” |
+| `app/projects/[id]/documents/genui/page.tsx` | `data-genui-*` on export anchor |

--- a/lib/documents/document-chat-prompts.ts
+++ b/lib/documents/document-chat-prompts.ts
@@ -1,3 +1,11 @@
+import {
+  GENUI_GANTT_REGISTER_PROMPT,
+  GENUI_KANBAN_STYLE_PROMPT,
+  GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT,
+  GENUI_RENDER_FULL_DOCUMENT_PROMPT,
+  GENUI_TIMELINE_FROM_SCHEDULE_PROMPT,
+} from "@/lib/documents/genui-prompts"
+
 const DOCUMENT_PROMPTS: { keywords: string[]; prompts: string[] }[] = [
   {
     keywords: ["risk"],
@@ -44,6 +52,15 @@ const DOCUMENT_PROMPTS: { keywords: string[]; prompts: string[] }[] = [
       "Visualize communication flow",
     ],
   },
+  {
+    keywords: ["schedule", "timeline", "milestone", "gantt"],
+    prompts: [
+      GENUI_TIMELINE_FROM_SCHEDULE_PROMPT,
+      GENUI_GANTT_REGISTER_PROMPT,
+      GENUI_KANBAN_STYLE_PROMPT,
+      "List critical path activities as a table with start and finish dates",
+    ],
+  },
 ]
 
 /** Suggested chat prompts based on document name / template keywords. */
@@ -55,7 +72,8 @@ export function getDocumentChatPrompts(docName: string, templateName?: string): 
     }
   }
   return [
-    "Render the full document: cover page, table of contents, then one Card per numbered chapter (### subsections inside chapters). Dark report theme — black background, gray sunk cards. Use Bullets for lists; Team only for named rosters.",
+    GENUI_RENDER_FULL_DOCUMENT_PROMPT,
+    GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT,
     "Summarize this document in a short executive overview",
     "Show the main sections as a structured table",
     "List every action item and owner mentioned",

--- a/lib/documents/genui-prompts.ts
+++ b/lib/documents/genui-prompts.ts
@@ -1,0 +1,25 @@
+/**
+ * GenUI workspace prompts — full-document render, optional dark variant, and focused widgets.
+ * Used by conversation starters and the "Render document" CTA. Layout behavior is driven by
+ * `buildLayoutPlan()` in `lib/openui/layoutPlan.ts` from the user's message text (not doc id).
+ */
+
+/** One-click full report: layout planner + light OpenUI theme (no forced dark mode). */
+export const GENUI_RENDER_FULL_DOCUMENT_PROMPT =
+  "Render the full document: cover page, table of contents, then one Card per numbered chapter (### subsections nested inside each chapter Card). Use Bullets for lists; Team only for named rosters; Table for registers and matrices. root = Stack with intro Card + section Cards (no Report component). Professional light presentation-ready layout."
+
+/** Optional starter — user must choose dark theme explicitly. */
+export const GENUI_RENDER_FULL_DOCUMENT_DARK_PROMPT =
+  "Render the full document with dark report theme: black background, gray sunk cards — cover page, table of contents, then one Card per numbered chapter (### subsections inside chapters). Use Bullets for lists; Team only for named rosters."
+
+/** Focused: single Timeline from a schedule-style section (no cover / TOC). */
+export const GENUI_TIMELINE_FROM_SCHEDULE_PROMPT =
+  "Generate a timeline from the Schedule Management Plan section. No cover, no table of contents."
+
+/** Focused: schedule register table (planner treats as table shell; not a bar-chart Gantt). */
+export const GENUI_GANTT_REGISTER_PROMPT =
+  "Render a Gantt chart from the Schedule Management Plan showing activities, start dates, finish dates, and dependencies. No cover, no table of contents."
+
+/** Focused: kanban-style columns via Table until a Kanban Lang component exists. */
+export const GENUI_KANBAN_STYLE_PROMPT =
+  "From the Schedule Management Plan, show work packages on a kanban-style board (Upcoming / In progress / Completed). No cover, no table of contents."

--- a/lib/genui/presentationSnapshot.ts
+++ b/lib/genui/presentationSnapshot.ts
@@ -1,0 +1,324 @@
+/**
+ * Step 3 (Publish) — reserved contracts for presentation snapshots.
+ *
+ * NOT implemented here: REST handlers, `document_presentations` table, blob upload.
+ * See: docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md
+ */
+
+import {
+  getLatestGenuiReportRenderElement,
+  prepareGenuiReportExportHtml,
+} from "@/lib/genui/reportExport";
+import {
+  wantsGenuiFocusedDetailRender,
+  wantsGenuiFullDocumentLayout,
+} from "@/lib/openui/layoutPlan";
+
+/** Bump when render_recipe or artifact semantics change. */
+export const GENUI_PRESENTATION_SPEC_VERSION = "1" as const;
+
+export type GenuiPresentationSpecVersion = typeof GENUI_PRESENTATION_SPEC_VERSION;
+
+/** Blob + API artifact kinds for a published presentation. */
+export const GENUI_PRESENTATION_ARTIFACT_KINDS = [
+  "pdf",
+  "docx",
+  "html",
+  "html_snapshot",
+  "openui_lang",
+  "plain_text",
+] as const;
+
+export type GenuiPresentationArtifactKind =
+  (typeof GENUI_PRESENTATION_ARTIFACT_KINDS)[number];
+
+/** Step 2 export bar actions → future blob kind (Word v1 saves HTML as .doc). */
+export const GENUI_STEP2_EXPORT_TO_ARTIFACT_KIND: Record<
+  "pdf" | "word" | "html" | "openui_lang" | "plain_text" | "source_markdown",
+  GenuiPresentationArtifactKind | "source_markdown"
+> = {
+  pdf: "pdf",
+  word: "docx",
+  html: "html",
+  openui_lang: "openui_lang",
+  plain_text: "plain_text",
+  source_markdown: "source_markdown",
+};
+
+export type GenuiLayoutMode = "focused" | "full" | "unknown";
+
+export type GenuiRenderRecipe = {
+  specVersion: GenuiPresentationSpecVersion;
+  /** Last user message that drove layout plan + executor (Step 2). */
+  userPrompt: string;
+  layoutMode: GenuiLayoutMode;
+  plannerSurface: "genui-workspace";
+  capturedAt: string;
+};
+
+/** Metadata row shape (Postgres) — bytes live in blob storage. */
+export type GenuiPresentationRecord = {
+  id: string;
+  projectId: string;
+  documentId: string;
+  documentVersion: number;
+  sourceContentFingerprint: string;
+  title: string;
+  label?: string;
+  status: "draft" | "published" | "stale";
+  renderRecipe: GenuiRenderRecipe;
+  artifacts: GenuiPresentationArtifactRef[];
+  /** Results of optional enterprise publish (Step 3) */
+  externalPublish?: GenuiPresentationExternalPublishRef[];
+  createdAt: string;
+  createdBy?: string;
+};
+
+export type GenuiPresentationArtifactRef = {
+  kind: GenuiPresentationArtifactKind;
+  blobPath: string;
+  mimeType: string;
+  byteSize?: number;
+};
+
+/**
+ * Client-side bundle gathered before a future `POST …/presentations`.
+ * Safe to build in Step 2 without persisting.
+ */
+export type GenuiPresentationSnapshotDraft = {
+  specVersion: GenuiPresentationSpecVersion;
+  projectId: string;
+  documentId: string;
+  documentTitle: string;
+  documentVersion: number;
+  sourceContentFingerprint: string;
+  renderRecipe: GenuiRenderRecipe;
+  payloads: {
+    openuiLang: string | null;
+    renderedHtml: string | null;
+    plainText: string | null;
+  };
+};
+
+/**
+ * Enterprise systems Step 3 can push to after snapshot + blobs are created.
+ * Reuses project integration settings (`project_integrations`) and existing server services.
+ */
+export const GENUI_PRESENTATION_INTEGRATION_PLATFORMS = [
+  "confluence",
+  "jira",
+  "sharepoint",
+  "projectwise",
+] as const;
+
+export type GenuiPresentationIntegrationPlatform =
+  (typeof GENUI_PRESENTATION_INTEGRATION_PLATFORMS)[number];
+
+/** Which snapshot artifact to send to each platform (defaults differ per platform). */
+export type GenuiIntegrationArtifactPreference = {
+  confluence?: "html_snapshot" | "pdf" | "markdown_source";
+  jira?: "pdf" | "html_snapshot";
+  sharepoint?: "pdf" | "docx" | "html";
+  projectwise?: "pdf" | "docx";
+};
+
+export type GenuiPresentationExternalPublishRef = {
+  platform: GenuiPresentationIntegrationPlatform;
+  status: "pending" | "published" | "failed" | "skipped";
+  /** Remote URL (Confluence page, Jira issue, SharePoint file, …) */
+  url?: string;
+  externalId?: string;
+  artifactKind?: GenuiPresentationArtifactKind | "markdown_source";
+  error?: string;
+  publishedAt?: string;
+};
+
+export type PublishPresentationIntegrationsRequest = {
+  /** Subset to run; empty = none. Server skips platforms disabled in project settings. */
+  platforms: GenuiPresentationIntegrationPlatform[];
+  artifactPreference?: GenuiIntegrationArtifactPreference;
+  /** Jira: defaults to document title + link back to ADPA presentation */
+  jiraIssueTitle?: string;
+  jiraIssueDescription?: string;
+  /** Confluence: update existing page when `documents.confluence_page_url` is set */
+  confluenceUpdateExisting?: boolean;
+};
+
+/** Future request body for publish API (reserve). */
+export type CreateGenuiPresentationRequest = {
+  specVersion: GenuiPresentationSpecVersion;
+  label?: string;
+  renderRecipe: GenuiRenderRecipe;
+  /** Client- or server-generated; server should re-verify against documents.content */
+  sourceContentFingerprint: string;
+  documentVersion: number;
+  /** At least one artifact source required when implementing server publish */
+  includeArtifacts?: GenuiPresentationArtifactKind[];
+  /** Optional push to Confluence / Jira / SharePoint / ProjectWise (Step 3 — same transaction as snapshot) */
+  publishIntegrations?: PublishPresentationIntegrationsRequest;
+};
+
+export type GenuiPresentationContext = {
+  projectId: string;
+  documentId: string;
+  documentVersion: number;
+  documentTitle: string;
+  sourceMarkdown: string;
+  /** Latest user prompt for layout (from page state). */
+  lastUserLayoutPrompt: string;
+};
+
+/** Stable, non-cryptographic fingerprint for markdown change detection. */
+export function fingerprintSourceMarkdown(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n").trim();
+  let hash = 5381;
+  for (let i = 0; i < normalized.length; i++) {
+    hash = (hash * 33) ^ normalized.charCodeAt(i);
+  }
+  return `djb2-${(hash >>> 0).toString(16)}`;
+}
+
+export function resolveGenuiLayoutModeFromPrompt(prompt: string): GenuiLayoutMode {
+  const trimmed = prompt.trim();
+  if (!trimmed) return "unknown";
+  if (wantsGenuiFocusedDetailRender(trimmed)) return "focused";
+  if (wantsGenuiFullDocumentLayout(trimmed)) return "full";
+  return "unknown";
+}
+
+export function buildRenderRecipe(userPrompt: string): GenuiRenderRecipe {
+  return {
+    specVersion: GENUI_PRESENTATION_SPEC_VERSION,
+    userPrompt: userPrompt.trim(),
+    layoutMode: resolveGenuiLayoutModeFromPrompt(userPrompt),
+    plannerSurface: "genui-workspace",
+    capturedAt: new Date().toISOString(),
+  };
+}
+
+export function getLatestRenderedReportHtml(): string | null {
+  if (typeof document === "undefined") return null;
+  const renderRoot = getLatestGenuiReportRenderElement();
+  if (!renderRoot) return null;
+  return prepareGenuiReportExportHtml(renderRoot).trim() || null;
+}
+
+export function getLatestRenderedReportPlainText(): string | null {
+  if (typeof document === "undefined") return null;
+  const renderRoot = getLatestGenuiReportRenderElement();
+  const text =
+    renderRoot?.innerText?.trim() || renderRoot?.textContent?.trim() || "";
+  return text || null;
+}
+
+/**
+ * Build a publish payload from the current Step 2 session (no network I/O).
+ * Returns null when required ids or source markdown are missing.
+ */
+export function buildPresentationSnapshotDraft(
+  ctx: GenuiPresentationContext,
+  options: { openuiLang?: string | null } = {}
+): GenuiPresentationSnapshotDraft | null {
+  if (!ctx.projectId || !ctx.documentId || !ctx.sourceMarkdown?.trim()) {
+    return null;
+  }
+
+  return {
+    specVersion: GENUI_PRESENTATION_SPEC_VERSION,
+    projectId: ctx.projectId,
+    documentId: ctx.documentId,
+    documentTitle: ctx.documentTitle,
+    documentVersion: ctx.documentVersion,
+    sourceContentFingerprint: fingerprintSourceMarkdown(ctx.sourceMarkdown),
+    renderRecipe: buildRenderRecipe(ctx.lastUserLayoutPrompt || ""),
+    payloads: {
+      openuiLang: options.openuiLang?.trim() || null,
+      renderedHtml: getLatestRenderedReportHtml(),
+      plainText: getLatestRenderedReportPlainText(),
+    },
+  };
+}
+
+/** Proposed blob key — implement upload against your storage adapter. */
+export function buildPresentationBlobPath(
+  projectId: string,
+  documentId: string,
+  presentationId: string,
+  kind: GenuiPresentationArtifactKind,
+  extension: string
+): string {
+  return `presentations/${projectId}/${documentId}/${presentationId}/${kind}.${extension}`;
+}
+
+/** Reserved REST paths (Express / Next proxy) — handlers not implemented. */
+export function getGenuiPresentationApiPaths(documentId: string) {
+  const base = `/api/v1/documents/${documentId}/presentations`;
+  return {
+    list: base,
+    create: base,
+    byId: (presentationId: string) => `${base}/${presentationId}`,
+    republishIntegrations: (presentationId: string) =>
+      `${base}/${presentationId}/integrations`,
+  };
+}
+
+export function isGenuiPresentationIntegrationPlatform(
+  value: string
+): value is GenuiPresentationIntegrationPlatform {
+  return (GENUI_PRESENTATION_INTEGRATION_PLATFORMS as readonly string[]).includes(
+    value
+  );
+}
+
+/** Default artifact per platform when client does not specify preferences. */
+export function defaultIntegrationArtifactPreference(): GenuiIntegrationArtifactPreference {
+  return {
+    confluence: "html_snapshot",
+    jira: "pdf",
+    sharepoint: "pdf",
+    projectwise: "pdf",
+  };
+}
+
+/**
+ * Maps Step 3 integration publish to existing ADPA server modules (implementers).
+ * GenUI publish must use **presentation artifacts**, not raw `documents.content` alone.
+ */
+export const GENUI_PRESENTATION_INTEGRATION_ADAPTERS = {
+  confluence: {
+    service: "ConfluenceIntegration / confluenceRoutes",
+    routes: "POST /api/integrations/confluence/:id/export",
+    projectSettings: "confluence_enabled, confluence_space_key_override",
+    note: "Today exports markdown only; Step 3 adds html_snapshot or PDF attachment mode.",
+  },
+  jira: {
+    service: "JiraLinkageService",
+    routes: "POST /api/jira-linkage/create-issue",
+    projectSettings: "jira_enabled, jira_project_key_override",
+    note: "Link issue to document; attach PDF from presentation blob or URL in description.",
+  },
+  sharepoint: {
+    service: "sharepointService / StorageArchivalService",
+    projectSettings: "sharepoint_auto_archive, sharepoint_drive_id",
+    note: "Upload PDF/DOCX file to configured drive.",
+  },
+  projectwise: {
+    service: "projectWiseService / StorageArchivalService",
+    projectSettings: "projectwise_auto_archive, projectwise_folder_path",
+    note: "Upload PDF/DOCX to configured folder.",
+  },
+} as const;
+
+/** Gate future “Save presentation” UI; default off until Step 3 ships. */
+export function isGenuiStep3PublishEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_GENUI_STEP3_PUBLISH === "true";
+}
+
+export function isPresentationStale(
+  snapshotFingerprint: string,
+  currentSourceMarkdown: string
+): boolean {
+  return (
+    fingerprintSourceMarkdown(currentSourceMarkdown) !== snapshotFingerprint
+  );
+}

--- a/lib/genui/reportExport.ts
+++ b/lib/genui/reportExport.ts
@@ -1,0 +1,242 @@
+/**
+ * Client-side export helpers for the GenUI component report (rendered `.genui-lang-render` DOM).
+ *
+ * Step 2 delivery only. For publish/snapshot contracts reserved for Step 3, see
+ * `lib/genui/presentationSnapshot.ts` and
+ * `docs/superpowers/specs/2026-05-21-genui-step3-presentations-design.md`.
+ */
+
+import {
+  buildTableBodyRowsHtml,
+  escapeHtmlText,
+  parseTableExportPayload,
+  resolveExportUrl,
+} from "@/lib/genui/reportExportPrepare";
+
+const REPORT_RENDER_SELECTOR = ".genui-advisor-pane .genui-lang-render";
+
+const PAGINATION_FOOTER_SELECTOR =
+  ".flex.items-center.justify-end.gap-2.pt-2";
+
+export function sanitizeExportFilename(title: string): string {
+  const base = title
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .slice(0, 80);
+  return base || "genui-report";
+}
+
+/** Latest rendered OpenUI report in the Step 2 pane (last assistant turn). */
+export function getLatestGenuiReportRenderElement(): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  const nodes = document.querySelectorAll<HTMLElement>(REPORT_RENDER_SELECTOR);
+  return nodes.length > 0 ? nodes[nodes.length - 1] : null;
+}
+
+export function downloadTextFile(content: string, filename: string, mime = "text/plain;charset=utf-8") {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+const EXPORT_PRINT_STYLES = `
+  @page { size: A4; margin: 16mm; }
+  body {
+    font-family: Inter, system-ui, sans-serif;
+    color: #0f172a;
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+  }
+  .genui-export-header {
+    border-bottom: 3px solid #7c3aed;
+    padding-bottom: 12px;
+    margin-bottom: 20px;
+  }
+  .genui-export-header h1 {
+    font-size: 20px;
+    margin: 0;
+    color: #0f172a;
+  }
+  .genui-export-header p {
+    margin: 4px 0 0;
+    font-size: 12px;
+    color: #64748b;
+  }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { border: 1px solid #e2e8f0; padding: 8px 10px; text-align: left; vertical-align: top; }
+  th { background: #f8fafc; font-weight: 600; }
+  img { max-width: 100%; height: auto; }
+`;
+
+function buildExportHeaderHtml(title: string): string {
+  const safeTitle = escapeHtmlText(title);
+  return `<div class="genui-export-header">
+    <h1>${safeTitle}</h1>
+    <p>Exported from ADPA GenUI component report</p>
+  </div>`;
+}
+
+function buildExportHtmlDocument(title: string, bodyHtml: string): string {
+  const safeTitle = escapeHtmlText(title);
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${safeTitle}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>${EXPORT_PRINT_STYLES}</style>
+</head>
+<body>
+  ${buildExportHeaderHtml(title)}
+  <div class="genui-export-body">${bodyHtml}</div>
+</body>
+</html>`;
+}
+
+/** Word-compatible single document (no nested full HTML documents). */
+function buildWordHtmlDocument(title: string, bodyHtml: string): string {
+  const safeTitle = escapeHtmlText(title);
+  return `\ufeff<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word">
+<head>
+  <meta charset="utf-8" />
+  <title>${safeTitle}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>${EXPORT_PRINT_STYLES}</style>
+</head>
+<body>
+  ${buildExportHeaderHtml(title)}
+  <div class="genui-export-body">${bodyHtml}</div>
+</body>
+</html>`;
+}
+
+function expandPaginatedTables(root: HTMLElement): void {
+  root.querySelectorAll<HTMLElement>("[data-genui-table-export]").forEach((wrapper) => {
+    const payload = parseTableExportPayload(wrapper.getAttribute("data-genui-table-export"));
+    if (!payload) return;
+
+    wrapper.querySelectorAll(PAGINATION_FOOTER_SELECTOR).forEach((el) => el.remove());
+    wrapper
+      .querySelectorAll('[aria-label="Previous page"], [aria-label="Next page"]')
+      .forEach((el) => el.closest(PAGINATION_FOOTER_SELECTOR)?.remove());
+
+    const tbody = wrapper.querySelector("tbody");
+    if (tbody) {
+      tbody.innerHTML = buildTableBodyRowsHtml(payload.columns);
+    }
+  });
+}
+
+function stripExportChrome(root: HTMLElement): void {
+  root
+    .querySelectorAll(
+      '[aria-label="Previous page"], [aria-label="Next page"], [aria-label="Scroll left"], [aria-label="Scroll right"]'
+    )
+    .forEach((el) => {
+      const footer = el.closest(PAGINATION_FOOTER_SELECTOR);
+      if (footer) footer.remove();
+      else el.remove();
+    });
+
+  root.querySelectorAll("button").forEach((btn) => {
+    const label = btn.getAttribute("aria-label") ?? "";
+    if (/page|scroll/i.test(label)) btn.remove();
+  });
+}
+
+function resolveImagesForExport(root: HTMLElement, origin: string): void {
+  root.querySelectorAll<HTMLImageElement>("img[src]").forEach((img) => {
+    const src = img.getAttribute("src");
+    if (!src) return;
+    img.setAttribute("src", resolveExportUrl(src, origin));
+  });
+}
+
+/**
+ * Clone the live report DOM and prepare it for static export (all table rows, no pagination UI).
+ */
+export function prepareGenuiReportExportHtml(renderRoot: HTMLElement): string {
+  const clone = renderRoot.cloneNode(true) as HTMLElement;
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : "http://localhost:3000";
+
+  expandPaginatedTables(clone);
+  stripExportChrome(clone);
+  resolveImagesForExport(clone, origin);
+
+  return clone.innerHTML;
+}
+
+export type GenuiReportExportResult = { ok: true } | { ok: false; reason: string };
+
+export function exportGenuiReportHtml(title: string): GenuiReportExportResult {
+  const renderRoot = getLatestGenuiReportRenderElement();
+  if (!renderRoot) {
+    return { ok: false, reason: "Render a report first (use a starter or Render document)." };
+  }
+  const bodyHtml = prepareGenuiReportExportHtml(renderRoot);
+  const html = buildExportHtmlDocument(title, bodyHtml);
+  const filename = `${sanitizeExportFilename(title)}.html`;
+  downloadTextFile(html, filename, "text/html;charset=utf-8");
+  return { ok: true };
+}
+
+/** Word opens HTML saved as .doc; preserves layout better than raw Lang for stakeholders. */
+export function exportGenuiReportWord(title: string): GenuiReportExportResult {
+  const renderRoot = getLatestGenuiReportRenderElement();
+  if (!renderRoot) {
+    return { ok: false, reason: "Render a report first (use a starter or Render document)." };
+  }
+  const bodyHtml = prepareGenuiReportExportHtml(renderRoot);
+  const wordShell = buildWordHtmlDocument(title, bodyHtml);
+  const filename = `${sanitizeExportFilename(title)}.doc`;
+  downloadTextFile(wordShell, filename, "application/msword");
+  return { ok: true };
+}
+
+/** Opens the browser print dialog (Save as PDF) using the rendered report DOM. */
+export async function exportGenuiReportPdf(title: string): Promise<GenuiReportExportResult> {
+  const renderRoot = getLatestGenuiReportRenderElement();
+  if (!renderRoot) {
+    return { ok: false, reason: "Render a report first (use a starter or Render document)." };
+  }
+
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "none";
+  iframe.setAttribute("aria-hidden", "true");
+  document.body.appendChild(iframe);
+
+  const doc = iframe.contentWindow?.document;
+  if (!doc) {
+    document.body.removeChild(iframe);
+    return { ok: false, reason: "Could not open print preview." };
+  }
+
+  const bodyHtml = prepareGenuiReportExportHtml(renderRoot);
+  doc.open();
+  doc.write(buildExportHtmlDocument(title, bodyHtml));
+  doc.close();
+
+  await new Promise((r) => setTimeout(r, 400));
+
+  try {
+    iframe.contentWindow?.focus();
+    iframe.contentWindow?.print();
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "Print dialog failed." };
+  } finally {
+    setTimeout(() => {
+      if (iframe.parentNode) document.body.removeChild(iframe);
+    }, 500);
+  }
+}

--- a/lib/genui/reportExport.ts
+++ b/lib/genui/reportExport.ts
@@ -7,9 +7,9 @@
  */
 
 import {
-  buildTableBodyRowsHtml,
   escapeHtmlText,
   parseTableExportPayload,
+  populateTableBodyRows,
   resolveExportUrl,
 } from "@/lib/genui/reportExportPrepare";
 
@@ -134,7 +134,7 @@ function expandPaginatedTables(root: HTMLElement): void {
 
     const tbody = wrapper.querySelector("tbody");
     if (tbody) {
-      tbody.innerHTML = buildTableBodyRowsHtml(payload.columns);
+      populateTableBodyRows(tbody, payload.columns);
     }
   });
 }

--- a/lib/genui/reportExport.ts
+++ b/lib/genui/reportExport.ts
@@ -44,6 +44,12 @@ export function downloadTextFile(content: string, filename: string, mime = "text
   URL.revokeObjectURL(url);
 }
 
+/** Safe teardown for PDF print iframe (avoids throws if body is gone during navigation). */
+function removePrintIframe(iframe: HTMLIFrameElement): void {
+  if (!iframe.parentNode || typeof document === "undefined" || !document.body) return;
+  document.body.removeChild(iframe);
+}
+
 const EXPORT_PRINT_STYLES = `
   @page { size: A4; margin: 16mm; }
   body {
@@ -207,6 +213,10 @@ export async function exportGenuiReportPdf(title: string): Promise<GenuiReportEx
     return { ok: false, reason: "Render a report first (use a starter or Render document)." };
   }
 
+  if (typeof document === "undefined" || !document.body) {
+    return { ok: false, reason: "Export is not available in this environment." };
+  }
+
   const iframe = document.createElement("iframe");
   iframe.style.position = "fixed";
   iframe.style.width = "0";
@@ -217,7 +227,7 @@ export async function exportGenuiReportPdf(title: string): Promise<GenuiReportEx
 
   const doc = iframe.contentWindow?.document;
   if (!doc) {
-    document.body.removeChild(iframe);
+    removePrintIframe(iframe);
     return { ok: false, reason: "Could not open print preview." };
   }
 
@@ -236,7 +246,7 @@ export async function exportGenuiReportPdf(title: string): Promise<GenuiReportEx
     return { ok: false, reason: "Print dialog failed." };
   } finally {
     setTimeout(() => {
-      if (iframe.parentNode) document.body.removeChild(iframe);
+      removePrintIframe(iframe);
     }, 500);
   }
 }

--- a/lib/genui/reportExportPrepare.ts
+++ b/lib/genui/reportExportPrepare.ts
@@ -49,19 +49,36 @@ export function formatExportTableCellText(cell: string): string {
     .trim();
 }
 
-export function buildTableBodyRowsHtml(columns: GenuiTableExportColumn[]): string {
-  const rowCount = tableExportRowCount(columns);
-  const rows: string[] = [];
-  for (let ri = 0; ri < rowCount; ri++) {
-    const cells = columns
-      .map((col) => {
-        const text = formatExportTableCellText(col.data[ri] ?? "");
-        return `<td>${escapeHtmlText(text).replace(/\n/g, "<br />")}</td>`;
-      })
-      .join("");
-    rows.push(`<tr>${cells}</tr>`);
+/** Fill table body via DOM APIs (avoids assigning user-derived HTML to innerHTML). */
+export function populateTableBodyRows(
+  tbody: HTMLTableSectionElement,
+  columns: GenuiTableExportColumn[]
+): void {
+  while (tbody.firstChild) {
+    tbody.removeChild(tbody.firstChild);
   }
-  return rows.join("");
+
+  const rowCount = tableExportRowCount(columns);
+  for (let ri = 0; ri < rowCount; ri++) {
+    const tr = document.createElement("tr");
+    for (const col of columns) {
+      const td = document.createElement("td");
+      appendExportTableCellText(td, col.data[ri] ?? "");
+      tr.appendChild(td);
+    }
+    tbody.appendChild(tr);
+  }
+}
+
+function appendExportTableCellText(td: HTMLTableCellElement, raw: string): void {
+  const formatted = formatExportTableCellText(raw);
+  const lines = formatted.split("\n");
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      td.appendChild(document.createElement("br"));
+    }
+    td.appendChild(document.createTextNode(line));
+  });
 }
 
 /** Resolve root-relative asset paths for offline Word / print. */

--- a/lib/genui/reportExportPrepare.ts
+++ b/lib/genui/reportExportPrepare.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure helpers for GenUI report export (testable without a browser).
+ * DOM orchestration lives in `reportExport.ts`.
+ */
+
+export type GenuiTableExportColumn = {
+  label: string;
+  data: string[];
+};
+
+export type GenuiTableExportPayload = {
+  columns: GenuiTableExportColumn[];
+};
+
+export function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Parse `data-genui-table-export` JSON from the Table component. */
+export function parseTableExportPayload(raw: string | null): GenuiTableExportPayload | null {
+  if (!raw?.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw) as GenuiTableExportPayload;
+    if (!parsed?.columns?.length) return null;
+    const columns = parsed.columns.map((col) => ({
+      label: String(col.label ?? ""),
+      data: Array.isArray(col.data) ? col.data.map((c) => String(c ?? "")) : [],
+    }));
+    return { columns };
+  } catch {
+    return null;
+  }
+}
+
+export function tableExportRowCount(columns: GenuiTableExportColumn[]): number {
+  if (!columns.length) return 0;
+  return Math.max(...columns.map((c) => c.data.length), 0);
+}
+
+/** Plain-text cell for export (strip simple markdown emphasis). */
+export function formatExportTableCellText(cell: string): string {
+  return cell
+    .replace(/\*\*/g, "")
+    .replace(/\r\n/g, "\n")
+    .trim();
+}
+
+export function buildTableBodyRowsHtml(columns: GenuiTableExportColumn[]): string {
+  const rowCount = tableExportRowCount(columns);
+  const rows: string[] = [];
+  for (let ri = 0; ri < rowCount; ri++) {
+    const cells = columns
+      .map((col) => {
+        const text = formatExportTableCellText(col.data[ri] ?? "");
+        return `<td>${escapeHtmlText(text).replace(/\n/g, "<br />")}</td>`;
+      })
+      .join("");
+    rows.push(`<tr>${cells}</tr>`);
+  }
+  return rows.join("");
+}
+
+/** Resolve root-relative asset paths for offline Word / print. */
+export function resolveExportUrl(href: string, origin: string): string {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith("data:") || trimmed.startsWith("blob:")) {
+    return trimmed;
+  }
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith("//")) {
+    const protocol = origin.startsWith("https") ? "https:" : "http:";
+    return `${protocol}${trimmed}`;
+  }
+  if (trimmed.startsWith("/")) {
+    return `${origin.replace(/\/$/, "")}${trimmed}`;
+  }
+  try {
+    return new URL(trimmed, origin.endsWith("/") ? origin : `${origin}/`).href;
+  } catch {
+    return trimmed;
+  }
+}

--- a/lib/llm/genuiPromptBudget.ts
+++ b/lib/llm/genuiPromptBudget.ts
@@ -74,14 +74,26 @@ function trimLeafSourceText(text: string, maxChars: number): string {
   return `${trimmed.slice(0, maxChars)}${TRUNCATION_NOTE}`
 }
 
+function countPipeColumns(text: string): number {
+  const header = text.split("\n").find((l) => /^\|/.test(l.trim()))
+  if (!header) return 0
+  return header.split("|").filter((c) => c.trim().length > 0).length
+}
+
 function leafSourceMaxChars(node: LayoutPlanNode, baseLeafMax: number): number {
   if (node.component !== "Table") return baseLeafMax
   const pipeRows = node.sourceText.split("\n").filter((l) => /^\|/.test(l.trim())).length
-  if (node.hints?.wbsDictionary === "true" || node.hints?.wideTable === "true" || pipeRows >= 10) {
-    return Math.max(baseLeafMax, 8_000, Math.min(14_000, pipeRows * 140))
+  const pipeCols = countPipeColumns(node.sourceText)
+  if (
+    node.hints?.attributeTable === "true" ||
+    node.hints?.wbsDictionary === "true" ||
+    node.hints?.wideTable === "true" ||
+    pipeRows >= 10
+  ) {
+    return Math.max(baseLeafMax, 10_000, Math.min(20_000, pipeRows * 180 + pipeCols * 400))
   }
-  if (pipeRows >= 6) {
-    return Math.max(baseLeafMax, 4_000)
+  if (pipeRows >= 6 || pipeCols >= 6) {
+    return Math.max(baseLeafMax, 6_000, Math.min(14_000, pipeRows * 160))
   }
   return baseLeafMax
 }

--- a/lib/openui/layoutPlan.ts
+++ b/lib/openui/layoutPlan.ts
@@ -88,9 +88,101 @@ export function wantsGenuiFullDocumentLayout(prompt: string): boolean {
   return false
 }
 
+/**
+ * Section-scoped or single-widget render (timeline only, one paragraph, etc.).
+ * Suppresses cover page and table of contents even when source text is a full governance doc.
+ */
+export function wantsGenuiFocusedDetailRender(prompt: string): boolean {
+  if (wantsGenuiFullDocumentLayout(prompt)) return false
+  const p = prompt.trim()
+  if (!p) return false
+
+  if (
+    /\b(no|without|skip|omit|exclude)\s+(a\s+)?(cover(\s+page)?|table\s+of\s+contents|toc)\b/i.test(
+      p
+    )
+  ) {
+    return true
+  }
+
+  const explicitPartial = [
+    /\b(only|just)\s+(the\s+)?(paragraph|timeline|table|section|schedule|milestone)/i,
+    /\brender\s+(only\s+)?(a|an|the)\s+(timeline|table|paragraph|gantt)\b/i,
+    /\b(timeline|paragraph|table)\s+from\b/i,
+    /\bfrom\s+the\s+.+\s+section\s+only\b/i,
+    /\bsingle\s+(detail|component|widget|paragraph)\b/i,
+    /\b(one|a)\s+(paragraph|timeline|table)\s+only\b/i,
+    /\b(single|one)\s+paragraph\b/i,
+    /\b(gantt\s+chart|kanban(?:-style)?\s+board)\b/i,
+    /\b(generate|render|show|create|build)\s+(a\s+)?(gantt|kanban|timeline)\b/i,
+  ]
+  if (explicitPartial.some((re) => re.test(p))) return true
+
+  if (
+    /\b(timeline|roadmap|milestone|schedule)\b/i.test(p) &&
+    /\bfrom\b/i.test(p) &&
+    !/\b(full|entire|whole)\s+document\b/i.test(p)
+  ) {
+    return true
+  }
+
+  /** Follow-up on a prior assistant report: "from this report, show a gantt chart" */
+  if (
+    /\b(from|based\s+on|using)\s+(this\s+)?(report|answer|response|visualization)\b/i.test(p) &&
+    /\b(gantt|kanban|timeline|chart|table|milestone|schedule|activities?|dependencies)\b/i.test(p) &&
+    !/\b(full|entire|whole)\s+document\b/i.test(p) &&
+    !/\b(all\s+chapters?|complete\s+report|cover\s+page)\b/i.test(p)
+  ) {
+    return true
+  }
+
+  if (/\b(gantt|kanban)\b/i.test(p) && !/\b(full|entire|whole)\s+document\b/i.test(p)) {
+    return true
+  }
+
+  return false
+}
+
+function normalizeSectionNeedle(value: string): string {
+  return value.toLowerCase().replace(/\s+/g, " ").trim()
+}
+
+/** When focused, narrow segmentation to the section the user named (e.g. schedule management plan). */
+function filterSegmentsForFocusedPrompt(
+  sectionSegments: TextSegment[],
+  prompt: string
+): TextSegment[] {
+  const quoted = prompt.match(/\bfrom\s+(?:the\s+)?["']([^"']+)["']/i)
+  const sectionMatch = prompt.match(
+    /\bfrom\s+(?:the\s+)?(.+?)\s+(?:section|part|chapter)\b/i
+  )
+  const needleRaw =
+    quoted?.[1]?.trim() ||
+    sectionMatch?.[1]?.trim() ||
+    (/\bschedule\s+management\s+plan\b/i.test(prompt) ? "schedule management plan" : undefined) ||
+    (/\bgantt\b/i.test(prompt) ? "schedule development" : undefined) ||
+    (/\bmilestone\s+schedule\b/i.test(prompt) ? "milestone schedule" : undefined)
+  if (!needleRaw) return sectionSegments
+
+  const needle = normalizeSectionNeedle(needleRaw)
+  const byTitle = sectionSegments.filter((s) => {
+    const title = s.title ? normalizeSectionNeedle(s.title) : ""
+    return title.includes(needle) || needle.includes(title)
+  })
+  if (byTitle.length > 0) return byTitle
+  return sectionSegments
+}
+
 function resolveShellId(prompt: string, primary: ComponentType): LayoutShellId {
   const p = prompt.toLowerCase()
   if (wantsGenuiFullDocumentLayout(prompt)) return "charter"
+  if (
+    wantsGenuiFocusedDetailRender(prompt) &&
+    (/\bgantt\b/i.test(p) ||
+      (/\b(activities?|start|finish|dependencies)\b/i.test(p) && /\b(date|schedule)\b/i.test(p)))
+  ) {
+    return "table"
+  }
   if (p.includes("charter") || p.includes("initiation")) return "charter"
   if (p.includes("status") || p.includes("leadership") || p.includes("progress report")) {
     return "status"
@@ -422,17 +514,25 @@ function classifySegmentBody(
 
   if (isMarkdownTableBlock(trimmed) || isStructuredTabularLines(trimmed)) {
     const pipeRows = trimmed.split("\n").filter((l) => /^\|/.test(l.trim())).length
+    const pipeHeader = trimmed.split("\n").find((l) => /^\|/.test(l.trim())) ?? ""
+    const pipeCols = pipeHeader.split("|").filter((c) => c.trim().length > 0).length
     const wbsLike =
       /\bwbs\s+dictionary\b/i.test(`${title ?? ""}\n${trimmed}`) ||
       (/\blevel\s*1\b/i.test(trimmed) && /\blevel\s*2\b/i.test(trimmed))
+    const attributeLike =
+      /\bactivity\s+attributes\b/i.test(`${title ?? ""}\n${trimmed}`) ||
+      (pipeCols >= 6 && /constraints|deliverable|activity\s+name/i.test(pipeHeader))
     return {
       component: "Table",
       mapping: "widget",
       hints: {
         note: wbsLike
           ? "WBS Dictionary — preserve all hierarchy columns and rows from source (Level 1–4); use Table widget"
-          : "derive columns and rows from source",
+          : attributeLike
+            ? "Activity attributes — preserve every row and full cell text from source; do not truncate cells"
+            : "derive columns and rows from source",
         ...(wbsLike ? { wbsDictionary: "true" } : {}),
+        ...(attributeLike ? { attributeTable: "true" } : {}),
         ...(pipeRows >= 8 ? { wideTable: "true", rowCount: String(pipeRows) } : {}),
       },
     }
@@ -1031,10 +1131,14 @@ function buildShellNodes(
   segments: TextSegment[],
   prompt: string,
   documentId?: string,
-  coverSummaryOverride?: string
+  coverSummaryOverride?: string,
+  focusedDetail = false
 ): LayoutPlanNode[] {
   const preambleSeg = segments.find((s) => s.id === "preamble")
-  const sectionSegments = segments.filter((s) => s.id !== "preamble")
+  let sectionSegments = segments.filter((s) => s.id !== "preamble")
+  if (focusedDetail) {
+    sectionSegments = filterSegmentsForFocusedPrompt(sectionSegments, prompt)
+  }
   const docTitle = documentTitleFromSegments(sectionSegments)
   const hierarchical = usesHierarchicalChapters(sectionSegments)
   const chapters = hierarchical ? groupSegmentsIntoChapters(sectionSegments) : []
@@ -1043,7 +1147,8 @@ function buildShellNodes(
     sectionSegments.find((s) => pred(s) && !isHeadingOnlySegment(s))
 
   const summarySource = extractDocumentSummary(segments, sectionSegments, chapters, prompt)
-  const useCover = shouldIncludeDocumentCover(sectionSegments, segments, chapters)
+  const useCover =
+    !focusedDetail && shouldIncludeDocumentCover(sectionSegments, segments, chapters)
   const { title: coverTitle, subtitle: coverSubtitle } = extractCoverTitleAndSubtitle(
     preambleSeg?.body,
     docTitle
@@ -1099,11 +1204,12 @@ function buildShellNodes(
   }
 
   const frontCard = coverCard ?? introCard
+  const withFront = (nodes: LayoutPlanNode[]) =>
+    focusedDetail ? nodes : [frontCard, ...nodes]
 
   if (sectionSegments.length === 0) {
     const single = classifySegmentBody(prompt)
-    return [
-      frontCard,
+    return withFront([
       {
         id: "answer-primary",
         component: single.component,
@@ -1112,23 +1218,23 @@ function buildShellNodes(
         fallbackReason: single.fallbackReason,
         hints: single.hints,
       },
-    ]
+    ])
   }
 
   const preferHierarchicalReport =
-    wantsGenuiFullDocumentLayout(prompt) ||
-    (hierarchical && chapters.length >= 2)
+    !focusedDetail &&
+    (wantsGenuiFullDocumentLayout(prompt) ||
+      (hierarchical && chapters.length >= 2))
 
   if (!preferHierarchicalReport && (shell === "risk" || shell === "table")) {
     const tableSeg = sectionSegments.find(
       (s) => classifySegmentBody(s.body, s.title).component === "Table"
     )
     if (tableSeg) {
-      return [frontCard, buildNodeFromSegment(tableSeg)]
+      return withFront([buildNodeFromSegment(tableSeg)])
     }
     const merged = sectionSegments.map((s) => s.body).join("\n\n").slice(0, 12_000)
-    return [
-      frontCard,
+    return withFront([
       {
         id: "primary-table",
         component: "Table",
@@ -1136,24 +1242,22 @@ function buildShellNodes(
         sourceText: merged,
         hints: { note: "risk or register columns from context" },
       },
-    ]
+    ])
   }
 
   if (shell === "timeline") {
     const tl = sectionSegments.find(
       (s) => classifySegmentBody(s.body, s.title).component === "Timeline"
     )
-    return [
-      frontCard,
-      tl
-        ? buildNodeFromSegment(tl)
-        : {
-            id: "primary-timeline",
-            component: "Timeline",
-            mapping: "widget",
-            sourceText: sectionSegments.map((s) => s.body).join("\n").slice(0, 12_000),
-          },
-    ]
+    const timelineNode = tl
+      ? buildNodeFromSegment(tl)
+      : {
+          id: "primary-timeline",
+          component: "Timeline" as const,
+          mapping: "widget" as const,
+          sourceText: sectionSegments.map((s) => s.body).join("\n").slice(0, 12_000),
+        }
+    return withFront([timelineNode])
   }
 
   if (hierarchical && chapters.length > 0) {
@@ -1197,10 +1301,10 @@ function buildShellNodes(
   }
 
   if (flatSections.length >= 1) {
-    return [frontCard, ...flatSections.map((seg) => buildSectionCardNode(seg, prompt))]
+    return withFront(flatSections.map((seg) => buildSectionCardNode(seg, prompt)))
   }
 
-  return [frontCard, ...sectionSegments.map(buildNodeFromSegment)]
+  return withFront(sectionSegments.map(buildNodeFromSegment))
 }
 
 function planConfidence(shell: LayoutShellId, segments: TextSegment[], nodes: LayoutPlanNode[]): number {
@@ -1220,10 +1324,18 @@ function planConfidence(shell: LayoutShellId, segments: TextSegment[], nodes: La
 export function buildLayoutPlan(input: BuildLayoutPlanInput): LayoutPlan {
   const prompt = input.prompt.trim()
   const sourceText = (input.sourceText ?? "").trim()
+  const focusedDetail = wantsGenuiFocusedDetailRender(prompt)
   const primary = selectComponentType({ prompt })
   const shell = resolveShellId(prompt, primary)
   const segments = sourceText ? segmentSourceText(sourceText) : []
-  const nodes = buildShellNodes(shell, segments, prompt, input.documentId, input.coverSummary)
+  const nodes = buildShellNodes(
+    shell,
+    segments,
+    prompt,
+    input.documentId,
+    input.coverSummary,
+    focusedDetail
+  )
   const totalChars = nodes.reduce((sum, n) => sum + n.sourceText.length, 0)
 
   return {
@@ -1231,6 +1343,7 @@ export function buildLayoutPlan(input: BuildLayoutPlanInput): LayoutPlan {
     root: "Stack",
     intentPrimary: toGenUIComponentName(primary),
     confidence: planConfidence(shell, segments, nodes),
+    focusedDetail,
     nodes,
     sourceCoverage: {
       segmentCount: segments.length || 1,
@@ -1298,19 +1411,40 @@ export function formatLayoutPlanForExecutor(
   options?: { reportDarkTheme?: boolean }
 ): string {
   const cappedPlan = compactLayoutPlanForExecutor(plan)
+  const focused = cappedPlan.focusedDetail === true
+  const hasCover = collectAllPlanNodes(cappedPlan.nodes).some((n) => n.id === "doc-cover")
   const shellHints: Record<LayoutShellId, string> = {
     charter:
       "root = Stack([TableOfContents?, intro Card, one Card per major chapter; ### subsections nested inside chapter Card])",
     status: "root = Stack([intro Card, section Cards, Bullets or Table for blockers])",
     risk: "root = Stack([intro Card, Table or section Cards per risk area])",
-    timeline: "root = Stack([intro Card, Timeline or section Cards])",
+    timeline: focused
+      ? "root = Stack([Timeline]) — no cover Card, no TableOfContents"
+      : "root = Stack([intro Card, Timeline or section Cards])",
     team: "root = Stack([intro Card, Team or section Cards])",
     comparison: "root = Stack([intro Card, Comparison])",
-    table: "root = Stack([intro Card, Table])",
+    table: focused
+      ? "root = Stack([Table]) — no cover Card, no TableOfContents"
+      : "root = Stack([intro Card, Table])",
     dashboard: "root = Stack([intro Card, section Cards or Tabs])",
-    generic:
-      "root = Stack([intro Card, one Card per document section — not Accordion unless user asked])",
+    generic: focused
+      ? "root = Stack([requested section Card or widget only]) — no cover Card, no TableOfContents"
+      : "root = Stack([intro Card, one Card per document section — not Accordion unless user asked])",
   }
+
+  const coverRules = hasCover
+    ? [
+        "- When node id doc-cover is present: root Stack MUST start with cover Card (ReportCoverHero with exact imageUrl from cover-hero hints, then CardHeader, then TextContent cover blurb) before TableOfContents and chapter Cards.",
+        "- Node cover-summary is a SHORT cover teaser (see hints.maxChars). Do NOT paste the full executive summary from chapter 1; preserve cover sourceText only (may tighten wording, not expand).",
+      ]
+    : []
+
+  const focusedRules = focused
+    ? [
+        "- FOCUSED DETAIL MODE: Do NOT add ReportCoverHero, cover Card, intro Card, or TableOfContents unless a matching node id appears in NODES below.",
+        "- root Stack MUST contain ONLY the components listed in NODES, in the same order — no extra Cards.",
+      ]
+    : []
 
   return [
     "=== REQUIRED LAYOUT PLAN (strict — do not change structure) ===",
@@ -1318,6 +1452,7 @@ export function formatLayoutPlanForExecutor(
     `root: ${cappedPlan.root}`,
     `intentPrimary: ${cappedPlan.intentPrimary}`,
     `confidence: ${cappedPlan.confidence.toFixed(2)}`,
+    ...(focused ? ["focusedDetail: true"] : []),
     `suggestedRootPattern: ${shellHints[cappedPlan.shell]}`,
     "",
     "EXECUTOR RULES:",
@@ -1326,8 +1461,8 @@ export function formatLayoutPlanForExecutor(
     "- Put facts from each node's sourceText into that component's props (rows, items, milestones, etc.).",
     "- Nodes with mapping typography-fallback MUST use TextContent (or Callout if warning) with the full sourceText preserved.",
     "- Never use root = Bullets(...) or root = TextContent(...) alone.",
-    "- When node id doc-cover is present: root Stack MUST start with cover Card (ReportCoverHero with exact imageUrl from cover-hero hints, then CardHeader, then TextContent cover blurb) before TableOfContents and chapter Cards.",
-    "- Node cover-summary is a SHORT cover teaser (see hints.maxChars). Do NOT paste the full executive summary from chapter 1; preserve cover sourceText only (may tighten wording, not expand).",
+    ...focusedRules,
+    ...coverRules,
     "- CardHeader must stay inside Card. One top-level Card per major chapter (H1 or numbered ## like \"1. Executive Summary\").",
     "- Every node with component CardHeader MUST appear as CardHeader(\"<label>\") or CardHeader(\"<label>\", \"<subtitle>\") — positional strings only (no title= named syntax).",
     "- CardHeader accepts at most two positional args. Never three args. Never CardHeader(\"title\", \"default\", ...) — \"default\" is TextContent size, not CardHeader.",
@@ -1339,6 +1474,7 @@ export function formatLayoutPlanForExecutor(
     "- Subsections with multiple blocks (Stack children in plan): render every child in order — intro prose, then Table, then trailing prose (e.g. Justification for Hybrid Approach).",
     "- Do not emit TextContent(\"---\") or other horizontal-rule placeholders; markdown --- lines are omitted from plan prose — end the subsection after the last real paragraph or table.",
     "- WBS Dictionary and wide markdown tables: use Table with all pipe rows from sourceText; hints.wbsDictionary means preserve Level 1–4 columns.",
+    "- hints.attributeTable or hints.wideTable: include every row and full cell text from sourceText — never emit \"[Truncated]\" or \"[Truncated for API limits\" in Table cells.",
     "- Apply TwoColumnProse for chapter lead paragraphs and long subsection intros (e.g. Executive Summary, §1.1 Overview) when the plan component is TwoColumnProse.",
     "- Use Accordion only when the user prompt explicitly requests accordion/collapsible/FAQ AND Bullets is not a better fit.",
     "- Do not invent metrics, dates, or names not supported by source text.",

--- a/lib/openui/layoutPlanTypes.ts
+++ b/lib/openui/layoutPlanTypes.ts
@@ -59,6 +59,8 @@ export type LayoutPlan = {
   intentPrimary: string
   confidence: number
   nodes: LayoutPlanNode[]
+  /** Single-widget / section-scoped render — no cover page or table of contents */
+  focusedDetail?: boolean
   /** All source characters that must appear in the final Lang output */
   sourceCoverage: { segmentCount: number; totalChars: number }
 }

--- a/lib/openui/markdownComponentOverrides.tsx
+++ b/lib/openui/markdownComponentOverrides.tsx
@@ -115,8 +115,24 @@ export const TableDef = defineComponent({
     const startRow = safePage * DEFAULT_PAGE_SIZE
     const visibleRowCount = Math.min(startRow + DEFAULT_PAGE_SIZE, rowCount) - startRow
 
+    const exportPayload = {
+      columns: colDefs.map((c) => ({
+        label: c.label,
+        data: c.data.map((cell) =>
+          typeof cell === "string" || typeof cell === "number"
+            ? String(cell)
+            : cell == null
+              ? ""
+              : String(cell)
+        ),
+      })),
+    }
+
     return (
-      <div>
+      <div
+        data-genui-table-export={JSON.stringify(exportPayload)}
+        className="genui-export-table-host"
+      >
         <ScrollableTable>
           <TableHeader>
             <TableRow>


### PR DESCRIPTION
## Summary

- **GenUI report surface:** toolbar (`Render document` / `+ New Report`), export bar (PDF, Word, HTML, plain text), report-surface context, prompt bridge.
- **Fixes:** plain-text export uses `getLatestGenuiReportRenderElement()` (toolbar sibling no longer breaks `:last-of-type`); double submit on Render document resolved in `GenuiPromptBridge`.
- **Layout:** focused follow-ups from prior report, layout plan tests, assistant message / workspace CSS updates.
- **Docs:** Step 3 presentations design reserve; updated GenUI skill and codedoc; **lessons learned** for kickoff vocabulary (`engine` vs observable deliverables) and DRACO alignment.
- **Env:** `.env.local.example` notes Mistral GenUI provider and Step 3 publish flag (not implemented).

## Test plan

- [x] `npx jest --testPathPatterns=genuiReportExport|genuiPresentationSnapshot|layoutPlan --no-coverage` (49 tests)
- [ ] Manual: GenUI workspace — render report, export plain text, single `/api/chat` on Render document
- [ ] Confirm `GENUI_LLM_PROVIDER=mistral` in `.env.local` if avoiding Gemini 429s

## Lessons learned doc

`docs/implementation/LESSONS_LEARNED_OPENUI_GENUI_KICKOFF.md` — copy-paste ready for ACT-CLS-001 / next charter.