### PR TITLE
feat(mongodb): complete vector store integration (APIs, sync, RAG)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -87,9 +87,15 @@ TAVILY_API_KEY=your-tavily-api-key
 # ==============================================
 # NoSQL & Vector Databases
 # ==============================================
-# MongoDB (RAG)
+# MongoDB optional vector store for RAG chunks (canonical docs stay in SQL)
 MONGODB_URI=mongodb+srv://[USER]:[PASSWORD]@[CLUSTER].mongodb.net/
 MONGODB_DB_NAME=adpa_rag
+# Atlas Vector Search index name on the chunks collection (default: vector_search_index)
+MONGODB_VECTOR_INDEX=vector_search_index
+# Embedding pipeline: atlas = Atlas DB trigger fills embeddings after insert; server = Voyage during sync
+MONGODB_EMBEDDING_MODE=atlas
+# When true, /api/rag/query and assisted document search prefer MongoDB vector search (falls back to pgvector)
+MONGODB_RAG_ENABLED=false
 
 # Pinecone (Vector DB)
 PINECONE_API_KEY=your-pinecone-api-key

--- a/server/src/__tests__/services/mongoChunkSchema.test.ts
+++ b/server/src/__tests__/services/mongoChunkSchema.test.ts
@@ -1,0 +1,30 @@
+import { buildMongoChunkDocument, mongoProjectFilter } from '../../lib/mongoChunkSchema';
+
+describe('mongoChunkSchema', () => {
+  it('buildMongoChunkDocument includes camelCase and snake_case fields', () => {
+    const doc = buildMongoChunkDocument(
+      {
+        documentId: 'doc-1',
+        content: 'hello world',
+        embedding: [0.1, 0.2],
+        projectId: 'proj-1',
+        metadata: { chunkIndex: 2, section: 'intro' },
+        chunkIndex: 2,
+      },
+      'chunk-1'
+    );
+
+    expect(doc.id).toBe('chunk-1');
+    expect(doc.documentId).toBe('doc-1');
+    expect(doc.document_id).toBe('doc-1');
+    expect(doc.project_id).toBe('proj-1');
+    expect(doc.metadata.projectId).toBe('proj-1');
+    expect(doc.chunk_index).toBe(2);
+  });
+
+  it('mongoProjectFilter matches both project_id and metadata.projectId', () => {
+    expect(mongoProjectFilter('proj-1')).toEqual({
+      $or: [{ project_id: 'proj-1' }, { 'metadata.projectId': 'proj-1' }],
+    });
+  });
+});

--- a/server/src/__tests__/services/mongoQuerySafety.test.ts
+++ b/server/src/__tests__/services/mongoQuerySafety.test.ts
@@ -1,0 +1,27 @@
+import { toMongoEqualityId, toMongoIndexName } from '../../lib/mongoQuerySafety';
+
+describe('mongoQuerySafety', () => {
+    describe('toMongoEqualityId', () => {
+        it('accepts UUID document ids', () => {
+            const id = '550e8400-e29b-41d4-a716-446655440000';
+            expect(toMongoEqualityId(id)).toBe(id);
+        });
+
+        it('rejects operator injection payloads', () => {
+            expect(() => toMongoEqualityId({ $gt: '' } as unknown as string)).toThrow();
+            expect(() => toMongoEqualityId('{"$gt":""}')).toThrow();
+            expect(() => toMongoEqualityId('id.with.dot')).toThrow();
+        });
+    });
+
+    describe('toMongoIndexName', () => {
+        it('accepts default vector index name', () => {
+            expect(toMongoIndexName('vector_search_index')).toBe('vector_search_index');
+        });
+
+        it('rejects invalid index names', () => {
+            expect(() => toMongoIndexName('bad index')).toThrow();
+            expect(() => toMongoIndexName('index$name')).toThrow();
+        });
+    });
+});

--- a/server/src/__tests__/services/mongoQuerySafety.test.ts
+++ b/server/src/__tests__/services/mongoQuerySafety.test.ts
@@ -1,4 +1,10 @@
-import { toMongoEqualityId, toMongoIndexName } from '../../lib/mongoQuerySafety';
+import {
+    ragChunkByDocumentIdFilter,
+    ragDocumentIdFilter,
+    ragDocumentIdReplaceFilter,
+    toMongoEqualityId,
+    toMongoIndexName,
+} from '../../lib/mongoQuerySafety';
 
 describe('mongoQuerySafety', () => {
     describe('toMongoEqualityId', () => {
@@ -11,6 +17,32 @@ describe('mongoQuerySafety', () => {
             expect(() => toMongoEqualityId({ $gt: '' } as unknown as string)).toThrow();
             expect(() => toMongoEqualityId('{"$gt":""}')).toThrow();
             expect(() => toMongoEqualityId('id.with.dot')).toThrow();
+        });
+    });
+
+    describe('ragDocumentIdFilter', () => {
+        it('uses $eq for document id lookups', () => {
+            const id = '550e8400-e29b-41d4-a716-446655440000';
+            expect(ragDocumentIdFilter(id)).toEqual({ id: { $eq: id } });
+        });
+    });
+
+    describe('ragDocumentIdReplaceFilter', () => {
+        it('returns filter and id for replaceOne', () => {
+            const id = '550e8400-e29b-41d4-a716-446655440000';
+            expect(ragDocumentIdReplaceFilter(id)).toEqual({
+                filter: { id: { $eq: id } },
+                id,
+            });
+        });
+    });
+
+    describe('ragChunkByDocumentIdFilter', () => {
+        it('uses $eq on both document id fields', () => {
+            const id = '550e8400-e29b-41d4-a716-446655440000';
+            expect(ragChunkByDocumentIdFilter(id)).toEqual({
+                $or: [{ documentId: { $eq: id } }, { document_id: { $eq: id } }],
+            });
         });
     });
 

--- a/server/src/__tests__/services/mongoRagService.test.ts
+++ b/server/src/__tests__/services/mongoRagService.test.ts
@@ -1,0 +1,30 @@
+describe('mongoRagService', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('isMongoRagEnabled is false unless explicitly enabled with credentials', async () => {
+    delete process.env.MONGODB_RAG_ENABLED;
+    process.env.MONGODB_URI = 'mongodb://localhost:27017';
+    process.env.VOYAGE_API_KEY = 'test-key';
+
+    const { isMongoRagEnabled } = await import('../../services/mongoRagService');
+    expect(isMongoRagEnabled()).toBe(false);
+  });
+
+  it('isMongoRagEnabled is true when flag and credentials are set', async () => {
+    process.env.MONGODB_RAG_ENABLED = 'true';
+    process.env.MONGODB_URI = 'mongodb://localhost:27017';
+    process.env.VOYAGE_API_KEY = 'test-key';
+
+    const { isMongoRagEnabled } = await import('../../services/mongoRagService');
+    expect(isMongoRagEnabled()).toBe(true);
+  });
+});

--- a/server/src/__tests__/services/mongoVectorStore.connect.test.ts
+++ b/server/src/__tests__/services/mongoVectorStore.connect.test.ts
@@ -1,0 +1,42 @@
+describe('MongoVectorStore.connect', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      MONGODB_URI: 'mongodb://localhost:27017',
+      MONGODB_DB_NAME: 'test_rag',
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('deduplicates concurrent connect into a single performConnect', async () => {
+    const { MongoVectorStore } = await import('../../services/mongoVectorStore');
+    const store = new MongoVectorStore();
+
+    const performConnect = jest
+      .spyOn(store as unknown as { performConnect: () => Promise<void> }, 'performConnect')
+      .mockImplementation(async function (this: InstanceType<typeof MongoVectorStore>) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        (store as unknown as { isConnected: boolean }).isConnected = true;
+        (store as unknown as { client: object }).client = {};
+        (store as unknown as { _db: object })._db = {
+          collection: () => ({
+            countDocuments: jest.fn().mockResolvedValue(0),
+            listSearchIndexes: () => ({ toArray: jest.fn().mockResolvedValue([]) }),
+          }),
+        };
+      });
+
+    await Promise.all([store.connect(), store.connect(), store.connect()]);
+
+    expect(performConnect).toHaveBeenCalledTimes(1);
+    expect(store.isConnectionReady()).toBe(true);
+
+    performConnect.mockRestore();
+  });
+});

--- a/server/src/lib/mongoChunkSchema.ts
+++ b/server/src/lib/mongoChunkSchema.ts
@@ -1,0 +1,63 @@
+import type { DocumentChunk } from '../types/rag';
+
+export type MongoChunkWriteInput = {
+  documentId: string;
+  content: string;
+  embedding: number[];
+  projectId?: string | null;
+  metadata?: Record<string, unknown>;
+  chunkIndex?: number;
+};
+
+/**
+ * Canonical MongoDB chunk shape used by sync, Atlas triggers, and Pinecone re-export.
+ * Includes snake_case aliases for cross-pipeline compatibility.
+ */
+export function buildMongoChunkDocument(
+  input: MongoChunkWriteInput,
+  id: string,
+  createdAt: Date = new Date()
+): DocumentChunk & {
+  document_id: string;
+  project_id: string | null;
+  chunk_index: number;
+} {
+  const chunkIndex =
+    typeof input.chunkIndex === 'number'
+      ? input.chunkIndex
+      : typeof input.metadata?.chunkIndex === 'number'
+        ? (input.metadata.chunkIndex as number)
+        : 0;
+
+  const projectId = input.projectId ?? (input.metadata?.projectId as string | undefined) ?? null;
+
+  const metadata = {
+    chunkIndex,
+    startPosition: (input.metadata?.startPosition as number) ?? 0,
+    endPosition: (input.metadata?.endPosition as number) ?? input.content.length,
+    tokenCount: (input.metadata?.tokenCount as number) ?? 0,
+    ...(input.metadata ?? {}),
+    projectId,
+  };
+
+  return {
+    id,
+    documentId: input.documentId,
+    document_id: input.documentId,
+    content: input.content,
+    embedding: input.embedding,
+    project_id: projectId,
+    chunk_index: chunkIndex,
+    metadata,
+    createdAt,
+  };
+}
+
+export function mongoProjectFilter(projectId: string): Record<string, unknown> {
+  return {
+    $or: [
+      { project_id: projectId },
+      { 'metadata.projectId': projectId },
+    ],
+  };
+}

--- a/server/src/lib/mongoQuerySafety.ts
+++ b/server/src/lib/mongoQuerySafety.ts
@@ -1,4 +1,5 @@
-/** UUID v4 (and common v1-style) for RAG entity primary keys. */
+import type { Collection, Document, Filter, WithId } from 'mongodb';
+
 const UUID_PATTERN =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -29,6 +30,37 @@ export function toMongoEqualityId(value: unknown, label = 'id'): string {
     }
 
     return trimmed;
+}
+
+/** Equality filter for RAG `documents.id` — uses `$eq` so SAST treats input as a literal. */
+export function ragDocumentIdFilter(value: unknown): { id: { $eq: string } } {
+    return { id: { $eq: toMongoEqualityId(value, 'documentId') } };
+}
+
+/** Chunk lookup by document id (camelCase or snake_case field). */
+export function ragChunkByDocumentIdFilter(value: unknown): {
+    $or: [{ documentId: { $eq: string } }, { document_id: { $eq: string } }];
+} {
+    const safe = toMongoEqualityId(value, 'documentId');
+    return {
+        $or: [{ documentId: { $eq: safe } }, { document_id: { $eq: safe } }],
+    };
+}
+
+/** findOne with validated `$eq` filter — keeps NoSQL-safe queries in one module for SAST. */
+export async function findOneByRagDocumentId<T extends Document>(
+    collection: Collection<T>,
+    documentId: unknown
+): Promise<WithId<T> | null> {
+    return collection.findOne(ragDocumentIdFilter(documentId) as Filter<T>);
+}
+
+/** replaceOne filter with validated `$eq` document id. */
+export function ragDocumentIdReplaceFilter(
+    documentId: unknown
+): { filter: { id: { $eq: string } }; id: string } {
+    const filter = ragDocumentIdFilter(documentId);
+    return { filter, id: filter.id.$eq };
 }
 
 /** Atlas search index names from config — literal string only. */

--- a/server/src/lib/mongoQuerySafety.ts
+++ b/server/src/lib/mongoQuerySafety.ts
@@ -1,0 +1,46 @@
+/** UUID v4 (and common v1-style) for RAG entity primary keys. */
+const UUID_PATTERN =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Alphanumeric ids (e.g. crypto.randomUUID() output without hyphens is not matched — use UUID). */
+const LITERAL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+const INDEX_NAME_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/**
+ * Coerce a value to a safe MongoDB equality filter string (prevents operator injection).
+ */
+export function toMongoEqualityId(value: unknown, label = 'id'): string {
+    if (typeof value !== 'string') {
+        throw new Error(`Invalid ${label}: must be a string`);
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed || trimmed.length > 128) {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    if (trimmed.includes('$') || trimmed.includes('.') || trimmed.includes('\0')) {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    if (!UUID_PATTERN.test(trimmed) && !LITERAL_ID_PATTERN.test(trimmed)) {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return trimmed;
+}
+
+/** Atlas search index names from config — literal string only. */
+export function toMongoIndexName(value: unknown, label = 'indexName'): string {
+    if (typeof value !== 'string') {
+        throw new Error(`Invalid ${label}: must be a string`);
+    }
+
+    const trimmed = value.trim();
+    if (!INDEX_NAME_PATTERN.test(trimmed)) {
+        throw new Error(`Invalid ${label}`);
+    }
+
+    return trimmed;
+}

--- a/server/src/routes/mongodbIntegrationRoutes.ts
+++ b/server/src/routes/mongodbIntegrationRoutes.ts
@@ -51,7 +51,6 @@ async function handleStats(_req: Request, res: Response) {
             });
         }
 
-        await mongoVectorStore.connect();
         const stats = await mongoVectorStore.getStats();
         return res.json(stats);
     } catch (error) {

--- a/server/src/routes/mongodbIntegrationRoutes.ts
+++ b/server/src/routes/mongodbIntegrationRoutes.ts
@@ -1,0 +1,257 @@
+import express, { Request, Response } from 'express';
+import Joi from 'joi';
+import { pool } from '../database/connection';
+import { authenticateToken, requirePermission } from '../middleware/auth';
+import { validate } from '../middleware/validation';
+import { childLogger } from '../utils/logger';
+import { mongoVectorStore } from '../services/mongoVectorStore';
+import {
+    mongoDBSyncService,
+    persistMongoSyncProgress,
+    readMongoSyncProgress,
+} from '../services/mongoDBSyncService';
+import { searchMongoChunks } from '../services/mongoRagService';
+
+const router = express.Router();
+const log = childLogger({ component: 'mongodbIntegrationRoutes' });
+
+const searchSchema = Joi.object({
+    query: Joi.string().min(2).max(2000).required(),
+    topK: Joi.number().integer().min(1).max(50).default(5),
+    projectId: Joi.string().uuid().optional(),
+});
+
+const syncSchema = Joi.object({
+    projectId: Joi.string().uuid().allow(null).optional(),
+    limit: Joi.number().integer().min(1).max(5000).optional(),
+});
+
+async function getIntegrationType(integrationId: string): Promise<string | null> {
+    const result = await pool.query(
+        `SELECT type FROM integrations WHERE id = $1`,
+        [integrationId]
+    );
+    if (result.rows.length === 0) {
+        return null;
+    }
+    return result.rows[0].type as string;
+}
+
+async function handleStats(_req: Request, res: Response) {
+    try {
+        if (!mongoVectorStore.isMongoConfigured()) {
+            return res.json({
+                documents: 0,
+                chunks: 0,
+                embeddedChunks: 0,
+                embeddingPercentage: 0,
+                indexStatus: 'not_configured',
+                database: process.env.MONGODB_DB_NAME || 'adpa_rag',
+                configured: false,
+            });
+        }
+
+        await mongoVectorStore.connect();
+        const stats = await mongoVectorStore.getStats();
+        return res.json(stats);
+    } catch (error) {
+        log.error('MongoDB stats failed', error);
+        return res.status(503).json({
+            error: 'MongoDB unavailable',
+            message: (error as Error).message,
+        });
+    }
+}
+
+router.get(
+    '/mongodb/stats',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    handleStats
+);
+
+router.get(
+    '/:integrationId/mongodb/stats',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    handleStats
+);
+
+router.get(
+    '/:integrationId/pinecone/stats',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    async (_req: Request, res: Response) => {
+        try {
+            const { pineconeService } = await import('../services/pineconeService');
+            const stats = await pineconeService.getIndexStats();
+            if (!stats) {
+                return res.status(503).json({ error: 'Pinecone unavailable' });
+            }
+            return res.json(stats);
+        } catch (error) {
+            log.error('Pinecone stats failed', error);
+            return res.status(503).json({
+                error: 'Pinecone unavailable',
+                message: (error as Error).message,
+            });
+        }
+    }
+);
+
+router.post(
+    '/mongodb/search',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    validate(searchSchema),
+    async (req: Request, res: Response) => {
+        try {
+            const { query, topK, projectId } = req.body;
+            const matches = await searchMongoChunks(query, topK, projectId);
+            return res.json({ success: true, matches });
+        } catch (error) {
+            log.error('MongoDB search failed', error);
+            return res.status(503).json({
+                success: false,
+                message: (error as Error).message,
+            });
+        }
+    }
+);
+
+router.post(
+    '/:integrationId/mongodb/search',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    validate(searchSchema),
+    async (req: Request, res: Response) => {
+        try {
+            const { query, topK, projectId } = req.body;
+            const matches = await searchMongoChunks(query, topK, projectId);
+            return res.json({ success: true, matches });
+        } catch (error) {
+            log.error('MongoDB search failed', error);
+            return res.status(503).json({
+                success: false,
+                message: (error as Error).message,
+            });
+        }
+    }
+);
+
+router.post(
+    '/:integrationId/sync',
+    authenticateToken,
+    requirePermission('integrations.sync'),
+    validate(syncSchema),
+    async (req: Request, res: Response) => {
+        const { integrationId } = req.params;
+
+        try {
+            const integrationType = await getIntegrationType(integrationId);
+            if (!integrationType) {
+                return res.status(404).json({ success: false, message: 'Integration not found' });
+            }
+
+            const projectId =
+                req.body.projectId === undefined || req.body.projectId === 'all'
+                    ? null
+                    : req.body.projectId;
+            const limit = req.body.limit as number | undefined;
+
+            if (integrationType === 'pinecone') {
+                const { pineconeService } = await import('../services/pineconeService');
+                void (async () => {
+                    try {
+                        await pool.query(
+                            `UPDATE integrations SET sync_status = 'syncing', updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+                            [integrationId]
+                        );
+                        await pineconeService.syncAll(projectId ?? undefined);
+                        await pool.query(
+                            `UPDATE integrations SET sync_status = 'completed', last_sync = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+                            [integrationId]
+                        );
+                    } catch (err) {
+                        log.error('Background Pinecone sync failed', err);
+                        await pool.query(
+                            `UPDATE integrations SET sync_status = 'failed', updated_at = CURRENT_TIMESTAMP WHERE id = $1`,
+                            [integrationId]
+                        );
+                    }
+                })();
+                return res.json({ success: true, message: 'Pinecone sync started' });
+            }
+
+            if (integrationType !== 'mongodb') {
+                return res.status(400).json({
+                    success: false,
+                    message: `Sync not supported for integration type: ${integrationType}`,
+                });
+            }
+
+            await persistMongoSyncProgress(integrationId, {
+                total: 0,
+                synced: 0,
+                skipped: 0,
+                errors: 0,
+                status: 'syncing',
+            });
+
+            void (async () => {
+                try {
+                    await mongoDBSyncService.syncProjectDocuments(projectId, limit, async (progress) => {
+                        await persistMongoSyncProgress(integrationId, progress);
+                    });
+                } catch (err) {
+                    log.error('Background MongoDB sync failed', err);
+                    await persistMongoSyncProgress(integrationId, {
+                        total: 0,
+                        synced: 0,
+                        skipped: 0,
+                        errors: 1,
+                        status: 'error',
+                    });
+                }
+            })();
+
+            return res.json({ success: true, message: 'MongoDB sync started' });
+        } catch (error) {
+            log.error('Failed to start vector sync', error);
+            return res.status(500).json({
+                success: false,
+                message: (error as Error).message,
+            });
+        }
+    }
+);
+
+router.get(
+    '/:integrationId/sync/status',
+    authenticateToken,
+    requirePermission('integrations.read'),
+    async (req: Request, res: Response) => {
+        try {
+            const { integrationId } = req.params;
+            const progress = await readMongoSyncProgress(integrationId);
+            if (!progress) {
+                return res.json({
+                    total: 0,
+                    synced: 0,
+                    skipped: 0,
+                    errors: 0,
+                    status: 'idle',
+                });
+            }
+            return res.json(progress);
+        } catch (error) {
+            log.error('Failed to read MongoDB sync status', error);
+            return res.status(500).json({
+                error: 'Failed to read sync status',
+                message: (error as Error).message,
+            });
+        }
+    }
+);
+
+export default router;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -81,6 +81,7 @@ import executionModuleRoutes from "./modules/execution/routes"
 import templatesModuleRoutes from "./modules/templates/routes"
 import intelligenceModuleRoutes from "./modules/intelligence/routes"
 import integrationsModuleRoutes from "./modules/integrations/routes"
+import mongodbIntegrationRoutes from "./routes/mongodbIntegrationRoutes"
 import adobePdfRoutes from "./routes/adobe-pdf"
 import { createDocumentFormatRoutes } from "./routes/document-formats"
 import contextAiRoutes from "./routes/context-ai"
@@ -281,6 +282,7 @@ if (portfolioModuleRoutes && portfolioModuleRoutes[0]) {
 }
 if (templatesModuleRoutes && templatesModuleRoutes[0]) app.use("/api/templates", templatesModuleRoutes[0].router)
 if (intelligenceModuleRoutes && intelligenceModuleRoutes[0]) app.use("/api/analytics", intelligenceModuleRoutes[0].router)
+app.use("/api/integrations", mongodbIntegrationRoutes)
 if (integrationsModuleRoutes && integrationsModuleRoutes[0]) app.use("/api/integrations", integrationsModuleRoutes[0].router)
 if (documentModuleRoutes && documentModuleRoutes[0]) app.use("/api/documents", documentModuleRoutes[0].router)
 if (analysisModuleRoutes && analysisModuleRoutes[0]) {

--- a/server/src/services/mongoDBSyncService.ts
+++ b/server/src/services/mongoDBSyncService.ts
@@ -1,10 +1,11 @@
 
 import { getDatabasePool } from '../database/connection';
+import { pool } from '../database/connection';
 import { logger } from '../utils/logger';
 import { documentProcessor } from './documentProcessor';
 import { mongoDBEmbeddingService } from './mongoDBEmbeddings';
 import { mongoVectorStore } from './mongoVectorStore';
-import { v4 as uuidv4 } from 'uuid';
+import type { MongoChunkWriteInput } from '../lib/mongoChunkSchema';
 
 export interface SyncResult {
     success: boolean;
@@ -16,12 +17,6 @@ export interface SyncResult {
     };
 }
 
-// Rate limiting configuration
-// VoyageAI Free Tier: 3 requests per minute
-// We'll be conservative and wait 21 seconds between requests
-const RATE_LIMIT_DELAY_MS = 21000;
-const BATCH_SIZE = 128; // Standard Voyage batch size limit (check docs, but 128 is reasonable)
-
 export interface SyncProgress {
     total: number;
     synced: number;
@@ -31,69 +26,122 @@ export interface SyncProgress {
     status: 'syncing' | 'completed' | 'error';
 }
 
-export class MongoDBSyncService {
+const RATE_LIMIT_DELAY_MS = 21000;
+const INSERT_BATCH_SIZE = 500;
+const EMBEDDING_BATCH_SIZE = 32;
 
-    /**
-     * Syncs all eligible documents for a project (or all projects) from Postgres to MongoDB Vector Store.
-     * Enforces strict rate limiting to avoid 429 errors from VoyageAI.
-     */
+function getEmbeddingMode(): 'atlas' | 'server' {
+    const mode = (process.env.MONGODB_EMBEDDING_MODE || 'atlas').toLowerCase();
+    return mode === 'server' ? 'server' : 'atlas';
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function persistMongoSyncProgress(
+    integrationId: string,
+    progress: SyncProgress
+): Promise<void> {
+    const syncStatus =
+        progress.status === 'syncing'
+            ? 'syncing'
+            : progress.status === 'completed'
+              ? 'completed'
+              : 'failed';
+
+    await pool.query(
+        `UPDATE integrations
+         SET sync_status = $2,
+             configuration = COALESCE(configuration, '{}'::jsonb) || jsonb_build_object('mongodb_sync_progress', $3::jsonb),
+             last_sync = CASE WHEN $2 IN ('completed', 'failed') THEN CURRENT_TIMESTAMP ELSE last_sync END,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = $1`,
+        [integrationId, syncStatus, JSON.stringify({ ...progress, updatedAt: new Date().toISOString() })]
+    );
+}
+
+export async function readMongoSyncProgress(integrationId: string): Promise<SyncProgress | null> {
+    const result = await pool.query(
+        `SELECT sync_status, configuration FROM integrations WHERE id = $1`,
+        [integrationId]
+    );
+    if (result.rows.length === 0) {
+        return null;
+    }
+    const row = result.rows[0];
+    const stored = row.configuration?.mongodb_sync_progress;
+    if (stored && typeof stored === 'object') {
+        return stored as SyncProgress;
+    }
+    if (row.sync_status === 'syncing') {
+        return { total: 0, synced: 0, skipped: 0, errors: 0, status: 'syncing' };
+    }
+    return null;
+}
+
+export class MongoDBSyncService {
     async syncProjectDocuments(
         projectId: string | null,
         limit?: number,
         onProgress?: (progress: SyncProgress) => Promise<void>
     ): Promise<SyncResult> {
         logger.info(`Starting MongoDB sync for ${projectId ? `project: ${projectId}` : 'ALL projects'} (limit: ${limit || 'all'})`);
+
         const result: SyncResult = {
             success: true,
             details: {
                 totalDocuments: 0,
                 syncedDocuments: 0,
                 skippedDocuments: 0,
-                errors: []
-            }
+                errors: [],
+            },
         };
 
-        const pool = getDatabasePool(); // Get the active pool
+        const dbPool = getDatabasePool();
+        const embeddingMode = getEmbeddingMode();
 
         try {
+            if (!mongoVectorStore.isMongoConfigured()) {
+                throw new Error('MONGODB_URI is not configured');
+            }
+
+            await mongoVectorStore.connect();
 
             let query = `
-                SELECT id, title, content, project_id
-                FROM documents 
-                WHERE content IS NOT NULL 
+                SELECT id, COALESCE(NULLIF(TRIM(title), ''), name) AS title, content, project_id
+                FROM documents
+                WHERE content IS NOT NULL
                 AND length(content) > 50
+                AND deleted_at IS NULL
             `;
-            const params: any[] = [];
+            const params: Array<string | number> = [];
 
             if (projectId) {
-                query += ` AND project_id = $1`;
                 params.push(projectId);
+                query += ` AND project_id = $${params.length}`;
             }
 
             if (limit) {
-                query += ` LIMIT $${params.length + 1}`;
                 params.push(limit);
+                query += ` LIMIT $${params.length}`;
             }
 
-            const pgResult = await pool.query(query, params);
-
+            const pgResult = await dbPool.query(query, params);
             if (!pgResult) {
-                throw new Error("Database query returned null (check logs for DB-GUARD errors)");
+                throw new Error('Database query returned null (check logs for DB-GUARD errors)');
             }
 
             const documents = pgResult.rows;
             result.details.totalDocuments = documents.length;
 
-            logger.info(`Found ${documents.length} documents to sync`);
-
-            // Initial progress report
             if (onProgress) {
                 await onProgress({
                     total: documents.length,
                     synced: 0,
                     skipped: 0,
                     errors: 0,
-                    status: 'syncing'
+                    status: 'syncing',
                 });
             }
 
@@ -101,7 +149,6 @@ export class MongoDBSyncService {
                 return result;
             }
 
-            // 2. Process documents in sequence with rate limiting
             for (const doc of documents) {
                 try {
                     if (onProgress) {
@@ -111,38 +158,28 @@ export class MongoDBSyncService {
                             skipped: result.details.skippedDocuments,
                             errors: result.details.errors.length,
                             currentDocumentId: doc.id,
-                            status: 'syncing'
+                            status: 'syncing',
                         });
                     }
 
-                    // Check if already synced/exists? 
-                    // For now, we'll do an upsert-like logic: 
-                    // ideally we should check a hash or 'synced_at' timestamp vs 'updated_at'
-                    // But for "Full Sync", we might just want to overwrite or ensure it's there.
-
-                    // Cleanup existing chunks for this document in MongoDB to avoid duplicates
-                    // (This assumes we want to fully replace the document representation)
-                    // Efficient way: deleteMany({ documentId: doc.id })
-                    await mongoVectorStore.chunksCollection.deleteMany({ documentId: doc.id });
-
-                    // Also update/insert the document metadata in 'documents' collection
-                    await mongoVectorStore.createDocument({
-                        id: doc.id,
-                        title: doc.title,
-                        content: doc.content.substring(0, 1000), // Store preview or full content
-                        type: 'txt',                             // Default to txt for now
-                        source: doc.title,                       // Use title as source
-                        metadata: { projectId: doc.project_id }
-                    }).catch(async (err) => {
-                        // If it fails (e.g. duplicate key), it might mean it exists. 
-                        // We deleted chunks, so we should update the document metadata.
-                        // For simplicity in this 'createDocument' wrapper, we ignore duplicate key error 
-                        // or we should implement 'upsertDocument' in vector store.
-                        // Let's assume createDocument throws if exists.
+                    await mongoVectorStore.chunksCollection.deleteMany({
+                        $or: [{ documentId: doc.id }, { document_id: doc.id }],
                     });
 
-                    // Chunk the document using processDocument to get metadata
-                    // We treat all as 'txt' for simplicity here, or we could try to infer from title/content
+                    const preview =
+                        typeof doc.content === 'string'
+                            ? doc.content.substring(0, 1000)
+                            : JSON.stringify(doc.content).substring(0, 1000);
+
+                    await mongoVectorStore.upsertDocument({
+                        id: doc.id,
+                        title: doc.title || 'Untitled',
+                        content: preview,
+                        type: 'markdown',
+                        source: doc.title || doc.id,
+                        metadata: { projectId: doc.project_id },
+                    });
+
                     const processedChunks = await documentProcessor.processDocument(
                         doc.content,
                         doc.id,
@@ -155,55 +192,67 @@ export class MongoDBSyncService {
                         continue;
                     }
 
-                    logger.info(`Document ${doc.id}: processing ${processedChunks.length} chunks`);
+                    if (embeddingMode === 'server') {
+                        for (let i = 0; i < processedChunks.length; i += EMBEDDING_BATCH_SIZE) {
+                            const batch = processedChunks.slice(i, i + EMBEDDING_BATCH_SIZE);
+                            const texts = batch.map((c) => c.content);
+                            const embeddings = await mongoDBEmbeddingService.generateEmbeddings(
+                                texts,
+                                'document'
+                            );
 
-                    // Process chunks in batches to respect rate limits (if using API) - OR just batch insertion
-                    // Since we are skipping embeddings (handled by Atlas or user choice), we just batch insert.
-                    const INSERT_BATCH_SIZE = 500;
+                            const chunkObjects: MongoChunkWriteInput[] = batch.map((chunk, idx) => ({
+                                documentId: doc.id,
+                                content: chunk.content,
+                                embedding: embeddings[idx] ?? [],
+                                projectId: doc.project_id,
+                                chunkIndex: chunk.metadata?.chunkIndex ?? i + idx,
+                                metadata: {
+                                    ...chunk.metadata,
+                                    projectId: doc.project_id,
+                                },
+                            }));
 
-                    for (let i = 0; i < processedChunks.length; i += INSERT_BATCH_SIZE) {
-                        const batch = processedChunks.slice(i, i + INSERT_BATCH_SIZE);
+                            await mongoVectorStore.createChunks(chunkObjects);
 
-                        logger.info(`Syncing batch ${Math.floor(i / INSERT_BATCH_SIZE) + 1} (${batch.length} chunks) to MongoDB`);
-
-                        // SKIP explicit embedding generation (User: "Voyage is MongoDB")
-                        // We provide empty embedding array as placeholder if required by type, 
-                        // or rely on Atlas Trigger to populate it later.
-
-                        const chunkObjects = batch.map((chunk, idx) => ({
-                            documentId: doc.id,
-                            content: chunk.content,
-                            embedding: [], // Empty placeholder
-                            metadata: {
-                                ...chunk.metadata,
-                                projectId: doc.project_id
+                            if (i + EMBEDDING_BATCH_SIZE < processedChunks.length) {
+                                await sleep(RATE_LIMIT_DELAY_MS);
                             }
-                        }));
-
-                        // Store in MongoDB
-                        await mongoVectorStore.createChunks(chunkObjects);
+                        }
+                    } else {
+                        for (let i = 0; i < processedChunks.length; i += INSERT_BATCH_SIZE) {
+                            const batch = processedChunks.slice(i, i + INSERT_BATCH_SIZE);
+                            const chunkObjects: MongoChunkWriteInput[] = batch.map((chunk, idx) => ({
+                                documentId: doc.id,
+                                content: chunk.content,
+                                embedding: [],
+                                projectId: doc.project_id,
+                                chunkIndex: chunk.metadata?.chunkIndex ?? i + idx,
+                                metadata: {
+                                    ...chunk.metadata,
+                                    projectId: doc.project_id,
+                                },
+                            }));
+                            await mongoVectorStore.createChunks(chunkObjects);
+                        }
                     }
 
                     result.details.syncedDocuments++;
-
                 } catch (docError) {
                     logger.error(`Failed to sync document ${doc.id}`, docError);
                     result.details.errors.push(`Doc ${doc.id}: ${(docError as Error).message}`);
-                    // Continue to next document
                 }
             }
 
-            // Final progress report
             if (onProgress) {
                 await onProgress({
                     total: documents.length,
                     synced: result.details.syncedDocuments,
                     skipped: result.details.skippedDocuments,
                     errors: result.details.errors.length,
-                    status: 'completed'
+                    status: 'completed',
                 });
             }
-
         } catch (error) {
             logger.error('Full sync failed', error);
             result.success = false;
@@ -215,7 +264,7 @@ export class MongoDBSyncService {
                     synced: 0,
                     skipped: 0,
                     errors: 1,
-                    status: 'error'
+                    status: 'error',
                 });
             }
         }

--- a/server/src/services/mongoRagService.ts
+++ b/server/src/services/mongoRagService.ts
@@ -1,0 +1,141 @@
+import { logger } from '../utils/logger';
+import { mongoDBEmbeddingService } from './mongoDBEmbeddings';
+import { mongoVectorStore } from './mongoVectorStore';
+import { mongoProjectFilter } from '../lib/mongoChunkSchema';
+import type { SearchResult } from './searchService';
+
+export function isMongoRagEnabled(): boolean {
+    return (
+        process.env.MONGODB_RAG_ENABLED === 'true' &&
+        Boolean(process.env.MONGODB_URI) &&
+        Boolean(process.env.VOYAGE_API_KEY)
+    );
+}
+
+export interface MongoSearchMatch {
+    content: string;
+    documentId?: string;
+    score?: number;
+    metadata?: Record<string, unknown>;
+}
+
+export async function searchMongoChunks(
+    query: string,
+    topK: number = 5,
+    projectId?: string
+): Promise<MongoSearchMatch[]> {
+    if (!mongoVectorStore.isMongoConfigured()) {
+        throw new Error('MongoDB is not configured');
+    }
+
+    await mongoVectorStore.connect();
+
+    const [queryVector] = await mongoDBEmbeddingService.generateEmbeddings([query], 'query');
+    if (!queryVector?.length) {
+        throw new Error('Failed to generate query embedding for MongoDB search');
+    }
+
+    const filters = projectId ? mongoProjectFilter(projectId) : undefined;
+
+    const results = await mongoVectorStore.vectorSearch(
+        queryVector,
+        topK,
+        filters
+    );
+
+    return results.map((row) => ({
+        content: row.content,
+        documentId: row.documentId ?? (row as { document_id?: string }).document_id,
+        score: (row as { score?: number }).score,
+        metadata: row.metadata as Record<string, unknown>,
+    }));
+}
+
+/** Map Mongo vector hits into universal search results for assisted search. */
+export async function searchDocumentsViaMongo(
+    query: string,
+    userId: string,
+    limit: number = 10
+): Promise<SearchResult[]> {
+    const { pool } = await import('../database/connection');
+
+    const projects = await pool.query(
+        `SELECT id, name FROM projects
+         WHERE owner_id = $1 OR $1::text = ANY(
+           SELECT jsonb_array_elements_text(COALESCE(team_members, '[]'::jsonb))
+         )
+         LIMIT 20`,
+        [userId]
+    );
+
+    const allMatches: SearchResult[] = [];
+    const perProjectLimit = Math.max(1, Math.ceil(limit / Math.max(projects.rows.length, 1)));
+
+    for (const project of projects.rows) {
+        try {
+            const hits = await searchMongoChunks(query, perProjectLimit, project.id);
+            for (const hit of hits) {
+                const documentId = hit.documentId;
+                if (!documentId) continue;
+
+                const docMeta = await pool.query(
+                    `SELECT id, COALESCE(NULLIF(TRIM(title), ''), name) AS title, updated_at, created_at, project_id
+                     FROM documents WHERE id = $1`,
+                    [documentId]
+                );
+                if (docMeta.rows.length === 0) continue;
+                const doc = docMeta.rows[0];
+
+                allMatches.push({
+                    id: doc.id,
+                    type: 'document',
+                    title: doc.title || 'Document',
+                    description: hit.content.substring(0, 240),
+                    content_preview: hit.content.substring(0, 500),
+                    author: '',
+                    author_id: '',
+                    created_at: doc.created_at,
+                    updated_at: doc.updated_at,
+                    tags: [],
+                    relevance_score: hit.score ?? 0.5,
+                    project_id: doc.project_id,
+                    project_name: project.name,
+                });
+            }
+        } catch (err) {
+            logger.warn('[mongoRagService] Project search failed', {
+                projectId: project.id,
+                error: (err as Error).message,
+            });
+        }
+    }
+
+    const byId = new Map<string, SearchResult>();
+    for (const item of allMatches) {
+        const existing = byId.get(item.id);
+        if (!existing || item.relevance_score > existing.relevance_score) {
+            byId.set(item.id, item);
+        }
+    }
+
+    return [...byId.values()]
+        .sort((a, b) => b.relevance_score - a.relevance_score)
+        .slice(0, limit);
+}
+
+export async function queryMongoForRag(
+    queryText: string,
+    topK: number = 5,
+    filter: Record<string, unknown> = {}
+): Promise<Array<Record<string, unknown>>> {
+    const projectId = typeof filter.project_id === 'string' ? filter.project_id : undefined;
+    const hits = await searchMongoChunks(queryText, topK, projectId);
+
+    return hits.map((hit) => ({
+        document_id: hit.documentId,
+        content: hit.content,
+        similarity: hit.score ?? 0,
+        metadata: hit.metadata ?? {},
+        source: 'mongodb_atlas',
+    }));
+}

--- a/server/src/services/mongoVectorStore.ts
+++ b/server/src/services/mongoVectorStore.ts
@@ -1,8 +1,10 @@
 
+import { randomUUID } from 'node:crypto';
 import { MongoClient, Db, Collection } from 'mongodb';
 import { logger } from '../utils/logger';
 import { RAGDocument, DocumentChunk } from '../types/rag';
 import { buildMongoChunkDocument, type MongoChunkWriteInput } from '../lib/mongoChunkSchema';
+import { toMongoEqualityId, toMongoIndexName } from '../lib/mongoQuerySafety';
 
 const DOCUMENTS_COLLECTION = 'documents';
 const CHUNKS_COLLECTION = 'chunks';
@@ -126,38 +128,41 @@ export class MongoVectorStore {
     ): Promise<string> {
         this.ensureConnected();
 
+        const documentId = toMongoEqualityId(document.id, 'documentId');
         const now = new Date();
-        const existing = await this.documentsCollection.findOne({ id: document.id });
+        const existing = await this.documentsCollection.findOne({ id: documentId });
         const docWithTimestamps: RAGDocument = {
             ...document,
+            id: documentId,
             createdAt: existing?.createdAt ?? now,
             updatedAt: now,
         };
 
         await this.documentsCollection.replaceOne(
-            { id: document.id },
+            { id: documentId },
             docWithTimestamps as RAGDocument,
             { upsert: true }
         );
 
         logger.info('RAG Document upserted', {
-            documentId: document.id,
+            documentId,
             title: document.title,
         });
 
-        return document.id;
+        return documentId;
     }
 
     /** @deprecated Prefer upsertDocument */
     async createDocument(document: Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id?: string }): Promise<string> {
-        const id = document.id || this.generateId();
+        const id = document.id ? toMongoEqualityId(document.id, 'documentId') : this.generateId();
         await this.upsertDocument({ ...document, id } as Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id: string });
         return id;
     }
 
     async getDocument(id: string): Promise<RAGDocument | null> {
         this.ensureConnected();
-        return await this.documentsCollection.findOne({ id }) as RAGDocument | null;
+        const documentId = toMongoEqualityId(id, 'documentId');
+        return await this.documentsCollection.findOne({ id: documentId }) as RAGDocument | null;
     }
 
     async createChunks(chunks: MongoChunkWriteInput[]): Promise<string[]> {
@@ -177,9 +182,10 @@ export class MongoVectorStore {
 
     async getChunks(documentId: string): Promise<DocumentChunk[]> {
         this.ensureConnected();
+        const safeDocumentId = toMongoEqualityId(documentId, 'documentId');
         return await this.chunksCollection
             .find({
-                $or: [{ documentId }, { document_id: documentId }],
+                $or: [{ documentId: safeDocumentId }, { document_id: safeDocumentId }],
             })
             .toArray() as DocumentChunk[];
     }
@@ -193,17 +199,18 @@ export class MongoVectorStore {
     ): Promise<Array<DocumentChunk & { score?: number }>> {
         this.ensureConnected();
 
+        const safeIndexName = toMongoIndexName(indexName);
         const pipeline: Record<string, unknown>[] = [];
 
         logger.info('Preparing vector search', {
             queryVectorDimensions: queryVector.length,
             limit,
-            indexName,
+            indexName: safeIndexName,
             numCandidates: numCandidates || limit * 20,
         });
 
         const vectorSearchStage: Record<string, unknown> = {
-            index: indexName,
+            index: safeIndexName,
             path: 'embedding',
             queryVector,
             numCandidates: numCandidates || limit * 20,
@@ -234,7 +241,7 @@ export class MongoVectorStore {
         } catch (error) {
             logger.error('Vector search failed', {
                 error: (error as Error).message,
-                indexName,
+                indexName: safeIndexName,
             });
             throw error;
         }
@@ -276,8 +283,12 @@ export class MongoVectorStore {
                 listSearchIndexes: () => { toArray: () => Promise<Array<Record<string, unknown>>> };
             }).listSearchIndexes;
             const indexes = await listSearchIndexes.call(this.chunksCollection).toArray();
-            const indexName = process.env.MONGODB_VECTOR_INDEX || 'vector_search_index';
-            const vectorIndex = indexes.find((idx) => idx.name === indexName);
+            const indexName = toMongoIndexName(
+                process.env.MONGODB_VECTOR_INDEX || 'vector_search_index'
+            );
+            const vectorIndex = indexes.find(
+                (idx) => typeof idx.name === 'string' && idx.name === indexName
+            );
             if (vectorIndex) {
                 indexStatus = vectorIndex.queryable === true ? 'active' : 'building';
             } else {
@@ -317,7 +328,7 @@ export class MongoVectorStore {
     }
 
     private generateId(): string {
-        return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 11)}`;
+        return randomUUID();
     }
 }
 

--- a/server/src/services/mongoVectorStore.ts
+++ b/server/src/services/mongoVectorStore.ts
@@ -2,6 +2,7 @@
 import { MongoClient, Db, Collection } from 'mongodb';
 import { logger } from '../utils/logger';
 import { RAGDocument, DocumentChunk } from '../types/rag';
+import { buildMongoChunkDocument, type MongoChunkWriteInput } from '../lib/mongoChunkSchema';
 
 const DOCUMENTS_COLLECTION = 'documents';
 const CHUNKS_COLLECTION = 'chunks';
@@ -14,6 +15,7 @@ function getMongoUri(): string | undefined {
 function getMongoDbName(): string {
     return process.env.MONGODB_DB_NAME || 'adpa_rag';
 }
+
 export class MongoVectorStore {
     private client: MongoClient | null = null;
     private _db!: Db;
@@ -53,6 +55,7 @@ export class MongoVectorStore {
         if (!this.client) return;
         try {
             await this.client.close();
+            this.client = null;
             this.isConnected = false;
             logger.info('Disconnected from MongoDB Atlas');
         } catch (error) {
@@ -63,14 +66,16 @@ export class MongoVectorStore {
         }
     }
 
+    isMongoConfigured(): boolean {
+        return Boolean(getMongoUri());
+    }
+
     private ensureConnected(): void {
         if (!this.isConnected) {
-            // Auto-connect attempt could go here, but for now throw
             throw new Error('Database not connected. Call connect() first.');
         }
     }
 
-    // Collections
     get documentsCollection(): Collection<RAGDocument> {
         this.ensureConnected();
         return this._db.collection(DOCUMENTS_COLLECTION);
@@ -81,26 +86,38 @@ export class MongoVectorStore {
         return this._db.collection(CHUNKS_COLLECTION);
     }
 
-    // Document Operations
-    async createDocument(document: Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id?: string }): Promise<string> {
+    async upsertDocument(
+        document: Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id: string }
+    ): Promise<string> {
         this.ensureConnected();
 
         const now = new Date();
+        const existing = await this.documentsCollection.findOne({ id: document.id });
         const docWithTimestamps: RAGDocument = {
             ...document,
-            id: document.id || this.generateId(),
-            createdAt: now,
-            updatedAt: now
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: now,
         };
 
-        await this.documentsCollection.insertOne(docWithTimestamps as any);
+        await this.documentsCollection.replaceOne(
+            { id: document.id },
+            docWithTimestamps as RAGDocument,
+            { upsert: true }
+        );
 
-        logger.info('RAG Document created', {
-            documentId: docWithTimestamps.id,
-            title: document.title
+        logger.info('RAG Document upserted', {
+            documentId: document.id,
+            title: document.title,
         });
 
-        return docWithTimestamps.id;
+        return document.id;
+    }
+
+    /** @deprecated Prefer upsertDocument */
+    async createDocument(document: Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id?: string }): Promise<string> {
+        const id = document.id || this.generateId();
+        await this.upsertDocument({ ...document, id } as Omit<RAGDocument, 'createdAt' | 'updatedAt'> & { id: string });
+        return id;
     }
 
     async getDocument(id: string): Promise<RAGDocument | null> {
@@ -108,55 +125,54 @@ export class MongoVectorStore {
         return await this.documentsCollection.findOne({ id }) as RAGDocument | null;
     }
 
-    // Chunk Operations
-    async createChunks(chunks: Omit<DocumentChunk, 'id' | 'createdAt'>[]): Promise<string[]> {
+    async createChunks(chunks: MongoChunkWriteInput[]): Promise<string[]> {
         this.ensureConnected();
 
-        const now = new Date();
-        const chunksWithTimestamps = chunks.map(chunk => ({
-            ...chunk,
-            id: this.generateId(),
-            createdAt: now
-        }));
-
-        if (chunksWithTimestamps.length > 0) {
-            const result = await this.chunksCollection.insertMany(chunksWithTimestamps as any);
-            return Object.values(result.insertedIds).map(id => id.toString());
+        if (chunks.length === 0) {
+            return [];
         }
-        return [];
+
+        const chunksWithTimestamps = chunks.map((chunk) =>
+            buildMongoChunkDocument(chunk, this.generateId())
+        );
+
+        await this.chunksCollection.insertMany(chunksWithTimestamps as DocumentChunk[]);
+        return chunksWithTimestamps.map((c) => c.id);
     }
 
     async getChunks(documentId: string): Promise<DocumentChunk[]> {
         this.ensureConnected();
-        return await this.chunksCollection.find({ documentId }).toArray() as DocumentChunk[];
+        return await this.chunksCollection
+            .find({
+                $or: [{ documentId }, { document_id: documentId }],
+            })
+            .toArray() as DocumentChunk[];
     }
 
-    // Vector Search
     async vectorSearch(
         queryVector: number[],
         limit: number = 10,
-        filters?: any,
-        indexName: string = 'vector_search_index',
+        filters?: Record<string, unknown>,
+        indexName: string = process.env.MONGODB_VECTOR_INDEX || 'vector_search_index',
         numCandidates?: number
-    ): Promise<DocumentChunk[]> {
+    ): Promise<Array<DocumentChunk & { score?: number }>> {
         this.ensureConnected();
 
-        const pipeline: any[] = [];
+        const pipeline: Record<string, unknown>[] = [];
 
         logger.info('Preparing vector search', {
             queryVectorDimensions: queryVector.length,
             limit,
             indexName,
-            numCandidates: numCandidates || limit * 20
+            numCandidates: numCandidates || limit * 20,
         });
 
-        // Build $vectorSearch stage
-        const vectorSearchStage: any = {
+        const vectorSearchStage: Record<string, unknown> = {
             index: indexName,
             path: 'embedding',
-            queryVector: queryVector,
-            numCandidates: numCandidates || limit * 20, // Recommended to be 10-20x the limit
-            limit: limit
+            queryVector,
+            numCandidates: numCandidates || limit * 20,
+            limit,
         };
 
         if (filters && Object.keys(filters).length > 0) {
@@ -164,62 +180,75 @@ export class MongoVectorStore {
         }
 
         pipeline.push({ $vectorSearch: vectorSearchStage });
-
-        // Project fields
-        // Note: In MongoDB, you can't mix inclusion and exclusion (except for _id).
-        // Since we are including specific fields, 'embedding' will be excluded by default.
         pipeline.push({
             $project: {
                 content: 1,
                 documentId: 1,
+                document_id: 1,
                 metadata: 1,
+                project_id: 1,
                 createdAt: 1,
-                score: { $meta: 'vectorSearchScore' } // Standard score field for $vectorSearch
-            }
-        });
-
-        logger.info('Executing vector search', {
-            limit,
-            filterCount: filters ? Object.keys(filters).length : 0
+                score: { $meta: 'vectorSearchScore' },
+            },
         });
 
         try {
             const results = await this.chunksCollection.aggregate(pipeline).toArray();
             logger.info('Vector search completed', { resultCount: results.length });
-            return results as DocumentChunk[];
+            return results as Array<DocumentChunk & { score?: number }>;
         } catch (error) {
             logger.error('Vector search failed', {
                 error: (error as Error).message,
-                pipeline: JSON.stringify(pipeline)
+                indexName,
             });
-            return [];
+            throw error;
         }
     }
 
-    async getStats(): Promise<any> {
+    async getStats(): Promise<{
+        documents: number;
+        chunks: number;
+        embeddedChunks: number;
+        embeddingPercentage: number;
+        indexStatus: string;
+        database: string;
+        configured: boolean;
+    }> {
+        if (!this.isMongoConfigured()) {
+            return {
+                documents: 0,
+                chunks: 0,
+                embeddedChunks: 0,
+                embeddingPercentage: 0,
+                indexStatus: 'not_configured',
+                database: getMongoDbName(),
+                configured: false,
+            };
+        }
+
         this.ensureConnected();
 
         const docCount = await this.documentsCollection.countDocuments();
         const chunkCount = await this.chunksCollection.countDocuments();
 
-        // Count chunks with embeddings (non-empty array)
         const embeddedChunkCount = await this.chunksCollection.countDocuments({
-            embedding: { $exists: true, $not: { $size: 0 } }
+            embedding: { $exists: true, $not: { $size: 0 } },
         });
 
-        // Try to check index health (simple check if it exists in listSearchIndexes)
         let indexStatus = 'unknown';
         try {
-            // listSearchIndexes is available in Atlas
-            const indexes = await (this.chunksCollection as any).listSearchIndexes().toArray();
-            const vectorIndex = indexes.find((idx: any) => idx.name === 'vector_search_index');
+            const indexes = await (this.chunksCollection as Collection & {
+                listSearchIndexes: () => { toArray: () => Promise<Array<{ name: string; queryable?: boolean }>> };
+            }).listSearchIndexes().toArray();
+            const indexName = process.env.MONGODB_VECTOR_INDEX || 'vector_search_index';
+            const vectorIndex = indexes.find((idx) => idx.name === indexName);
             if (vectorIndex) {
                 indexStatus = vectorIndex.queryable ? 'active' : 'building';
             } else {
                 indexStatus = 'missing';
             }
         } catch (err) {
-            logger.warn('Failed to list search indexes (might not be Atlas or insufficient permissions)', { error: (err as Error).message });
+            logger.warn('Failed to list search indexes', { error: (err as Error).message });
             indexStatus = 'unavailable';
         }
 
@@ -229,14 +258,16 @@ export class MongoVectorStore {
             embeddedChunks: embeddedChunkCount,
             embeddingPercentage: chunkCount > 0 ? Math.round((embeddedChunkCount / chunkCount) * 100) : 0,
             indexStatus,
-            database: getMongoDbName()
+            database: getMongoDbName(),
+            configured: true,
         };
     }
 
     async ping(): Promise<boolean> {
         try {
-            this.ensureConnected();
-            if (!this.client) return false;
+            if (!this.isConnected || !this.client) {
+                return false;
+            }
             await this.client.db(getMongoDbName()).command({ ping: 1 });
             return true;
         } catch (error) {
@@ -246,7 +277,7 @@ export class MongoVectorStore {
     }
 
     private generateId(): string {
-        return Math.random().toString(36).substring(2) + Date.now().toString(36);
+        return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 11)}`;
     }
 }
 

--- a/server/src/services/mongoVectorStore.ts
+++ b/server/src/services/mongoVectorStore.ts
@@ -4,7 +4,13 @@ import { MongoClient, Db, Collection } from 'mongodb';
 import { logger } from '../utils/logger';
 import { RAGDocument, DocumentChunk } from '../types/rag';
 import { buildMongoChunkDocument, type MongoChunkWriteInput } from '../lib/mongoChunkSchema';
-import { toMongoEqualityId, toMongoIndexName } from '../lib/mongoQuerySafety';
+import {
+    findOneByRagDocumentId,
+    ragChunkByDocumentIdFilter,
+    ragDocumentIdReplaceFilter,
+    toMongoEqualityId,
+    toMongoIndexName,
+} from '../lib/mongoQuerySafety';
 
 const DOCUMENTS_COLLECTION = 'documents';
 const CHUNKS_COLLECTION = 'chunks';
@@ -128,9 +134,9 @@ export class MongoVectorStore {
     ): Promise<string> {
         this.ensureConnected();
 
-        const documentId = toMongoEqualityId(document.id, 'documentId');
+        const { filter: idFilter, id: documentId } = ragDocumentIdReplaceFilter(document.id);
         const now = new Date();
-        const existing = await this.documentsCollection.findOne({ id: documentId });
+        const existing = await findOneByRagDocumentId(this.documentsCollection, document.id);
         const docWithTimestamps: RAGDocument = {
             ...document,
             id: documentId,
@@ -139,7 +145,7 @@ export class MongoVectorStore {
         };
 
         await this.documentsCollection.replaceOne(
-            { id: documentId },
+            idFilter,
             docWithTimestamps as RAGDocument,
             { upsert: true }
         );
@@ -161,8 +167,7 @@ export class MongoVectorStore {
 
     async getDocument(id: string): Promise<RAGDocument | null> {
         this.ensureConnected();
-        const documentId = toMongoEqualityId(id, 'documentId');
-        return await this.documentsCollection.findOne({ id: documentId }) as RAGDocument | null;
+        return (await findOneByRagDocumentId(this.documentsCollection, id)) as RAGDocument | null;
     }
 
     async createChunks(chunks: MongoChunkWriteInput[]): Promise<string[]> {
@@ -182,12 +187,9 @@ export class MongoVectorStore {
 
     async getChunks(documentId: string): Promise<DocumentChunk[]> {
         this.ensureConnected();
-        const safeDocumentId = toMongoEqualityId(documentId, 'documentId');
-        return await this.chunksCollection
-            .find({
-                $or: [{ documentId: safeDocumentId }, { document_id: safeDocumentId }],
-            })
-            .toArray() as DocumentChunk[];
+        return (await this.chunksCollection
+            .find(ragChunkByDocumentIdFilter(documentId))
+            .toArray()) as DocumentChunk[];
     }
 
     async vectorSearch(

--- a/server/src/services/mongoVectorStore.ts
+++ b/server/src/services/mongoVectorStore.ts
@@ -20,14 +20,37 @@ export class MongoVectorStore {
     private client: MongoClient | null = null;
     private _db!: Db;
     private isConnected: boolean = false;
+    /** Single in-flight connect; prevents concurrent callers from opening duplicate clients. */
+    private connectPromise: Promise<void> | null = null;
 
     get db(): Db {
         this.ensureConnected();
         return this._db;
     }
 
+    /**
+     * Establishes (or reuses) the MongoDB client. Safe to call concurrently — all callers
+     * await the same connection attempt.
+     */
     async connect(): Promise<void> {
-        if (this.isConnected) return;
+        if (this.isConnected) {
+            return;
+        }
+
+        if (!this.connectPromise) {
+            this.connectPromise = this.performConnect().finally(() => {
+                this.connectPromise = null;
+            });
+        }
+
+        await this.connectPromise;
+
+        if (!this.isConnected) {
+            throw new Error('MongoDB connection failed');
+        }
+    }
+
+    private async performConnect(): Promise<void> {
         const uri = getMongoUri();
         const dbName = getMongoDbName();
         if (!uri) {
@@ -35,24 +58,31 @@ export class MongoVectorStore {
         }
 
         try {
-            this.client = new MongoClient(uri);
-            await this.client.connect();
-            this._db = this.client.db(dbName);
+            const client = new MongoClient(uri);
+            await client.connect();
+            this.client = client;
+            this._db = client.db(dbName);
             this.isConnected = true;
 
             logger.info('Connected to MongoDB Atlas for Vector Store', {
-                database: dbName
+                database: dbName,
             });
         } catch (error) {
+            this.client = null;
+            this.isConnected = false;
             logger.error('Failed to connect to MongoDB Atlas', {
-                error: (error as Error).message
+                error: (error as Error).message,
             });
             throw error;
         }
     }
 
     async disconnect(): Promise<void> {
-        if (!this.client) return;
+        this.connectPromise = null;
+        if (!this.client) {
+            this.isConnected = false;
+            return;
+        }
         try {
             await this.client.close();
             this.client = null;
@@ -60,7 +90,7 @@ export class MongoVectorStore {
             logger.info('Disconnected from MongoDB Atlas');
         } catch (error) {
             logger.error('Failed to disconnect from MongoDB Atlas', {
-                error: (error as Error).message
+                error: (error as Error).message,
             });
             throw error;
         }
@@ -70,8 +100,13 @@ export class MongoVectorStore {
         return Boolean(getMongoUri());
     }
 
+    /** True when a client is connected and ready for operations. */
+    isConnectionReady(): boolean {
+        return this.isConnected && this.client !== null;
+    }
+
     private ensureConnected(): void {
-        if (!this.isConnected) {
+        if (!this.isConnectionReady()) {
             throw new Error('Database not connected. Call connect() first.');
         }
     }
@@ -226,7 +261,7 @@ export class MongoVectorStore {
             };
         }
 
-        this.ensureConnected();
+        await this.connect();
 
         const docCount = await this.documentsCollection.countDocuments();
         const chunkCount = await this.chunksCollection.countDocuments();
@@ -237,13 +272,14 @@ export class MongoVectorStore {
 
         let indexStatus = 'unknown';
         try {
-            const indexes = await (this.chunksCollection as Collection & {
-                listSearchIndexes: () => { toArray: () => Promise<Array<{ name: string; queryable?: boolean }>> };
-            }).listSearchIndexes().toArray();
+            const listSearchIndexes = (this.chunksCollection as unknown as {
+                listSearchIndexes: () => { toArray: () => Promise<Array<Record<string, unknown>>> };
+            }).listSearchIndexes;
+            const indexes = await listSearchIndexes.call(this.chunksCollection).toArray();
             const indexName = process.env.MONGODB_VECTOR_INDEX || 'vector_search_index';
             const vectorIndex = indexes.find((idx) => idx.name === indexName);
             if (vectorIndex) {
-                indexStatus = vectorIndex.queryable ? 'active' : 'building';
+                indexStatus = vectorIndex.queryable === true ? 'active' : 'building';
             } else {
                 indexStatus = 'missing';
             }
@@ -265,7 +301,11 @@ export class MongoVectorStore {
 
     async ping(): Promise<boolean> {
         try {
-            if (!this.isConnected || !this.client) {
+            if (!this.isMongoConfigured()) {
+                return false;
+            }
+            await this.connect();
+            if (!this.client) {
                 return false;
             }
             await this.client.db(getMongoDbName()).command({ ping: 1 });

--- a/server/src/services/pineconeService.ts
+++ b/server/src/services/pineconeService.ts
@@ -653,12 +653,15 @@ export class PineconeService {
           const db = mongoClient.db('adpa_rag');
           const chunksCollection = db.collection('chunks');
 
-          const chunkFilter: any = {
-            embedding: { $exists: true, $not: { $size: 0 } }
+          const chunkFilter: Record<string, unknown> = {
+            embedding: { $exists: true, $not: { $size: 0 } },
           };
 
           if (projectId) {
-            chunkFilter.project_id = projectId;
+            chunkFilter.$or = [
+              { project_id: projectId },
+              { 'metadata.projectId': projectId },
+            ];
           }
 
           const chunks = await chunksCollection.find(chunkFilter).limit(1000).toArray();
@@ -682,11 +685,14 @@ export class PineconeService {
                 values: chunk.embedding,
                 metadata: {
                   type: 'chunk',
-                  document_id: chunk.document_id || '',
-                  project_id: chunk.project_id || '',
+                  document_id: chunk.document_id || chunk.documentId || '',
+                  project_id:
+                    chunk.project_id ||
+                    chunk.metadata?.projectId ||
+                    '',
                   content: chunk.content ? chunk.content.substring(0, 500) : '',
-                  chunk_index: chunk.chunk_index || 0,
-                  created_at: chunk.created_at || new Date().toISOString()
+                  chunk_index: chunk.chunk_index ?? chunk.metadata?.chunkIndex ?? 0,
+                  created_at: chunk.created_at || chunk.createdAt || new Date().toISOString()
                 }
               })).filter(v => v.values && v.values.length > 0);
 

--- a/server/src/services/ragService.ts
+++ b/server/src/services/ragService.ts
@@ -1,5 +1,6 @@
 import { pool } from "../database/connection"
 import { logger } from "../utils/logger"
+import { isMongoRagEnabled, queryMongoForRag } from "./mongoRagService"
 
 // Use global fetch (Node 18+) or fallback if needed, but avoid 'node-fetch' import if possible to prevent ESM/CJS issues
 // If global.fetch is undefined, one might need to import it, but standard Node 18+ has it.
@@ -218,6 +219,29 @@ export class RagService {
         }
 
         try {
+            if (isMongoRagEnabled()) {
+                try {
+                    const mongoRows = await queryMongoForRag(queryText, topK, filter);
+                    if (mongoRows.length > 0) {
+                        const duration = Date.now() - startTime;
+                        await this.logAnalytics({
+                            operation_type: 'query',
+                            success: true,
+                            duration_ms: duration,
+                            chunks_processed: mongoRows.length,
+                            metadata: {
+                                backend: 'mongodb_atlas',
+                                query_length: queryText.length,
+                                top_k: topK,
+                            },
+                        });
+                        return mongoRows;
+                    }
+                } catch (mongoError: any) {
+                    logger.warn(`[RagService] MongoDB query failed, falling back to pgvector: ${mongoError.message}`);
+                }
+            }
+
             // 1. Embed Query
             const response = await fetch('https://api.voyageai.com/v1/embeddings', {
                 method: 'POST',

--- a/server/src/services/searchService.ts
+++ b/server/src/services/searchService.ts
@@ -647,6 +647,26 @@ export async function searchDocuments(
   userId: string
 ): Promise<SearchResult[]> {
   try {
+    if (request.useSemanticSearch !== false) {
+      const { isMongoRagEnabled, searchDocumentsViaMongo } = await import('./mongoRagService')
+      if (isMongoRagEnabled()) {
+        try {
+          const mongoResults = await searchDocumentsViaMongo(
+            request.query,
+            userId,
+            request.limit || 20
+          )
+          if (mongoResults.length > 0) {
+            return mongoResults
+          }
+        } catch (mongoError) {
+          logger.warn('[searchDocuments] MongoDB vector search failed, using default retrieval', {
+            error: (mongoError as Error).message,
+          })
+        }
+      }
+    }
+
     // Use semantic search if enabled
     if (request.useSemanticSearch) {
       // Get user's projects for context

--- a/server/src/startup/dependencies/mongodb.ts
+++ b/server/src/startup/dependencies/mongodb.ts
@@ -12,7 +12,7 @@ export const mongodbDependency: Dependency = {
     try {
       if (!process.env.MONGODB_URI) {
         logger.warn("MongoDB (Optional) not configured, skipping initialization")
-        updateDependencyHealth("MongoDB Atlas", "healthy", 0, "Not configured")
+        updateDependencyHealth("MongoDB Atlas", "unhealthy", 0, "Not configured (optional)")
         return
       }
       await mongoVectorStore.connect()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Amazon Q review: **race condition** on MongoDB stats where `connect()` and `getStats()` could run without a guaranteed ready client.

## Fix

- **Single-flight `connect()`** — concurrent callers share one `performConnect()` attempt; avoids duplicate clients and torn connection state.
- **`getStats()` / `ping()`** — always `await this.connect()` before touching collections.
- **Stats route** — calls only `getStats()` (connection handled inside the store).
- **Test** — `mongoVectorStore.connect.test.ts` verifies concurrent `connect()` invokes `performConnect` once.

## Verification

```bash
cd server && npx jest --testPathPattern="mongoChunkSchema|mongoRagService|mongoVectorStore.connect" --no-coverage --forceExit
```

All 5 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17618378-d971-403c-8078-d5ebf1238030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17618378-d971-403c-8078-d5ebf1238030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

