### PR TITLE
fix(integrations): MongoDB dashboard auth, empty states, and search h…

### DIFF
--- a/app/integrations/MongoDBDashboard.tsx
+++ b/app/integrations/MongoDBDashboard.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useCallback } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import {
     RefreshCw,
     FileText,
@@ -12,57 +13,64 @@ import {
     CheckCircle2,
     AlertCircle,
     Clock,
-    Activity
+    Activity,
 } from "lucide-react"
 import { toast } from "sonner"
 import { Database } from "@/components/ui/icons-shim"
+import { apiClient } from "@/lib/api"
 
 interface MongoDBStats {
-    documents: number;
-    chunks: number;
-    embeddedChunks: number;
-    embeddingPercentage: number;
-    indexStatus: 'active' | 'building' | 'missing' | 'unavailable' | 'unknown';
-    database: string;
+    documents: number
+    chunks: number
+    embeddedChunks: number
+    embeddingPercentage: number
+    indexStatus: string
+    database: string
+    configured?: boolean
+    voyageConfigured?: boolean
+    embeddingMode?: string
+    searchReady?: boolean
+    setupHint?: string
 }
 
 interface MongoDBDashboardProps {
-    integrationId: string | null;
+    integrationId: string | null
 }
+
+type LoadState = "loading" | "ready" | "error"
 
 export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
     const [stats, setStats] = useState<MongoDBStats | null>(null)
-    const [loading, setLoading] = useState(false)
+    const [loadState, setLoadState] = useState<LoadState>("loading")
+    const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
-    const fetchStats = async () => {
-        setLoading(true)
+    const statsPath = integrationId
+        ? `/integrations/${integrationId}/mongodb/stats`
+        : "/integrations/mongodb/stats"
+
+    const fetchStats = useCallback(async () => {
+        setLoadState("loading")
+        setErrorMessage(null)
         try {
-            const token = localStorage.getItem('auth_token') || localStorage.getItem('token')
-            const statsPath = integrationId
-                ? `/api/integrations/${integrationId}/mongodb/stats`
-                : '/api/integrations/mongodb/stats'
-
-            const response = await fetch(statsPath, {
-                headers: { 'Authorization': `Bearer ${token}` }
-            })
-
-            if (!response.ok) {
-                throw new Error("Failed to fetch MongoDB statistics")
-            }
-
-            const data = await response.json()
+            const data = await apiClient.get<MongoDBStats>(statsPath)
             setStats(data)
+            setLoadState("ready")
         } catch (error) {
             console.error("Dashboard error:", error)
-            toast.error("Failed to load MongoDB statistics")
-        } finally {
-            setLoading(false)
+            const message =
+                error instanceof Error ? error.message : "Failed to load MongoDB statistics"
+            setErrorMessage(message)
+            setStats(null)
+            setLoadState("error")
+            toast.error(message)
         }
-    }
+    }, [statsPath])
 
     useEffect(() => {
-        fetchStats()
-    }, [integrationId])
+        void fetchStats()
+    }, [fetchStats])
+
+    const showSetup = loadState === "ready" && stats && (!stats.configured || stats.setupHint)
 
     return (
         <div className="space-y-6">
@@ -76,11 +84,11 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                 <Button
                     variant="outline"
                     size="sm"
-                    onClick={fetchStats}
-                    disabled={loading}
+                    onClick={() => void fetchStats()}
+                    disabled={loadState === "loading"}
                     className="gap-2"
                 >
-                    <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+                    <RefreshCw className={`h-4 w-4 ${loadState === "loading" ? "animate-spin" : ""}`} />
                     Refresh
                 </Button>
             </div>
@@ -89,9 +97,32 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                 <Card className="border-dashed">
                     <CardContent className="py-4 text-center text-sm text-muted-foreground">
                         <Database className="h-5 w-5 inline-block mr-2 align-text-bottom opacity-60" />
-                        Using server-level MongoDB analysis (no active MongoDB integration record found).
+                        No MongoDB integration record in the database yet. Stats use server env (
+                        <code className="text-xs">MONGODB_URI</code>). On Overview, enable
+                        &quot;MongoDB Vector Store&quot; before syncing.
                     </CardContent>
                 </Card>
+            )}
+
+            {loadState === "error" && (
+                <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Could not load MongoDB stats</AlertTitle>
+                    <AlertDescription>
+                        {errorMessage}
+                        {errorMessage?.includes("403") || errorMessage?.toLowerCase().includes("permission")
+                            ? " Your account needs integrations.read or integrations.view (admins have access automatically)."
+                            : null}
+                    </AlertDescription>
+                </Alert>
+            )}
+
+            {showSetup && stats?.setupHint && (
+                <Alert>
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertTitle>Setup required</AlertTitle>
+                    <AlertDescription>{stats.setupHint}</AlertDescription>
+                </Alert>
             )}
 
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
@@ -101,7 +132,9 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                         <FileText className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">{stats?.documents ?? '...'}</div>
+                        <div className="text-2xl font-bold">
+                            {loadState === "loading" ? "…" : stats?.documents ?? "—"}
+                        </div>
                         <p className="text-xs text-muted-foreground">In RAG collection</p>
                     </CardContent>
                 </Card>
@@ -112,11 +145,13 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                         <Layers className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">{stats?.chunks ?? '...'}</div>
+                        <div className="text-2xl font-bold">
+                            {loadState === "loading" ? "…" : stats?.chunks ?? "—"}
+                        </div>
                         <p className="text-xs text-muted-foreground">
                             {stats && stats.documents > 0
                                 ? `~${Math.round(stats.chunks / stats.documents)} per document`
-                                : 'Ready for sync'}
+                                : "Run sync from Overview"}
                         </p>
                     </CardContent>
                 </Card>
@@ -127,7 +162,9 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                         <Activity className="h-4 w-4 text-muted-foreground" />
                     </CardHeader>
                     <CardContent>
-                        <div className="text-2xl font-bold">{stats?.embeddingPercentage ?? '...'}%</div>
+                        <div className="text-2xl font-bold">
+                            {loadState === "loading" ? "…" : `${stats?.embeddingPercentage ?? 0}%`}
+                        </div>
                         <div className="mt-2">
                             <Progress value={stats?.embeddingPercentage ?? 0} className="h-2" />
                         </div>
@@ -139,25 +176,36 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                         <CardTitle className="text-sm font-medium">Index Status</CardTitle>
                         <Badge
                             variant={
-                                stats?.indexStatus === 'active' ? 'default' :
-                                    stats?.indexStatus === 'building' ? 'outline' : 'destructive'
+                                stats?.indexStatus === "active"
+                                    ? "default"
+                                    : stats?.indexStatus === "building"
+                                      ? "outline"
+                                      : "destructive"
                             }
                         >
-                            {stats?.indexStatus ?? 'unknown'}
+                            {loadState === "loading" ? "…" : (stats?.indexStatus ?? "unknown")}
                         </Badge>
                     </CardHeader>
                     <CardContent>
                         <div className="text-sm font-medium flex items-center gap-2">
-                            {stats?.indexStatus === 'active' ? (
-                                <><CheckCircle2 className="h-4 w-4 text-green-500" /> Vector Search Ready</>
-                            ) : stats?.indexStatus === 'building' ? (
-                                <><Clock className="h-4 w-4 text-amber-500 animate-pulse" /> Index Building...</>
+                            {stats?.indexStatus === "active" ? (
+                                <>
+                                    <CheckCircle2 className="h-4 w-4 text-green-500" /> Vector Search
+                                    Ready
+                                </>
+                            ) : stats?.indexStatus === "building" ? (
+                                <>
+                                    <Clock className="h-4 w-4 text-amber-500 animate-pulse" /> Index
+                                    Building…
+                                </>
                             ) : (
-                                <><AlertCircle className="h-4 w-4 text-red-500" /> Action Required</>
+                                <>
+                                    <AlertCircle className="h-4 w-4 text-red-500" /> Action Required
+                                </>
                             )}
                         </div>
                         <p className="text-xs text-muted-foreground mt-1">
-                            Atlas vector_search_index
+                            {process.env.NEXT_PUBLIC_MONGODB_VECTOR_INDEX || "vector_search_index"}
                         </p>
                     </CardContent>
                 </Card>
@@ -170,63 +218,100 @@ export function MongoDBDashboard({ integrationId }: MongoDBDashboardProps) {
                 <CardContent className="space-y-2 text-sm">
                     <div className="flex justify-between">
                         <span className="text-muted-foreground">Database Name:</span>
-                        <span className="font-mono">{stats?.database ?? '...'}</span>
+                        <span className="font-mono">{stats?.database ?? "—"}</span>
                     </div>
                     <div className="flex justify-between">
                         <span className="text-muted-foreground">Embedded Chunks:</span>
-                        <span>{stats?.embeddedChunks ?? '...'} / {stats?.chunks ?? '...'}</span>
+                        <span>
+                            {stats?.embeddedChunks ?? "—"} / {stats?.chunks ?? "—"}
+                        </span>
+                    </div>
+                    <div className="flex justify-between">
+                        <span className="text-muted-foreground">Embedding mode:</span>
+                        <span className="font-mono">{stats?.embeddingMode ?? "atlas"}</span>
+                    </div>
+                    <div className="flex justify-between">
+                        <span className="text-muted-foreground">Voyage API (search):</span>
+                        <span>{stats?.voyageConfigured ? "Configured" : "Missing on server"}</span>
                     </div>
                     <div className="flex justify-between border-t pt-2 mt-2">
-                        <span className="text-muted-foreground italic">Note: Embeddings are generated asynchronously via Atlas Triggers.</span>
+                        <span className="text-muted-foreground italic">
+                            Semantic search needs synced chunks with embeddings and an active vector
+                            index.
+                        </span>
                     </div>
                 </CardContent>
             </Card>
 
             <div className="space-y-4">
                 <h3 className="text-lg font-semibold">Semantic Search</h3>
-                <VectorSearch integrationId={integrationId} />
+                <VectorSearch
+                    integrationId={integrationId}
+                    searchReady={stats?.searchReady}
+                    setupHint={stats?.setupHint}
+                />
             </div>
         </div>
     )
 }
 
-function VectorSearch({ integrationId }: { integrationId: string | null }) {
+function VectorSearch({
+    integrationId,
+    searchReady,
+    setupHint,
+}: {
+    integrationId: string | null
+    searchReady?: boolean
+    setupHint?: string
+}) {
     const [query, setQuery] = useState("")
-    const [results, setResults] = useState<any[]>([])
+    const [results, setResults] = useState<
+        Array<{ content: string; score?: number; metadata?: Record<string, unknown> }>
+    >([])
     const [searching, setSearching] = useState(false)
+    const [lastSearchNote, setLastSearchNote] = useState<string | null>(null)
+
+    const searchPath = integrationId
+        ? `/integrations/${integrationId}/mongodb/search`
+        : "/integrations/mongodb/search"
 
     const handleSearch = async (e: React.FormEvent) => {
         e.preventDefault()
         if (!query.trim()) return
 
         setSearching(true)
+        setLastSearchNote(null)
+        setResults([])
         try {
-            const token = localStorage.getItem('auth_token') || localStorage.getItem('token')
-            const searchPath = integrationId
-                ? `/api/integrations/${integrationId}/mongodb/search`
-                : '/api/integrations/mongodb/search'
+            const data = await apiClient.post<{
+                success: boolean
+                matches?: Array<{
+                    content: string
+                    score?: number
+                    metadata?: Record<string, unknown>
+                }>
+                message?: string
+            }>(searchPath, { query: query.trim(), topK: 5 })
 
-            const response = await fetch(searchPath, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                },
-                body: JSON.stringify({ query, topK: 5 })
-            })
-
-            const data = await response.json()
             if (data.success) {
-                setResults(data.matches || [])
-                if (data.matches?.length === 0) {
+                const matches = data.matches ?? []
+                setResults(matches)
+                if (matches.length === 0) {
+                    setLastSearchNote(
+                        "No matches for this query. Try different wording or sync more documents."
+                    )
                     toast.info("No matching documents found")
                 }
             } else {
-                toast.error(data.message || "Search failed")
+                const msg = data.message || "Search failed"
+                setLastSearchNote(msg)
+                toast.error(msg)
             }
         } catch (error) {
             console.error("Search error:", error)
-            toast.error("Failed to perform search")
+            const msg = error instanceof Error ? error.message : "Failed to perform search"
+            setLastSearchNote(msg)
+            toast.error(msg)
         } finally {
             setSearching(false)
         }
@@ -241,13 +326,16 @@ function VectorSearch({ integrationId }: { integrationId: string | null }) {
                         Enter a query to search existing embeddings using vector similarity.
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-3">
+                    {searchReady === false && setupHint && (
+                        <p className="text-sm text-amber-600 dark:text-amber-500">{setupHint}</p>
+                    )}
                     <form onSubmit={handleSearch} className="flex gap-2">
                         <input
                             type="text"
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
-                            placeholder="e.g., 'What are the project requirements?'"
+                            placeholder="e.g., What are the project requirements?"
                             className="flex-1 px-3 py-2 border rounded-md text-sm bg-background"
                         />
                         <Button type="submit" disabled={searching}>
@@ -257,10 +345,13 @@ function VectorSearch({ integrationId }: { integrationId: string | null }) {
                                     Searching...
                                 </>
                             ) : (
-                                'Search'
+                                "Search"
                             )}
                         </Button>
                     </form>
+                    {lastSearchNote && (
+                        <p className="text-sm text-muted-foreground">{lastSearchNote}</p>
+                    )}
                 </CardContent>
             </Card>
 
@@ -271,7 +362,10 @@ function VectorSearch({ integrationId }: { integrationId: string | null }) {
                             <CardHeader className="py-3 bg-muted/20">
                                 <div className="flex justify-between items-start">
                                     <div className="text-sm font-medium text-muted-foreground">
-                                        Score: {(result.score * 100).toFixed(1)}%
+                                        Score:{" "}
+                                        {typeof result.score === "number"
+                                            ? `${(result.score * 100).toFixed(1)}%`
+                                            : "—"}
                                     </div>
                                     <Badge variant="outline" className="text-xs">
                                         Chunk {i + 1}
@@ -284,7 +378,8 @@ function VectorSearch({ integrationId }: { integrationId: string | null }) {
                                     <div className="mt-2 pt-2 border-t text-xs text-muted-foreground grid grid-cols-2 gap-2">
                                         {Object.entries(result.metadata).map(([key, value]) => (
                                             <div key={key}>
-                                                <span className="font-semibold">{key}:</span> {String(value)}
+                                                <span className="font-semibold">{key}:</span>{" "}
+                                                {String(value)}
                                             </div>
                                         ))}
                                     </div>

--- a/app/integrations/MongoDBSyncDialog.tsx
+++ b/app/integrations/MongoDBSyncDialog.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge"
 import { Loader2, CheckCircle2, XCircle } from "lucide-react"
 import { Database } from "@/components/ui/icons-shim"
 import { toast } from "sonner"
+import { apiClient } from "@/lib/api"
 
 interface Project {
     id: string
@@ -96,7 +97,7 @@ export function MongoDBSyncDialog({
                             ...prev,
                             ...data,
                             // Map DB status to UI status if needed
-                            status: data.status === 'connected' ? 'idle' : data.status
+                            status: data.status ?? 'idle',
                         }))
 
                         if (data.status === 'completed' || data.status === 'error') {
@@ -121,7 +122,12 @@ export function MongoDBSyncDialog({
     }, [polling, integrationId, onSyncComplete])
 
     const handleStartSync = async () => {
-        if (!integrationId || !projectId) return
+        if (!integrationId || integrationId.endsWith("-default") || !projectId) {
+            if (integrationId?.endsWith("-default")) {
+                toast.error("Enable MongoDB on the Overview tab before syncing.")
+            }
+            return
+        }
 
         try {
             setSyncStatus({
@@ -133,23 +139,13 @@ export function MongoDBSyncDialog({
             })
             setPolling(true)
 
-            const token = localStorage.getItem('auth_token') || localStorage.getItem('token')
             const bodyProjectId = projectId === "all" ? null : projectId
 
-            const response = await fetch(`/api/integrations/${integrationId}/sync`, {
-                method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${token}`
-                },
-                body: JSON.stringify({ projectId: bodyProjectId })
-            })
+            const data = await apiClient.post<{ success: boolean; message?: string }>(
+                `/integrations/${integrationId}/sync`,
+                { projectId: bodyProjectId }
+            )
 
-            if (!response.ok) {
-                throw new Error("Failed to start sync")
-            }
-
-            const data = await response.json()
             if (!data.success) {
                 throw new Error(data.message || "Sync failed to start")
             }
@@ -157,7 +153,8 @@ export function MongoDBSyncDialog({
             toast.success("Sync started")
         } catch (error) {
             console.error("Sync start error:", error)
-            toast.error("Failed to start sync")
+            const msg = error instanceof Error ? error.message : "Failed to start sync"
+            toast.error(msg)
             setPolling(false)
             setSyncStatus(prev => ({ ...prev, status: 'error' }))
         }

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -379,8 +379,10 @@ export default function Integrations() {
     try {
       setLoading(true)
       console.log("Loading integrations from backend...")
-      const response: any = await apiClient.getIntegrations()
-      const backendIntegrations = Array.isArray(response) ? response : response.integrations || [] // Handle both formats
+      const response: any = await apiClient.get("/integrations?limit=100")
+      const backendIntegrations = Array.isArray(response)
+        ? response
+        : response.integrations || response.data?.integrations || []
       console.log("Backend integrations:", backendIntegrations)
 
       // Handle case where API returns non-array data
@@ -1187,7 +1189,10 @@ export default function Integrations() {
         // Use the dedicated Notion sync function with project selection
         await handleNotionSync()
       } else if (integration.type === "mongodb") {
-        // Open MongoDB Sync Dialog
+        if (integration.id === "mongodb-default") {
+          toast.error("Enable MongoDB with the toggle first, then run Sync.")
+          return
+        }
         setMongoIntegrationToSync(integration.id)
         setMongoSyncDialogOpen(true)
       } else {

--- a/server/src/database/seed.ts
+++ b/server/src/database/seed.ts
@@ -86,6 +86,9 @@ async function seedDatabase() {
         "templates.create": true,
         "templates.update": true,
         "ai.generate": true,
+        "integrations.view": true,
+        "integrations.read": true,
+        "integrations.sync": true,
       })
     ])
 

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -191,7 +191,7 @@ export const authenticateToken = async (req: AuthRequest, res: Response, next: N
       id: user.id,
       email: user.email,
       role: user.role,
-      permissions: user.permissions,
+      permissions: normalizeUserPermissions(user.permissions),
     }
 
     // Update last login (best-effort; log but don't fail auth if update errors)
@@ -226,6 +226,20 @@ export const requireRole = (roles: string[]) => {
   }
 }
 
+function normalizeUserPermissions(permissions: unknown): Record<string, boolean> {
+  if (!permissions) {
+    return {}
+  }
+  if (typeof permissions === 'string') {
+    try {
+      return JSON.parse(permissions) as Record<string, boolean>
+    } catch {
+      return {}
+    }
+  }
+  return permissions as Record<string, boolean>
+}
+
 export const requirePermission = (permission: string) => {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     if (!req.user) {
@@ -238,13 +252,38 @@ export const requirePermission = (permission: string) => {
       return next()
     }
 
-    const userPermissions = req.user.permissions || {}
+    const userPermissions = normalizeUserPermissions(req.user.permissions)
     if (!userPermissions[permission]) {
       return res.status(403).json({ error: `Permission '${permission}' required` })
     }
 
     next()
   }
+}
+
+/** Read-only integration dashboards (MongoDB/Pinecone stats, search, sync status). */
+export const requireIntegrationReadAccess = (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  if (!req.user) {
+    return res.status(401).json({ error: "Authentication required" })
+  }
+
+  const userRole = req.user.role?.toLowerCase()
+  if (userRole === 'super_admin' || userRole === 'admin') {
+    return next()
+  }
+
+  const userPermissions = normalizeUserPermissions(req.user.permissions)
+  if (userPermissions['integrations.read'] || userPermissions['integrations.view']) {
+    return next()
+  }
+
+  return res.status(403).json({
+    error: "Permission 'integrations.read' or 'integrations.view' required",
+  })
 }
 
 // Backwards-compatible aliases used across the codebase and tests

--- a/server/src/routes/mongodbIntegrationRoutes.ts
+++ b/server/src/routes/mongodbIntegrationRoutes.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response } from 'express';
 import Joi from 'joi';
 import { pool } from '../database/connection';
-import { authenticateToken, requirePermission } from '../middleware/auth';
+import { authenticateToken, requireIntegrationReadAccess, requirePermission } from '../middleware/auth';
 import { validate } from '../middleware/validation';
 import { childLogger } from '../utils/logger';
 import { mongoVectorStore } from '../services/mongoVectorStore';
@@ -37,10 +37,40 @@ async function getIntegrationType(integrationId: string): Promise<string | null>
     return result.rows[0].type as string;
 }
 
+function buildMongoCapabilityFlags(stats: {
+    configured: boolean;
+    embeddedChunks: number;
+    indexStatus: string;
+}) {
+    const voyageConfigured = Boolean(process.env.VOYAGE_API_KEY);
+    const embeddingMode = (process.env.MONGODB_EMBEDDING_MODE || 'atlas').toLowerCase();
+    const searchReady =
+        stats.configured &&
+        voyageConfigured &&
+        stats.embeddedChunks > 0 &&
+        (stats.indexStatus === 'active' || stats.indexStatus === 'building');
+
+    let setupHint: string | undefined;
+    if (!stats.configured) {
+        setupHint = 'Set MONGODB_URI on the API server, then restart the backend.';
+    } else if (!voyageConfigured) {
+        setupHint = 'Set VOYAGE_API_KEY on the API server for semantic search embeddings.';
+    } else if (stats.embeddedChunks === 0) {
+        setupHint =
+            embeddingMode === 'server'
+                ? 'Run a MongoDB sync from the Integrations overview (embeddings are generated during sync).'
+                : 'Run a MongoDB sync, then wait for Atlas to finish embedding chunks (MONGODB_EMBEDDING_MODE=atlas).';
+    } else if (stats.indexStatus === 'missing') {
+        setupHint = 'Create the Atlas Vector Search index on the chunks collection.';
+    }
+
+    return { voyageConfigured, embeddingMode, searchReady, setupHint };
+}
+
 async function handleStats(_req: Request, res: Response) {
     try {
         if (!mongoVectorStore.isMongoConfigured()) {
-            return res.json({
+            const payload = {
                 documents: 0,
                 chunks: 0,
                 embeddedChunks: 0,
@@ -48,11 +78,18 @@ async function handleStats(_req: Request, res: Response) {
                 indexStatus: 'not_configured',
                 database: process.env.MONGODB_DB_NAME || 'adpa_rag',
                 configured: false,
+            };
+            return res.json({
+                ...payload,
+                ...buildMongoCapabilityFlags(payload),
             });
         }
 
         const stats = await mongoVectorStore.getStats();
-        return res.json(stats);
+        return res.json({
+            ...stats,
+            ...buildMongoCapabilityFlags(stats),
+        });
     } catch (error) {
         log.error('MongoDB stats failed', error);
         return res.status(503).json({
@@ -65,21 +102,21 @@ async function handleStats(_req: Request, res: Response) {
 router.get(
     '/mongodb/stats',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     handleStats
 );
 
 router.get(
     '/:integrationId/mongodb/stats',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     handleStats
 );
 
 router.get(
     '/:integrationId/pinecone/stats',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     async (_req: Request, res: Response) => {
         try {
             const { pineconeService } = await import('../services/pineconeService');
@@ -101,7 +138,7 @@ router.get(
 router.post(
     '/mongodb/search',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     validate(searchSchema),
     async (req: Request, res: Response) => {
         try {
@@ -121,7 +158,7 @@ router.post(
 router.post(
     '/:integrationId/mongodb/search',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     validate(searchSchema),
     async (req: Request, res: Response) => {
         try {
@@ -228,7 +265,7 @@ router.post(
 router.get(
     '/:integrationId/sync/status',
     authenticateToken,
-    requirePermission('integrations.read'),
+    requireIntegrationReadAccess,
     async (req: Request, res: Response) => {
         try {
             const { integrationId } = req.params;

--- a/server/src/services/mongoRagService.ts
+++ b/server/src/services/mongoRagService.ts
@@ -25,7 +25,11 @@ export async function searchMongoChunks(
     projectId?: string
 ): Promise<MongoSearchMatch[]> {
     if (!mongoVectorStore.isMongoConfigured()) {
-        throw new Error('MongoDB is not configured');
+        throw new Error('MongoDB is not configured (set MONGODB_URI on the API server)');
+    }
+
+    if (!process.env.VOYAGE_API_KEY) {
+        throw new Error('Semantic search requires VOYAGE_API_KEY on the API server');
     }
 
     await mongoVectorStore.connect();
@@ -42,6 +46,23 @@ export async function searchMongoChunks(
         topK,
         filters
     );
+
+    if (results.length === 0) {
+        const stats = await mongoVectorStore.getStats();
+        if (stats.chunks === 0) {
+            throw new Error(
+                'No vectors in MongoDB yet. Enable the integration on Overview, run Sync, then refresh stats.'
+            );
+        }
+        if (stats.embeddedChunks === 0) {
+            const mode = (process.env.MONGODB_EMBEDDING_MODE || 'atlas').toLowerCase();
+            throw new Error(
+                mode === 'server'
+                    ? 'Chunks exist but none have embeddings. Re-run sync with MONGODB_EMBEDDING_MODE=server.'
+                    : 'Chunks exist but none are embedded yet. Wait for Atlas triggers or switch to MONGODB_EMBEDDING_MODE=server.'
+            );
+        }
+    }
 
     return results.map((row) => ({
         content: row.content,


### PR DESCRIPTION
…ints

- Allow integrations.view for MongoDB stats/search (fixes 403 for demo users)
- Load integrations with limit=100 so MongoDB record is found
- Dashboard uses apiClient, shows setup/errors instead of blank placeholders
- Stats include voyageConfigured, searchReady, and setupHint
- Clearer search errors when no vectors or missing VOYAGE_API_KEY
- Block sync on placeholder mongodb-default until integration is enabled