### PR TITLE
fix(server): relax TLS for Supabase pooler on PaaS hosts

### DIFF
--- a/server/src/__tests__/database/connectionSsl.test.ts
+++ b/server/src/__tests__/database/connectionSsl.test.ts
@@ -1,0 +1,30 @@
+import { buildSslConfig, stripLibpqSslQueryParams } from '../../database/connection'
+
+describe('buildSslConfig', () => {
+  const poolerUrl =
+    'postgresql://postgres.xxx@aws-1-us-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true'
+
+  afterEach(() => {
+    delete process.env.ADPA_STRICT_SUPABASE_TLS
+    delete process.env.ADPA_ALLOW_INSECURE_TLS
+    delete process.env.DATABASE_SSL_REJECT_UNAUTHORIZED
+    delete process.env.DB_SSL_REJECT_UNAUTHORIZED
+  })
+
+  it('defaults to relaxed TLS for Supabase pooler (Render/PaaS)', () => {
+    expect(buildSslConfig(poolerUrl)).toEqual({ rejectUnauthorized: false })
+  })
+
+  it('allows strict TLS when ADPA_STRICT_SUPABASE_TLS=true', () => {
+    process.env.ADPA_STRICT_SUPABASE_TLS = 'true'
+    expect(buildSslConfig(poolerUrl)).toEqual({ rejectUnauthorized: true })
+  })
+
+  it('strips libpq ssl query params from connection strings', () => {
+    const cleaned = stripLibpqSslQueryParams(
+      'postgresql://u:p@host:5432/db?sslmode=require&pgbouncer=true'
+    )
+    expect(cleaned).not.toContain('sslmode=')
+    expect(cleaned).toContain('pgbouncer=true')
+  })
+})

--- a/server/src/database/connection.ts
+++ b/server/src/database/connection.ts
@@ -41,11 +41,24 @@ const connectionMethods = [
 ]
 
 const isTrustedPoolingProvider = (target?: string) =>
-  !!target && (target.includes("supabase.co") || target.includes("supabase.com") || target.includes("azure"))
+  !!target &&
+  (target.includes("supabase.co") ||
+    target.includes("supabase.com") ||
+    target.includes("pooler.supabase.com") ||
+    target.includes("rlwy.net") ||
+    target.includes("azure"))
 
 const shouldRejectUnauthorized = () => {
-  // Default to strict TLS unless explicitly disabled for custom databases
-  return process.env.ADPA_ALLOW_INSECURE_TLS === "true" ? false : true
+  if (process.env.ADPA_ALLOW_INSECURE_TLS === "true") return false
+  if (process.env.DATABASE_SSL_REJECT_UNAUTHORIZED === "false") return false
+  if (process.env.DB_SSL_REJECT_UNAUTHORIZED === "false") return false
+  return true
+}
+
+/** Supabase/Railway poolers on PaaS often present chains Node rejects unless verification is relaxed. */
+function rejectUnauthorizedForTrustedPooler(): boolean {
+  if (process.env.ADPA_STRICT_SUPABASE_TLS === "true") return true
+  return false
 }
 
 /**
@@ -53,7 +66,7 @@ const shouldRejectUnauthorized = () => {
  * object on the Pool, which breaks Supabase pooler TLS on some hosts (SELF_SIGNED_CERT_IN_CHAIN).
  * @see https://github.com/brianc/node-postgres/issues/2375
  */
-function stripLibpqSslQueryParams(connectionUrl: URL): string {
+export function stripLibpqSslQueryParams(connectionUrl: URL | string): string {
   const u = new URL(connectionUrl.toString())
   for (const k of ["sslmode", "sslcert", "sslkey", "sslrootcert", "sslcrl"]) {
     u.searchParams.delete(k)
@@ -106,8 +119,7 @@ function formatConnectionLogTarget(poolConfig: {
 
 export function buildSslConfig(target?: string) {
   if (isTrustedPoolingProvider(target)) {
-    // Keep TLS verification enabled by default; only relax when explicitly allowed.
-    return { rejectUnauthorized: shouldRejectUnauthorized() }
+    return { rejectUnauthorized: rejectUnauthorizedForTrustedPooler() }
   }
 
   // Disable SSL for local connections

--- a/server/src/modules/morphic/MorphicRepository.ts
+++ b/server/src/modules/morphic/MorphicRepository.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg'
+import { buildSslConfig, stripLibpqSslQueryParams } from '../../database/connection'
 import { childLogger } from "../../utils/logger"
 
 /**
@@ -163,13 +164,13 @@ export class MorphicRepository {
             const isRemote = (morphicUrl.includes('rlwy.net') || morphicUrl.includes('supabase') || morphicUrl.includes('pooler.supabase.com') || morphicUrl.includes('azure')) && 
                              !morphicUrl.includes('localhost') && !morphicUrl.includes('127.0.0.1');
 
-            const sslConfig = (isRemote || (process.env.MORPHIC_DB_SSL === 'true')) 
-                ? { rejectUnauthorized: false } 
-                : false;
-            
+            const sslConfig = isRemote || process.env.MORPHIC_DB_SSL === 'true'
+                ? buildSslConfig(morphicUrl)
+                : false
+
             try {
                 MorphicRepository._pool = new Pool({
-                    connectionString: morphicUrl,
+                    connectionString: stripLibpqSslQueryParams(morphicUrl),
                     ssl: sslConfig,
                     max: 10,
                     idleTimeoutMillis: 10000,
@@ -182,9 +183,10 @@ export class MorphicRepository {
         }
 
         if (mainUrl) {
+            const trimmedMainUrl = mainUrl.replace(/^["']|["']$/g, '')
             MorphicRepository._pool = new Pool({
-                connectionString: mainUrl.replace(/^["']|["']$/g, ''),
-                ssl: { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED === 'false' ? false : true },
+                connectionString: stripLibpqSslQueryParams(trimmedMainUrl),
+                ssl: buildSslConfig(trimmedMainUrl),
                 max: 5
             });
             this.log.info('Morphic repository using main database as fallback');


### PR DESCRIPTION
Render and similar platforms hit SELF_SIGNED_CERT_IN_CHAIN against the transaction pooler; default to rejectUnauthorized: false for trusted pooler hosts unless ADPA_STRICT_SUPABASE_TLS is set, strip libpq ssl URL params, and align Morphic DB pools with the shared SSL helpers.