### PR TITLE
fix(analysis): entity details dialog + Pinecone entity RAG sync

### DIFF
--- a/app/integrations/PineconeDashboard.tsx
+++ b/app/integrations/PineconeDashboard.tsx
@@ -353,7 +353,13 @@ export function PineconeDashboard({ integrationId }: PineconeDashboardProps) {
                         <span className="font-semibold text-blue-600">Score: {(match.score * 100).toFixed(1)}%</span>
                         <Badge variant="outline" className="text-[10px]">{match.metadata?.type || 'unknown'}</Badge>
                       </div>
-                      <p className="font-medium">{match.metadata?.title || match.metadata?.name || match.id}</p>
+                      <p className="font-medium">
+                        {match.metadata?.title ||
+                          match.metadata?.name ||
+                          (typeof match.metadata?.text === 'string'
+                            ? `${match.metadata.text.slice(0, 80)}${match.metadata.text.length > 80 ? '…' : ''}`
+                            : match.id)}
+                      </p>
                       {match.metadata?.text && (
                         <p className="text-xs text-muted-foreground line-clamp-2 mt-1">{match.metadata.text}</p>
                       )}

--- a/app/projects/[id]/components/ProjectDataExtraction.tsx
+++ b/app/projects/[id]/components/ProjectDataExtraction.tsx
@@ -647,7 +647,7 @@ export function ProjectDataExtraction({ projectId, documents }: ProjectDataExtra
       setShowEntityDialog(true)
 
       const { getApiUrl } = await import('@/lib/api-url')
-      const apiUrl = getApiUrl(`/project-data-extraction/entities/${projectId}/${entityType}?limit=100`)
+      const apiUrl = getApiUrl(`/project-data-extraction/entities/${projectId}/${entityType}?limit=500`)
       console.log('[ENTITY-DETAILS] Fetching:', apiUrl)
 
       const response = await fetch(apiUrl, {

--- a/server/src/modules/analysis/AnalysisController.ts
+++ b/server/src/modules/analysis/AnalysisController.ts
@@ -30,6 +30,7 @@ import { listDomainExtractionConfigs } from '@/modules/context';
 import { PMBOK_DOMAINS } from '@/types/pmbok';
 import { ENTITY_DOMAIN_WEIGHTS } from '../../types/entity-domain-weights';
 import { createInitialBatchProgressMeta, normalizeBatchingConfig } from '../../services/extraction/batchPlanner';
+import { ENTITY_COUNT_TABLES } from './entityTypeTables';
 
 export class AnalysisController {
   private repository = new AnalysisRepository(pool);
@@ -421,26 +422,46 @@ export class AnalysisController {
   getExtractionResults = async (req: Request, res: Response) => {
     try {
       const { projectId } = req.params;
-      const tables = [
-        { key: 'stakeholders', name: 'stakeholders' },
-        { key: 'requirements', name: 'requirements' },
-        { key: 'risks', name: 'risks' },
-        { key: 'milestones', name: 'milestones' },
-        { key: 'activities', name: 'activities' },
-        { key: 'deliverables', name: 'deliverables' },
-        { key: 'constraints', name: 'constraints' },
-        { key: 'success_criteria', name: 'success_criteria' },
-        { key: 'best_practices', name: 'best_practices' },
-        { key: 'team_agreements', name: 'team_agreements' },
-        { key: 'development_approaches', name: 'development_approaches' },
-        { key: 'work_items', name: 'work_items' },
-        { key: 'performance_actuals', name: 'performance_actuals' },
-      ];
-      const entityCounts = await this.repository.getProjectEntityCounts(projectId, tables);
+      const entityCounts = await this.repository.getProjectEntityCounts(projectId, ENTITY_COUNT_TABLES);
       res.json({ success: true, projectId, entityCounts });
     } catch (error) {
       this.logger.error('Extraction results fetch failed', { error });
       res.status(500).json({ error: 'Extraction results fetch failed' });
+    }
+  };
+
+  /**
+   * List entities for a project by type (used by ProjectDataExtraction entity detail dialog).
+   */
+  getEntitiesByType = async (req: Request, res: Response) => {
+    try {
+      const { projectId, entityType } = req.params;
+      const limit = Math.min(Math.max(parseInt(String(req.query.limit ?? '100'), 10) || 100, 1), 500);
+      const offset = Math.max(parseInt(String(req.query.offset ?? '0'), 10) || 0, 0);
+
+      const { entities, total, tableName } = await this.repository.getProjectEntitiesByType(
+        projectId,
+        entityType,
+        { limit, offset }
+      );
+
+      res.json({
+        success: true,
+        projectId,
+        entityType,
+        tableName,
+        entities,
+        total,
+        limit,
+        offset,
+      });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.startsWith('Unknown entity type:')) {
+        return res.status(400).json({ error: message });
+      }
+      this.logger.error('Entity details fetch failed', { error: message });
+      res.status(500).json({ error: 'Entity details fetch failed' });
     }
   };
 }

--- a/server/src/modules/analysis/AnalysisRepository.ts
+++ b/server/src/modules/analysis/AnalysisRepository.ts
@@ -1,5 +1,6 @@
 import { Pool, PoolClient } from 'pg';
 import { childLogger } from '../../utils/logger';
+import { resolveEntityTableName } from './entityTypeTables';
 
 export class AnalysisRepository {
   private logger = childLogger({ component: 'AnalysisRepository' });
@@ -223,5 +224,52 @@ export class AnalysisRepository {
     }
     
     return counts;
+  }
+
+  /**
+   * Fetch extracted entities for a project from the typed entity table.
+   */
+  async getProjectEntitiesByType(
+    projectId: string,
+    entityTypeKey: string,
+    options?: { limit?: number; offset?: number }
+  ): Promise<{ entities: Record<string, unknown>[]; total: number; tableName: string }> {
+    const tableName = resolveEntityTableName(entityTypeKey);
+    if (!tableName) {
+      throw new Error(`Unknown entity type: ${entityTypeKey}`);
+    }
+
+    const limit = Math.min(Math.max(options?.limit ?? 100, 1), 500);
+    const offset = Math.max(options?.offset ?? 0, 0);
+
+    const countResult = await this.pool.query(
+      `SELECT COUNT(*)::int AS count FROM ${tableName} WHERE project_id = $1`,
+      [projectId]
+    );
+    const total = countResult.rows[0]?.count ?? 0;
+
+    try {
+      const result = await this.pool.query(
+        `SELECT * FROM ${tableName}
+         WHERE project_id = $1
+         ORDER BY created_at DESC NULLS LAST, id DESC
+         LIMIT $2 OFFSET $3`,
+        [projectId, limit, offset]
+      );
+      return { entities: result.rows, total, tableName };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('created_at')) {
+        const result = await this.pool.query(
+          `SELECT * FROM ${tableName}
+           WHERE project_id = $1
+           ORDER BY id DESC
+           LIMIT $2 OFFSET $3`,
+          [projectId, limit, offset]
+        );
+        return { entities: result.rows, total, tableName };
+      }
+      throw error;
+    }
   }
 }

--- a/server/src/modules/analysis/AnalysisRepository.ts
+++ b/server/src/modules/analysis/AnalysisRepository.ts
@@ -1,6 +1,9 @@
 import { Pool, PoolClient } from 'pg';
 import { childLogger } from '../../utils/logger';
-import { resolveEntityTableName } from './entityTypeTables';
+import {
+  getAllowedEntityTableName,
+  quotedEntityTableName,
+} from './entityTypeTables';
 
 export class AnalysisRepository {
   private logger = childLogger({ component: 'AnalysisRepository' });
@@ -212,8 +215,9 @@ export class AnalysisRepository {
     
     for (const table of tables) {
       try {
+        const fromTable = quotedEntityTableName(table.name);
         const result = await this.pool.query(
-          `SELECT COUNT(*) as count FROM ${table.name} WHERE project_id = $1`,
+          `SELECT COUNT(*) as count FROM ${fromTable} WHERE project_id = $1`,
           [projectId]
         );
         counts[table.key] = parseInt(result.rows[0].count) || 0;
@@ -234,23 +238,21 @@ export class AnalysisRepository {
     entityTypeKey: string,
     options?: { limit?: number; offset?: number }
   ): Promise<{ entities: Record<string, unknown>[]; total: number; tableName: string }> {
-    const tableName = resolveEntityTableName(entityTypeKey);
-    if (!tableName) {
-      throw new Error(`Unknown entity type: ${entityTypeKey}`);
-    }
+    const tableName = getAllowedEntityTableName(entityTypeKey);
+    const fromTable = quotedEntityTableName(tableName);
 
     const limit = Math.min(Math.max(options?.limit ?? 100, 1), 500);
     const offset = Math.max(options?.offset ?? 0, 0);
 
     const countResult = await this.pool.query(
-      `SELECT COUNT(*)::int AS count FROM ${tableName} WHERE project_id = $1`,
+      `SELECT COUNT(*)::int AS count FROM ${fromTable} WHERE project_id = $1`,
       [projectId]
     );
     const total = countResult.rows[0]?.count ?? 0;
 
     try {
       const result = await this.pool.query(
-        `SELECT * FROM ${tableName}
+        `SELECT * FROM ${fromTable}
          WHERE project_id = $1
          ORDER BY created_at DESC NULLS LAST, id DESC
          LIMIT $2 OFFSET $3`,
@@ -261,7 +263,7 @@ export class AnalysisRepository {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes('created_at')) {
         const result = await this.pool.query(
-          `SELECT * FROM ${tableName}
+          `SELECT * FROM ${fromTable}
            WHERE project_id = $1
            ORDER BY id DESC
            LIMIT $2 OFFSET $3`,

--- a/server/src/modules/analysis/__tests__/entityTypeTables.test.ts
+++ b/server/src/modules/analysis/__tests__/entityTypeTables.test.ts
@@ -1,4 +1,10 @@
-import { resolveEntityTableName, ENTITY_CAMEL_KEY_TO_TABLE } from '../entityTypeTables'
+import {
+  resolveEntityTableName,
+  ENTITY_CAMEL_KEY_TO_TABLE,
+  getAllowedEntityTableName,
+  quotedEntityTableName,
+  assertAllowedEntityTableName,
+} from '../entityTypeTables'
 
 describe('entityTypeTables', () => {
   it('maps camelCase frontend keys to database tables', () => {
@@ -18,5 +24,22 @@ describe('entityTypeTables', () => {
 
   it('covers all extraction entity tables', () => {
     expect(Object.keys(ENTITY_CAMEL_KEY_TO_TABLE).length).toBeGreaterThanOrEqual(60)
+  })
+
+  it('getAllowedEntityTableName rejects unknown types', () => {
+    expect(() => getAllowedEntityTableName('notAnEntity')).toThrow(/Unknown entity type/)
+  })
+
+  it('quotedEntityTableName rejects injection-like names', () => {
+    expect(() => quotedEntityTableName('requirements; DROP TABLE users')).toThrow(
+      /Invalid entity table/
+    )
+    expect(() => quotedEntityTableName('not_on_whitelist')).toThrow(/Invalid entity table/)
+  })
+
+  it('quotedEntityTableName returns double-quoted identifiers for allowed tables', () => {
+    expect(quotedEntityTableName('requirements')).toBe('"requirements"')
+    expect(getAllowedEntityTableName('successCriteria')).toBe('success_criteria')
+    assertAllowedEntityTableName('success_criteria')
   })
 })

--- a/server/src/modules/analysis/__tests__/entityTypeTables.test.ts
+++ b/server/src/modules/analysis/__tests__/entityTypeTables.test.ts
@@ -1,0 +1,22 @@
+import { resolveEntityTableName, ENTITY_CAMEL_KEY_TO_TABLE } from '../entityTypeTables'
+
+describe('entityTypeTables', () => {
+  it('maps camelCase frontend keys to database tables', () => {
+    expect(resolveEntityTableName('requirements')).toBe('requirements')
+    expect(resolveEntityTableName('successCriteria')).toBe('success_criteria')
+    expect(resolveEntityTableName('earnedValueMetrics')).toBe('earned_value_metrics')
+    expect(resolveEntityTableName('scopeBaselines')).toBe('scope_baselines')
+  })
+
+  it('accepts snake_case table names', () => {
+    expect(resolveEntityTableName('success_criteria')).toBe('success_criteria')
+  })
+
+  it('rejects unknown types', () => {
+    expect(resolveEntityTableName('notAnEntity')).toBeNull()
+  })
+
+  it('covers all extraction entity tables', () => {
+    expect(Object.keys(ENTITY_CAMEL_KEY_TO_TABLE).length).toBeGreaterThanOrEqual(60)
+  })
+})

--- a/server/src/modules/analysis/entityTypeTables.ts
+++ b/server/src/modules/analysis/entityTypeTables.ts
@@ -1,0 +1,96 @@
+/**
+ * Maps frontend camelCase entity keys to PostgreSQL table names.
+ * Table names align with ExtractionOrchestrationService fallback counts (safeCount list).
+ */
+export const ENTITY_CAMEL_KEY_TO_TABLE: Record<string, string> = {
+  stakeholders: 'stakeholders',
+  requirements: 'requirements',
+  risks: 'risks',
+  milestones: 'milestones',
+  constraints: 'constraints',
+  successCriteria: 'success_criteria',
+  bestPractices: 'best_practices',
+  phases: 'phases',
+  resources: 'resources',
+  technologies: 'technologies',
+  qualityStandards: 'quality_standards',
+  complianceSecurity: 'compliance_security',
+  deliverables: 'deliverables',
+  scopeItems: 'scope_items',
+  activities: 'activities',
+  teamAgreements: 'team_agreements',
+  developmentApproaches: 'development_approaches',
+  projectIterations: 'project_iterations',
+  workItems: 'work_items',
+  capacityPlans: 'capacity_plans',
+  performanceMeasurements: 'performance_measurements',
+  earnedValueMetrics: 'earned_value_metrics',
+  opportunities: 'opportunities',
+  riskResponses: 'risk_responses',
+  performanceActuals: 'performance_actuals',
+  governanceDecisions: 'governance_decisions',
+  approvalWorkflows: 'approval_workflows',
+  steeringCommittees: 'steering_committees',
+  changeControlBoards: 'change_control_boards',
+  policyCompliance: 'policy_compliance',
+  scopeBaselines: 'scope_baselines',
+  wbsNodes: 'wbs_nodes',
+  scopeChangeRequests: 'scope_change_requests',
+  requirementsTraceability: 'requirements_traceability',
+  scopeVerification: 'scope_verification',
+  scheduleBaselines: 'schedule_baselines',
+  scheduleActivities: 'schedule_activities',
+  criticalPathActivities: 'critical_path_activities',
+  scheduleVariances: 'schedule_variances',
+  scheduleForecasts: 'schedule_forecasts',
+  budgetBaselines: 'budget_baselines',
+  costActuals: 'cost_actuals',
+  costEstimates: 'cost_estimates',
+  fundingTranches: 'funding_tranches',
+  financialVariances: 'financial_variances',
+  procurementCosts: 'procurement_costs',
+  resourceAssignments: 'resource_assignments',
+  resourcePool: 'resource_pool',
+  capacityForecasts: 'capacity_forecasts',
+  utilizationRecords: 'utilization_records',
+  resourceConflicts: 'resource_conflicts',
+  onboardingOffboarding: 'onboarding_offboarding',
+  riskAssessments: 'risk_assessments',
+  riskResponsePlans: 'risk_response_plans',
+  riskTriggers: 'risk_triggers',
+  riskReviews: 'risk_reviews',
+  contingencyReserves: 'contingency_reserves',
+  riskMetrics: 'risk_metrics',
+  engagementActions: 'engagement_actions',
+  communicationLogs: 'communication_logs',
+  satisfactionSurveys: 'satisfaction_surveys',
+  stakeholderIssues: 'stakeholder_issues',
+  relationshipHealth: 'relationship_health',
+  dtAssets: 'dt_assets',
+}
+
+const ALLOWED_TABLES = new Set(Object.values(ENTITY_CAMEL_KEY_TO_TABLE))
+
+/** Tables used for project-level entity count queries ({ key, name }). */
+export const ENTITY_COUNT_TABLES = Object.entries(ENTITY_CAMEL_KEY_TO_TABLE).map(([key, name]) => ({
+  key,
+  name,
+}))
+
+/**
+ * Resolve a frontend entity type key (camelCase) or snake_case table name to a DB table.
+ */
+export function resolveEntityTableName(entityTypeKey: string): string | null {
+  if (!entityTypeKey || typeof entityTypeKey !== 'string') return null
+
+  const trimmed = entityTypeKey.trim()
+  if (ENTITY_CAMEL_KEY_TO_TABLE[trimmed]) {
+    return ENTITY_CAMEL_KEY_TO_TABLE[trimmed]
+  }
+
+  if (ALLOWED_TABLES.has(trimmed)) {
+    return trimmed
+  }
+
+  return null
+}

--- a/server/src/modules/analysis/entityTypeTables.ts
+++ b/server/src/modules/analysis/entityTypeTables.ts
@@ -71,6 +71,9 @@ export const ENTITY_CAMEL_KEY_TO_TABLE: Record<string, string> = {
 
 const ALLOWED_TABLES = new Set(Object.values(ENTITY_CAMEL_KEY_TO_TABLE))
 
+/** Safe PostgreSQL unquoted identifiers (lowercase snake_case entity tables). */
+const PG_IDENTIFIER_RE = /^[a-z][a-z0-9_]*$/
+
 /** Tables used for project-level entity count queries ({ key, name }). */
 export const ENTITY_COUNT_TABLES = Object.entries(ENTITY_CAMEL_KEY_TO_TABLE).map(([key, name]) => ({
   key,
@@ -93,4 +96,37 @@ export function resolveEntityTableName(entityTypeKey: string): string | null {
   }
 
   return null
+}
+
+/**
+ * Assert table name is on the entity whitelist and matches safe identifier rules.
+ * Use before interpolating a table name into SQL (values still use $1, $2, …).
+ */
+export function assertAllowedEntityTableName(tableName: string): void {
+  if (!ALLOWED_TABLES.has(tableName)) {
+    throw new Error(`Invalid entity table: ${tableName}`)
+  }
+  if (!PG_IDENTIFIER_RE.test(tableName)) {
+    throw new Error(`Invalid entity table identifier: ${tableName}`)
+  }
+}
+
+/**
+ * Resolve entity type key to a whitelist-validated table name for SQL FROM clauses.
+ */
+export function getAllowedEntityTableName(entityTypeKey: string): string {
+  const tableName = resolveEntityTableName(entityTypeKey)
+  if (!tableName) {
+    throw new Error(`Unknown entity type: ${entityTypeKey}`)
+  }
+  assertAllowedEntityTableName(tableName)
+  return tableName
+}
+
+/**
+ * Double-quoted PostgreSQL identifier for a whitelist-validated entity table.
+ */
+export function quotedEntityTableName(tableName: string): string {
+  assertAllowedEntityTableName(tableName)
+  return `"${tableName}"`
 }

--- a/server/src/modules/analysis/routes.ts
+++ b/server/src/modules/analysis/routes.ts
@@ -23,6 +23,7 @@ router.post("/extract", authenticateToken, requirePermission("ai.generate"), con
 router.get("/status/:jobId", authenticateToken, controller.getJobStatus);
 router.get("/summary/:projectId", authenticateToken, controller.getSummary);
 router.get("/results/:projectId", authenticateToken, controller.getExtractionResults);
+router.get("/entities/:projectId/:entityType", authenticateToken, controller.getEntitiesByType);
 router.post("/trigger-baseline", authenticateToken, controller.triggerBaseline);
 
 const analysisRoutes: RouteConfig[] = [

--- a/server/src/routes/integrationPineconeRoutes.ts
+++ b/server/src/routes/integrationPineconeRoutes.ts
@@ -1,0 +1,245 @@
+/**
+ * Pinecone integration analytics + sync (Integrations UI).
+ * Mounted at /api/integrations — paths must be registered before generic /:id CRUD
+ * if those ever broaden to wildcards.
+ */
+
+import { Router, Request, Response } from "express"
+import { authenticateToken, requirePermission } from "../middleware/auth"
+import { pool } from "../database/connection"
+import { logger } from "../utils/logger"
+import { PineconeService, pineconeService, normalizePineconeHost } from "../services/pineconeService"
+
+const router = Router()
+
+type IntegrationRow = {
+  id: string
+  type: string
+  configuration: Record<string, unknown> | null
+  credentials_encrypted: string | null
+}
+
+function parseIntegrationConfig(raw: unknown): Record<string, unknown> {
+  if (!raw) return {}
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+function parseCredentials(raw: string | null): Record<string, unknown> {
+  if (!raw) return {}
+  try {
+    const decoded = Buffer.from(raw, "base64").toString("utf-8")
+    return JSON.parse(decoded) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+function resolvePineconeService(integration: IntegrationRow): PineconeService {
+  const config = parseIntegrationConfig(integration.configuration)
+  const credentials = parseCredentials(integration.credentials_encrypted)
+
+  const apiKey =
+    (typeof credentials.apiKey === "string" && credentials.apiKey) ||
+    (typeof credentials.api_key === "string" && credentials.api_key) ||
+    process.env.PINECONE_API_KEY
+
+  const indexName =
+    (typeof config.indexName === "string" && config.indexName) ||
+    (typeof config.index_name === "string" && config.index_name) ||
+    process.env.PINECONE_INDEX_NAME
+
+  const indexHost =
+    normalizePineconeHost(typeof config.host === "string" ? config.host : undefined) ||
+    normalizePineconeHost(typeof config.indexHost === "string" ? config.indexHost : undefined) ||
+    normalizePineconeHost(process.env.PINECONE_INDEX_HOST)
+
+  if (!apiKey) {
+    return pineconeService
+  }
+
+  return new PineconeService({
+    apiKey,
+    indexName: indexName || undefined,
+    indexHost: indexHost || undefined,
+  })
+}
+
+async function loadIntegration(integrationId: string): Promise<IntegrationRow | null> {
+  const result = await pool.query(
+    `SELECT id, type, configuration, credentials_encrypted FROM integrations WHERE id = $1`,
+    [integrationId]
+  )
+  return (result.rows[0] as IntegrationRow | undefined) ?? null
+}
+
+function normalizeNamespaces(
+  namespaces: Record<string, { recordCount?: number; vectorCount?: number }> | undefined
+): Record<string, { vectorCount: number }> {
+  const out: Record<string, { vectorCount: number }> = {}
+  if (!namespaces) return out
+  for (const [key, data] of Object.entries(namespaces)) {
+    const count = data?.recordCount ?? data?.vectorCount ?? 0
+    out[key] = { vectorCount: count }
+  }
+  return out
+}
+
+/**
+ * GET /api/integrations/:integrationId/pinecone/stats
+ */
+router.get(
+  "/:integrationId/pinecone/stats",
+  authenticateToken,
+  requirePermission("integrations.read"),
+  async (req: Request, res: Response) => {
+    try {
+      const { integrationId } = req.params
+      const integration = await loadIntegration(integrationId)
+
+      if (!integration) {
+        return res.status(404).json({ error: "Integration not found" })
+      }
+      if (integration.type !== "pinecone") {
+        return res.status(400).json({ error: "Integration is not a Pinecone integration" })
+      }
+
+      const service = resolvePineconeService(integration)
+      const config = parseIntegrationConfig(integration.configuration)
+
+      const connected = await service.testConnection()
+      if (!connected) {
+        return res.status(503).json({
+          error: "Pinecone connection failed",
+          indexName: config.indexName ?? process.env.PINECONE_INDEX_NAME ?? null,
+          environment: config.environment ?? process.env.PINECONE_ENVIRONMENT ?? null,
+        })
+      }
+
+      const indexStats = await service.getIndexStats()
+      if (!indexStats) {
+        return res.status(503).json({ error: "Failed to read Pinecone index statistics" })
+      }
+
+      return res.json({
+        indexStats: {
+          totalVectorCount: indexStats.totalVectorCount ?? 0,
+          dimensionCount: indexStats.dimensionCount ?? 1024,
+          indexFullness: indexStats.indexFullness ?? 0,
+          namespaces: normalizeNamespaces(indexStats.namespaces),
+        },
+        indexName:
+          (typeof config.indexName === "string" && config.indexName) ||
+          process.env.PINECONE_INDEX_NAME ||
+          "unknown",
+        environment:
+          (typeof config.environment === "string" && config.environment) ||
+          process.env.PINECONE_ENVIRONMENT ||
+          "unknown",
+      })
+    } catch (error) {
+      logger.error("Pinecone integration stats failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return res.status(500).json({ error: "Internal server error" })
+    }
+  }
+)
+
+/**
+ * POST /api/integrations/:integrationId/pinecone/search
+ */
+router.post(
+  "/:integrationId/pinecone/search",
+  authenticateToken,
+  requirePermission("integrations.sync"),
+  async (req: Request, res: Response) => {
+    try {
+      const { integrationId } = req.params
+      const { query, namespace, topK } = req.body as {
+        query?: string
+        namespace?: string
+        topK?: number
+      }
+
+      if (!query || typeof query !== "string" || !query.trim()) {
+        return res.status(400).json({ error: "query is required" })
+      }
+
+      const integration = await loadIntegration(integrationId)
+      if (!integration) {
+        return res.status(404).json({ error: "Integration not found" })
+      }
+      if (integration.type !== "pinecone") {
+        return res.status(400).json({ error: "Integration is not a Pinecone integration" })
+      }
+
+      const service = resolvePineconeService(integration)
+      const ns = typeof namespace === "string" && namespace.length > 0 ? namespace : undefined
+      const matches = await service.search(query.trim(), topK ?? 5, undefined, ns)
+
+      return res.json({ matches })
+    } catch (error) {
+      logger.error("Pinecone integration search failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return res.status(500).json({ error: "Search failed" })
+    }
+  }
+)
+
+/**
+ * POST /api/integrations/:integrationId/sync
+ * Pinecone: bulk upsert projects/documents/chunks from Postgres + Mongo.
+ */
+router.post(
+  "/:integrationId/sync",
+  authenticateToken,
+  requirePermission("integrations.sync"),
+  async (req: Request, res: Response) => {
+    try {
+      const { integrationId } = req.params
+      const { projectId } = (req.body as { projectId?: string }) ?? {}
+
+      const integration = await loadIntegration(integrationId)
+      if (!integration) {
+        return res.status(404).json({ error: "Integration not found" })
+      }
+
+      if (integration.type !== "pinecone") {
+        return res.status(400).json({
+          error: `Sync for integration type "${integration.type}" is not implemented on this endpoint`,
+        })
+      }
+
+      const service = resolvePineconeService(integration)
+      const result = await service.syncAll(projectId)
+
+      if (integration.id) {
+        await pool.query(
+          `UPDATE integrations SET last_sync = CURRENT_TIMESTAMP, sync_status = $2 WHERE id = $1`,
+          [integration.id, result.success ? "success" : "error"]
+        )
+      }
+
+      return res.json(result)
+    } catch (error) {
+      logger.error("Pinecone integration sync failed", {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return res.status(500).json({
+        success: false,
+        details: { error: error instanceof Error ? error.message : String(error) },
+      })
+    }
+  }
+)
+
+export default router

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -81,6 +81,7 @@ import executionModuleRoutes from "./modules/execution/routes"
 import templatesModuleRoutes from "./modules/templates/routes"
 import intelligenceModuleRoutes from "./modules/intelligence/routes"
 import integrationsModuleRoutes from "./modules/integrations/routes"
+import integrationPineconeRoutes from "./routes/integrationPineconeRoutes"
 import adobePdfRoutes from "./routes/adobe-pdf"
 import { createDocumentFormatRoutes } from "./routes/document-formats"
 import contextAiRoutes from "./routes/context-ai"
@@ -281,6 +282,8 @@ if (portfolioModuleRoutes && portfolioModuleRoutes[0]) {
 }
 if (templatesModuleRoutes && templatesModuleRoutes[0]) app.use("/api/templates", templatesModuleRoutes[0].router)
 if (intelligenceModuleRoutes && intelligenceModuleRoutes[0]) app.use("/api/analytics", intelligenceModuleRoutes[0].router)
+// Pinecone stats/search/sync — register before generic /:id CRUD
+app.use("/api/integrations", integrationPineconeRoutes)
 if (integrationsModuleRoutes && integrationsModuleRoutes[0]) app.use("/api/integrations", integrationsModuleRoutes[0].router)
 if (documentModuleRoutes && documentModuleRoutes[0]) app.use("/api/documents", documentModuleRoutes[0].router)
 if (analysisModuleRoutes && analysisModuleRoutes[0]) {

--- a/server/src/services/discoveryService.ts
+++ b/server/src/services/discoveryService.ts
@@ -32,7 +32,7 @@ export class DiscoveryService {
         const internalResults = await pineconeService.search(query, limit)
         results.push(...internalResults.map((r: any) => ({
           title: r.metadata?.title || r.metadata?.name || 'Internal Document',
-          content: r.metadata?.content || r.metadata?.description || '',
+          content: r.metadata?.text || r.metadata?.content || r.metadata?.description || '',
           source: 'internal' as const,
           score: r.score,
           metadata: r.metadata

--- a/server/src/services/pineconeEntitySync.ts
+++ b/server/src/services/pineconeEntitySync.ts
@@ -1,0 +1,331 @@
+import type { Pool } from 'pg';
+import { logger } from '../utils/logger';
+
+export interface PineconeEntityRow {
+  id: string;
+  entity_type: string;
+  name: string;
+  project_id: string;
+  source_document_id: string | null;
+  source_document_title: string;
+  description: string;
+  confidence: number;
+  created_at: string;
+}
+
+type EntityFetchDefinition = {
+  entityType: string;
+  sql: string;
+};
+
+/**
+ * Typed domain tables synced into Pinecone `entities` namespace.
+ * Each row includes project_id, entity_type, and document source origin.
+ */
+const ENTITY_FETCH_DEFINITIONS: EntityFetchDefinition[] = [
+  {
+    entityType: 'stakeholders',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(NULLIF(name, ''), role, 'Unnamed stakeholder') AS entity_name,
+      LEFT(TRIM(COALESCE(role, '') || ' ' || COALESCE(expectations, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM stakeholders WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'requirements',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(NULLIF(name, ''), title, 'Unnamed requirement') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM requirements WHERE deleted_at IS NULL AND ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'risks',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed risk') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM risks WHERE deleted_at IS NULL AND ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'milestones',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed milestone') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM milestones WHERE deleted_at IS NULL AND ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'constraints',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(NULLIF(name, ''), title, 'Unnamed constraint') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM constraints WHERE deleted_at IS NULL AND ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'success_criteria',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed success criterion') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM success_criteria WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'best_practices',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed best practice') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM best_practices WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'phases',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed phase') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM phases WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'resources',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed resource') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM resources WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'technologies',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed technology') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM technologies WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'quality_standards',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed quality standard') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM quality_standards WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'deliverables',
+    sql: `SELECT id, project_id,
+      COALESCE(source_document_id, extracted_from_document_id) AS source_document_id,
+      COALESCE(name, 'Unnamed deliverable') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, confidence_score
+      FROM deliverables WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'scope_items',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed scope item') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM scope_items WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'activities',
+    sql: `SELECT id, project_id,
+      COALESCE(source_document_id, extracted_from_document_id) AS source_document_id,
+      COALESCE(NULLIF(name, ''), activity_name, 'Unnamed activity') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, confidence_score
+      FROM activities WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'team_agreements',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed team agreement') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM team_agreements WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'development_approaches',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed development approach') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM development_approaches WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'project_iterations',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed iteration') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM project_iterations WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'work_items',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed work item') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM work_items WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'capacity_plans',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed capacity plan') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM capacity_plans WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'performance_measurements',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed performance measurement') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM performance_measurements WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'earned_value_metrics',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed earned value metric') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM earned_value_metrics WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'opportunities',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed opportunity') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM opportunities WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'risk_responses',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed risk response') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM risk_responses WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+  {
+    entityType: 'performance_actuals',
+    sql: `SELECT id, project_id, source_document_id,
+      COALESCE(name, 'Unnamed performance actual') AS entity_name,
+      LEFT(TRIM(COALESCE(description, '') || ' ' || COALESCE(source_snippet, '')), 1500) AS entity_text,
+      created_at, NULL::numeric AS confidence_score
+      FROM performance_actuals WHERE ($1::uuid IS NULL OR project_id = $1)`,
+  },
+];
+
+async function loadDocumentTitles(
+  pgPool: Pool,
+  documentIds: string[]
+): Promise<Map<string, string>> {
+  const titles = new Map<string, string>();
+  if (documentIds.length === 0) return titles;
+
+  const uniqueIds = [...new Set(documentIds.filter(Boolean))];
+  const chunkSize = 500;
+
+  for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+    const chunk = uniqueIds.slice(i, i + chunkSize);
+    const result = await pgPool.query<{ id: string; title: string }>(
+      `SELECT id, COALESCE(NULLIF(title, ''), name, 'Untitled document') AS title
+       FROM documents
+       WHERE id = ANY($1::uuid[])`,
+      [chunk]
+    );
+    for (const row of result.rows) {
+      titles.set(row.id, row.title);
+    }
+  }
+
+  return titles;
+}
+
+export async function fetchEntitiesForPinecone(
+  pgPool: Pool,
+  projectId?: string
+): Promise<PineconeEntityRow[]> {
+  const projectParam = projectId ?? null;
+  const rows: PineconeEntityRow[] = [];
+  const documentIds: string[] = [];
+
+  for (const definition of ENTITY_FETCH_DEFINITIONS) {
+    try {
+      const result = await pgPool.query(definition.sql, [projectParam]);
+      for (const row of result.rows) {
+        const sourceDocumentId = row.source_document_id ?? null;
+        if (sourceDocumentId) {
+          documentIds.push(sourceDocumentId);
+        }
+
+        rows.push({
+          id: String(row.id),
+          entity_type: definition.entityType,
+          name: String(row.entity_name ?? '').trim() || definition.entityType,
+          project_id: String(row.project_id),
+          source_document_id: sourceDocumentId,
+          source_document_title: '',
+          description: String(row.entity_text ?? '').trim(),
+          confidence: row.confidence_score != null ? Number(row.confidence_score) : 0.85,
+          created_at: row.created_at
+            ? new Date(row.created_at).toISOString()
+            : new Date().toISOString(),
+        });
+      }
+    } catch (error) {
+      logger.debug('Skipping Pinecone entity table during sync', {
+        entityType: definition.entityType,
+        error: (error as Error).message,
+      });
+    }
+  }
+
+  const documentTitles = await loadDocumentTitles(pgPool, documentIds);
+  for (const row of rows) {
+    if (row.source_document_id) {
+      row.source_document_title = documentTitles.get(row.source_document_id) ?? '';
+    }
+  }
+
+  logger.info('Fetched entities for Pinecone sync', {
+    projectId: projectId ?? 'all',
+    total: rows.length,
+    byType: rows.reduce<Record<string, number>>((acc, row) => {
+      acc[row.entity_type] = (acc[row.entity_type] ?? 0) + 1;
+      return acc;
+    }, {}),
+  });
+
+  return rows;
+}
+
+export function entityRowToPineconeRecord(entity: PineconeEntityRow) {
+  const sourceLabel = entity.source_document_title || entity.source_document_id || '';
+  const text = [
+    entity.name,
+    entity.entity_type.replace(/_/g, ' '),
+    entity.description,
+    sourceLabel ? `Source document: ${sourceLabel}` : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  return {
+    _id: `entity_${entity.entity_type}_${entity.id}`,
+    text,
+    type: 'entity',
+    name: entity.name,
+    entity_type: entity.entity_type,
+    project_id: entity.project_id,
+    source_document_id: entity.source_document_id ?? '',
+    source_document_title: entity.source_document_title,
+    document_id: entity.source_document_id ?? '',
+    confidence: entity.confidence,
+    created_at: entity.created_at,
+  };
+}

--- a/server/src/services/pineconeService.ts
+++ b/server/src/services/pineconeService.ts
@@ -1,5 +1,27 @@
-import { Pinecone, PineconeRecord } from '@pinecone-database/pinecone';
+import { Pinecone } from '@pinecone-database/pinecone';
 import { logger } from '../utils/logger';
+
+const INTEGRATED_SEARCH_NAMESPACES = ['projects', 'documents', 'entities'] as const;
+
+export function normalizePineconeHost(raw?: string | null): string | undefined {
+  if (!raw || typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.replace(/^https?:\/\//i, '').replace(/\/$/, '');
+}
+
+function mapSearchHit(hit: {
+  _id?: string;
+  _score?: number;
+  fields?: Record<string, unknown>;
+}) {
+  const metadata = (hit.fields ?? {}) as Record<string, unknown>;
+  return {
+    id: hit._id,
+    score: hit._score ?? 0,
+    metadata,
+  };
+}
 
 interface PineconeConfig {
   apiKey: string;
@@ -87,10 +109,10 @@ export class PineconeService {
 
     this.indexName = config?.indexName || process.env.PINECONE_INDEX_NAME || 'adpa-rag-index';
 
-    const normalizedConfigHost = typeof config?.indexHost === 'string' ? config.indexHost.trim() : undefined;
-    const normalizedEnvHost = typeof process.env.PINECONE_INDEX_HOST === 'string'
-      ? process.env.PINECONE_INDEX_HOST.trim()
-      : undefined;
+    const normalizedConfigHost = normalizePineconeHost(
+      typeof config?.indexHost === 'string' ? config.indexHost : undefined
+    );
+    const normalizedEnvHost = normalizePineconeHost(process.env.PINECONE_INDEX_HOST);
 
     // If config is provided and omits host, prefer auto-discovery instead of falling back to env host.
     const host = config
@@ -264,17 +286,27 @@ export class PineconeService {
       logger.info('Starting entity upsert with integrated embedding', { entitiesCount: entities.length });
 
       // Use integrated embedding with correct record format from documentation
-      const records = entities.map(entity => ({
-        _id: `entity_${entity.id || entity.name}`, // Use _id as required by upsert_records
-        text: `${entity.name} ${entity.type || entity.entity_type || ''} ${entity.description || ''}`.trim(), // Combined text for embedding
-        type: 'entity',
-        name: entity.name,
-        entity_type: entity.type || entity.entity_type || 'unknown',
-        confidence: entity.confidence || 0.85,
-        document_id: entity.document_id || '',
-        project_id: entity.project_id || '',
-        created_at: entity.created_at || new Date().toISOString()
-      })).filter(r => r.text.length > 0);
+      const { entityRowToPineconeRecord } = await import('./pineconeEntitySync');
+      const records = entities
+        .map((entity) => {
+          if (entity.entity_type && entity.project_id) {
+            return entityRowToPineconeRecord(entity);
+          }
+          return {
+            _id: `entity_${entity.entity_type || 'unknown'}_${entity.id || entity.name}`,
+            text: `${entity.name} ${entity.type || entity.entity_type || ''} ${entity.description || ''} ${entity.source_document_title || ''}`.trim(),
+            type: 'entity',
+            name: entity.name,
+            entity_type: entity.type || entity.entity_type || 'unknown',
+            confidence: entity.confidence || 0.85,
+            document_id: entity.document_id || entity.source_document_id || '',
+            source_document_id: entity.source_document_id || entity.document_id || '',
+            source_document_title: entity.source_document_title || '',
+            project_id: entity.project_id || '',
+            created_at: entity.created_at || new Date().toISOString(),
+          };
+        })
+        .filter(r => r.text.length > 0);
 
       if (records.length === 0) {
         logger.warn('Skipping entities upsert: No records with valid text content');
@@ -404,43 +436,124 @@ export class PineconeService {
     }
   }
 
+  private async searchIntegratedNamespace(
+    namespace: string,
+    query: string,
+    topK: number,
+    filter?: Record<string, unknown>
+  ): Promise<any[]> {
+    const indexTarget = this.index.namespace(namespace);
+    const response = await indexTarget.searchRecords({
+      query: {
+        topK,
+        inputs: { text: query },
+        ...(filter ? { filter } : {}),
+      },
+      fields: [
+        'type',
+        'name',
+        'title',
+        'text',
+        'project_id',
+        'description',
+        'entity_type',
+        'source_document_id',
+        'source_document_title',
+        'document_id',
+        'framework',
+        'status',
+      ],
+    });
+
+    return (response.result?.hits ?? []).map(mapSearchHit);
+  }
+
+  private async searchVectorNamespace(
+    namespace: string,
+    query: string,
+    topK: number,
+    filter?: Record<string, unknown>
+  ): Promise<any[]> {
+    const queryVector = await this.generateQueryEmbedding(query.toLowerCase());
+    const searchRequest: Record<string, unknown> = {
+      vector: queryVector,
+      topK,
+      includeMetadata: true,
+    };
+
+    if (filter) {
+      searchRequest.filter = filter;
+    }
+
+    const results = await this.index.namespace(namespace).query(searchRequest);
+    return results.matches || [];
+  }
+
   /**
-   * Search for similar items in Pinecone
+   * Search for similar items in Pinecone (integrated embedding index + legacy vector namespaces)
    */
   async search(query: string, topK: number = 10, filter?: any, namespace?: string): Promise<any[]> {
-    if (!query || query.trim().length === 0) {
+    const trimmedQuery = query?.trim();
+    if (!trimmedQuery) {
       logger.warn('Search query is empty, skipping');
       return [];
     }
+
     try {
-      const queryVector = await this.generateQueryEmbedding(query.toLowerCase());
+      if (namespace) {
+        if (namespace === 'chunks') {
+          const matches = await this.searchVectorNamespace(namespace, trimmedQuery, topK, filter);
+          logger.info('Pinecone vector search completed', {
+            query: trimmedQuery,
+            topK,
+            namespace,
+            resultsCount: matches.length,
+          });
+          return matches;
+        }
 
-      const searchRequest: any = {
-        vector: queryVector,
-        topK,
-        includeMetadata: true
-      };
-
-      if (filter) {
-        searchRequest.filter = filter;
+        const matches = await this.searchIntegratedNamespace(namespace, trimmedQuery, topK, filter);
+        logger.info('Pinecone integrated search completed', {
+          query: trimmedQuery,
+          topK,
+          namespace,
+          resultsCount: matches.length,
+        });
+        return matches;
       }
 
-      const indexTarget = namespace ? this.index.namespace(namespace) : this.index;
-      const results = await indexTarget.query(searchRequest);
+      const perNamespaceLimit = Math.max(topK, 5);
+      const namespaceResults = await Promise.all(
+        INTEGRATED_SEARCH_NAMESPACES.map(async (ns) => {
+          try {
+            return await this.searchIntegratedNamespace(ns, trimmedQuery, perNamespaceLimit, filter);
+          } catch (error) {
+            logger.warn('Pinecone namespace search skipped', {
+              namespace: ns,
+              error: (error as Error).message,
+            });
+            return [];
+          }
+        })
+      );
 
-      logger.info('Pinecone search completed', {
-        query,
+      const merged = namespaceResults
+        .flat()
+        .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+        .slice(0, topK);
+
+      logger.info('Pinecone multi-namespace search completed', {
+        query: trimmedQuery,
         topK,
-        namespace,
-        resultsCount: results.matches?.length || 0
+        resultsCount: merged.length,
       });
 
-      return results.matches || [];
+      return merged;
     } catch (error) {
       logger.error('Pinecone search failed', {
         error: (error as Error).message,
-        query,
-        namespace
+        query: trimmedQuery,
+        namespace,
       });
       return [];
     }
@@ -451,7 +564,7 @@ export class PineconeService {
    */
   async delete(ids: string[]): Promise<boolean> {
     try {
-      await this.index.deleteOne(ids);
+      await this.index.deleteMany({ ids });
       logger.info('Vectors deleted from Pinecone', { count: ids.length });
       return true;
     } catch (error) {
@@ -500,6 +613,7 @@ export class PineconeService {
     const stats = {
       projects: { total: 0, synced: 0, failed: 0 },
       documents: { total: 0, synced: 0, failed: 0 },
+      entities: { total: 0, synced: 0, failed: 0 },
       chunks: { total: 0, synced: 0, failed: 0 }
     };
 
@@ -643,7 +757,50 @@ export class PineconeService {
         }
       }
 
-      // 3. Sync chunks from MongoDB (if available)
+      // 3. Sync extracted entities from PostgreSQL domain tables
+      logger.info('Starting Pinecone sync - Entities', { projectId });
+
+      const { fetchEntitiesForPinecone, entityRowToPineconeRecord } = await import('./pineconeEntitySync');
+      const entityRows = await fetchEntitiesForPinecone(pgPool, projectId);
+      stats.entities.total = entityRows.length;
+
+      if (onProgress) {
+        await onProgress({
+          stage: 'entities',
+          current: 0,
+          total: stats.entities.total,
+          message: `Syncing ${stats.entities.total} entities...`,
+        });
+      }
+
+      if (entityRows.length > 0) {
+        const batchSize = 50;
+        for (let i = 0; i < entityRows.length; i += batchSize) {
+          const batch = entityRows.slice(i, i + batchSize);
+          const records = batch.map(entityRowToPineconeRecord).filter((r) => r.text.length > 0);
+          if (records.length === 0) continue;
+
+          try {
+            const result = await this.index.namespace('entities').upsertRecords({ records });
+            const synced = result?.upsertedCount || records.length;
+            stats.entities.synced += synced;
+
+            if (onProgress) {
+              await onProgress({
+                stage: 'entities',
+                current: stats.entities.synced,
+                total: stats.entities.total,
+                message: `Synced ${stats.entities.synced}/${stats.entities.total} entities to namespace "entities"`,
+              });
+            }
+          } catch (error) {
+            stats.entities.failed += records.length;
+            logger.error('Failed to sync entity batch', { error: (error as Error).message });
+          }
+        }
+      }
+
+      // 4. Sync chunks from MongoDB (if available)
       if (process.env.MONGODB_URI) {
         try {
           logger.info('Starting Pinecone sync - Chunks', { projectId });
@@ -715,7 +872,8 @@ export class PineconeService {
         }
       }
 
-      const totalSynced = stats.projects.synced + stats.documents.synced + stats.chunks.synced;
+      const totalSynced =
+        stats.projects.synced + stats.documents.synced + stats.entities.synced + stats.chunks.synced;
 
       logger.info('Pinecone sync completed', { stats, totalSynced });
 
@@ -725,6 +883,7 @@ export class PineconeService {
           synced_items: totalSynced,
           projects: stats.projects,
           documents: stats.documents,
+          entities: stats.entities,
           chunks: stats.chunks,
           last_sync: new Date().toISOString()
         }


### PR DESCRIPTION
## Summary
- Implement missing \GET /api/project-data-extraction/entities/:projectId/:entityType\ so Project Data Extraction entity cards open a populated dialog (was empty while counts worked).
- Map camelCase entity keys to PostgreSQL tables; align extraction result counts with full entity table set.
- Add Pinecone integration API (stats, search sandbox with scored top matches, sync) and \pineconeEntitySync\ to upsert domain entities into the \entities\ namespace with \source_document_id\ metadata.
- Improve Pinecone search (integrated namespaces, score mapping) and discovery fallback for \metadata.text\.

## Test plan
- [ ] Restart backend; open Project Data Extraction, click Requirements (or other type) and confirm dialog lists entities with fields.
- [ ] Where \source_document_id\ is set, confirm View Source Document navigates correctly.
- [ ] Integrations > Pinecone: Refresh stats, run Search Sandbox on \entities\ namespace, confirm scored matches.
- [ ] Run Sync; confirm \entities\ namespace count increases and \sync_status\ is success.
- [ ] \cd server && npx jest --testPathPattern=entityTypeTables --no-coverage\


Made with [Cursor](https://cursor.com)